### PR TITLE
refactor: move tree collapse helpers to tree-toggle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test"
   },
   "keywords": [],
   "author": "François-Régis Jaunatre",

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -6,6 +6,54 @@ export function initializeFilter(apiResult) {
     currentApiResult = apiResult;
 }
 
+/**
+ * Counts the filters that are not at their default value.
+ * A multi-select with several values counts once.
+ */
+export function countActiveFilters({ assignees, reviewers, sprints, fixVersions, sync, ready }) {
+    return [
+        assignees.length > 0,
+        reviewers.length > 0,
+        sprints.length > 0,
+        fixVersions.length > 0,
+        ready === true,
+        sync !== 'Show all'
+    ].filter(Boolean).length;
+}
+
+/**
+ * Decides whether a pull request needs the attention of the people selected
+ * in the assignee and reviewer filters. Pure: everything it needs is passed in.
+ *
+ * - assignee: the PR is in progress and a linked issue is assigned to a selected assignee
+ * - reviewer: the PR is in review and a selected reviewer (never the author) has not approved
+ *
+ * The title of a PR with attention is highlighted; the "Ready for reviewer"
+ * filter keeps the PRs with reviewer attention.
+ */
+export function computeAttention(pullRequestData, { statusInProgress, statusInReview, linkedIssues, assignees, reviewers }) {
+    const assignee = assignees.length > 0 && statusInProgress &&
+        linkedIssues.some(issue => issue.fields.assignee && assignees.includes(issue.fields.assignee.displayName));
+    const reviewer = reviewers.length > 0 && statusInReview &&
+        pullRequestData.participants.some(participant =>
+            participant.user.uuid !== pullRequestData.author.uuid &&
+            reviewers.includes(participant.user.display_name) &&
+            !participant.approved
+        );
+    return { assignee, reviewer, any: assignee || reviewer };
+}
+
+function getLinkedIssues(pullRequestData) {
+    const keys = currentApiResult.jiraIssuesMap[pullRequestData.id] || [];
+    return keys
+        .map(key => currentApiResult.jiraIssuesDetails.find(issue => issue.key === key))
+        .filter(issue => issue);
+}
+
+/**
+ * Applies the filters to the rendered tree and refreshes the counters.
+ * @returns {number} how many pull requests are left shown and need attention
+ */
 export function filterBranches(assignees, reviewers, sprints, fixVersions, sync, ready) {
     // Start filtering from the root branches
     let rootBranches = document.getElementsByClassName("root-branch");
@@ -19,6 +67,14 @@ export function filterBranches(assignees, reviewers, sprints, fixVersions, sync,
     const reviewer = reviewers.length > 0 ? reviewers[0] : "Show all";
     const sprint = sprints.length > 0 ? sprints[0] : "Show all";
     updateAllCounters(assignee, reviewer, sprint, sync);
+
+    return countShownAttention();
+}
+
+function countShownAttention() {
+    return Array.from(document.querySelectorAll('.pull-request.needs-attention'))
+        .filter(pr => pr.style.display !== 'none' && !pr.classList.contains('filtered'))
+        .length;
 }
 
 function filterBranch(branch, assignees, reviewers, sprints, fixVersions, sync, ready) {
@@ -52,8 +108,19 @@ function filterPullRequests(pullRequests, assignees, reviewers, sprints, fixVers
             visiblePullRequests += visibleChildren;
         }
 
+        // Attention is computed from data before visibility, so the ready filter never
+        // depends on what a previous pass rendered
+        const attention = computeAttention(pullRequestData, {
+            statusInProgress: pr.classList.contains('status-in-progress'),
+            statusInReview: pr.classList.contains('status-in-review'),
+            linkedIssues: getLinkedIssues(pullRequestData),
+            assignees,
+            reviewers
+        });
+        pr.classList.toggle('needs-attention', attention.any);
+
         // Check if this pull request should be visible
-        let isVisible = isPullRequestVisible(pr, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready);
+        let isVisible = isPullRequestVisible(pr, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready, attention);
 
         // Update visibility state
         pr.classList.toggle("filtered", !isVisible);
@@ -61,14 +128,13 @@ function filterPullRequests(pullRequests, assignees, reviewers, sprints, fixVers
 
         if (isVisible) {
             visiblePullRequests++;
-            updatePullRequestStyle(pr, pullRequestData, assignees, reviewers, sprints);
         }
     }
 
     return visiblePullRequests;
 }
 
-function isPullRequestVisible(prElement, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready) {
+function isPullRequestVisible(prElement, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready, attention) {
     // Assignee filter - check Jira issue assignees
     // Empty array = show all (no filtering)
     // Non-empty = match ANY selected value
@@ -113,54 +179,8 @@ function isPullRequestVisible(prElement, pullRequestData, assignees, reviewers, 
         (sync === "requested" && hasSyncLabel) ||
         (sync === "OK" && !hasSyncLabel);
 
-    // Ready for reviewer filter
-    let readyMatch = true;
-    if (ready) {
-        const isInReview = prElement.classList.contains('status-in-review');
-        const link = prElement.querySelector('.pull-request-link');
-        const style = window.getComputedStyle(link);
-        const hasSecondaryColor = style.color === 'rgb(255, 86, 48)'; // --secondary-color in RGB
-        readyMatch = isInReview && hasSecondaryColor;
-    }
+    // Ready for reviewer filter: in review, and a selected reviewer has not approved yet
+    const readyMatch = !ready || attention.reviewer;
 
     return assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch;
-}
-
-// Update the updatePullRequestStyle function in app-filter.js
-function updatePullRequestStyle(prElement, pullRequestData, assignees, reviewers) {
-    let title = prElement.querySelector("a");
-    let titleColor = "";
-
-    // Check if any Jira issue for this PR is assigned to any filtered assignee
-    if (assignees.length > 0) {
-        const jiraIssueKeys = currentApiResult.jiraIssuesMap[pullRequestData.id] || [];
-        const hasAssignee = jiraIssueKeys.some(issueKey => {
-            const issue = currentApiResult.jiraIssuesDetails.find(i => i.key === issueKey);
-            return issue && issue.fields.assignee && assignees.includes(issue.fields.assignee.displayName);
-        });
-
-        if (hasAssignee && prElement.classList.contains("status-in-progress")) {
-            titleColor = "var(--secondary-color)";
-        }
-    }
-
-    if (reviewers.length > 0) {
-        // Check if any selected reviewer has not approved this PR
-        let hasUnapprovedReviewer = reviewers.some(reviewer => {
-            let reviewerParticipant = pullRequestData.participants.find(p =>
-                p.user.uuid !== pullRequestData.author.uuid && p.user.display_name === reviewer
-            );
-            return reviewerParticipant && !reviewerParticipant.approved;
-        });
-
-        if (hasUnapprovedReviewer && prElement.classList.contains("status-in-review")) {
-            titleColor = "var(--secondary-color)";
-        }
-    }
-
-    if (titleColor) {
-        title.style.color = titleColor;
-    } else {
-        title.style.color = ""; // Reset color if no condition is met
-    }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,6 @@
 import { initializeFilter, filterBranches } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
+import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
 
 let currentProject = null;
 let currentSprints = [];
@@ -257,34 +258,6 @@ function handleFilterChange() {
 }
 
 
-function toggleChildren(button) {
-    const pullRequest = button.closest('.pull-request');
-    const children = pullRequest.nextElementSibling;
-    if (children && children.classList.contains('children')) {
-        pullRequest.classList.toggle('collapsed');
-        children.style.display = children.style.display === 'none' ? 'block' : 'none';
-
-        // Toggle visibility of child counter
-        const childCounter = pullRequest.querySelector('.child-counter');
-        if (childCounter) {
-            childCounter.classList.toggle('visible');
-        }
-    }
-}
-
-
-function toggleRootBranch(button) {
-    const rootBranch = button.closest('.root-branch');
-    rootBranch.classList.toggle('collapsed');
-}
-
-function toggleRepository(button) {
-    const repository = button.closest('.repository');
-    repository.classList.toggle('collapsed');
-    const icon = button.querySelector('i');
-    icon.classList.toggle('fa-chevron-down');
-    icon.classList.toggle('fa-chevron-right');
-}
 
 function populateFilters(pullRequests) {
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
@@ -399,102 +372,6 @@ function renderOrphanedIssues(issues) {
     `;
 }
 
-// Function to capture current toggle states before re-rendering
-function captureToggleStates() {
-    const states = {
-        repositories: [],
-        rootBranches: [],
-        pullRequests: []
-    };
-
-    // Capture repository states
-    document.querySelectorAll('.repository').forEach(repo => {
-        const repoNameElement = repo.querySelector('.repository-header h1');
-        if (repoNameElement) {
-            const repoName = repoNameElement.textContent.trim();
-            states.repositories.push({
-                name: repoName,
-                collapsed: repo.classList.contains('collapsed')
-            });
-        }
-    });
-
-    // Capture root branch states
-    document.querySelectorAll('.root-branch').forEach(branch => {
-        const branchNameElement = branch.querySelector('.root-branch-header h2 a');
-        if (branchNameElement) {
-            // Extract just the branch name, removing the external link icon
-            const branchName = branchNameElement.childNodes[0].textContent.trim();
-            states.rootBranches.push({
-                name: branchName,
-                collapsed: branch.classList.contains('collapsed')
-            });
-        }
-    });
-
-    // Capture pull request states (children visibility)
-    document.querySelectorAll('.pull-request').forEach(pr => {
-        const prId = pr.dataset.id;
-        const children = pr.nextElementSibling;
-        if (children && children.classList.contains('children')) {
-            states.pullRequests.push({
-                id: prId,
-                collapsed: pr.classList.contains('collapsed')
-            });
-        }
-    });
-
-    return states;
-}
-
-// Function to restore toggle states after re-rendering
-function restoreToggleStates(states) {
-    if (!states) return;
-
-    // Restore repository states
-    states.repositories.forEach(state => {
-        const repo = Array.from(document.querySelectorAll('.repository')).find(r => {
-            const nameElement = r.querySelector('.repository-header h1');
-            return nameElement && nameElement.textContent.trim() === state.name;
-        });
-        if (repo && state.collapsed) {
-            repo.classList.add('collapsed');
-        }
-    });
-
-    // Restore root branch states
-    states.rootBranches.forEach(state => {
-        const branch = Array.from(document.querySelectorAll('.root-branch')).find(b => {
-            const nameElement = b.querySelector('.root-branch-header h2 a');
-            if (nameElement) {
-                const branchName = nameElement.childNodes[0].textContent.trim();
-                return branchName === state.name;
-            }
-            return false;
-        });
-        if (branch && state.collapsed) {
-            branch.classList.add('collapsed');
-        }
-    });
-
-    // Restore pull request states
-    states.pullRequests.forEach(state => {
-        const pr = document.querySelector(`.pull-request[data-id="${state.id}"]`);
-        if (pr && state.collapsed) {
-            const children = pr.nextElementSibling;
-            if (children && children.classList.contains('children')) {
-                pr.classList.add('collapsed');
-                children.style.display = 'none';
-
-                // Toggle visibility of child counter
-                const childCounter = pr.querySelector('.child-counter');
-                if (childCounter) {
-                    childCounter.classList.add('visible');
-                }
-            }
-        }
-    });
-}
 
 async function renderEverything() {
     if (!currentProject) {
@@ -638,8 +515,9 @@ function renderRepositories(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
                 <div class="repository-header" onclick="toggleRepository(this)">
                     <button class="toggle-button">
                         <i class="fas fa-chevron-down"></i>
+                        <i class="fas fa-chevron-right"></i>
                     </button>
-                    <h1>${repoName}</h1>
+                    <h2 class="repository-name">${repoName}</h2>
                     <div class="repo-pr-counter" title="${pullRequestCount} pull request${pullRequestCount !== 1 ? 's' : ''}">
                         ${pullRequestCount}
                     </div>
@@ -699,13 +577,12 @@ function renderPullRequests(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
                             <i class="fas fa-chevron-down"></i>
                             <i class="fas fa-chevron-right"></i>
                         </button>
-                        <h2>
-                            <a href="${branchUrl}" target="_blank" onclick="event.stopPropagation();" 
-                               style="color: inherit; text-decoration: none;">
+                        <h3 class="root-branch-name">
+                            <a href="${branchUrl}" target="_blank" onclick="event.stopPropagation();" class="root-branch-link">
                                 ${rootBranch}
-                                <i class="fas fa-external-link-alt" style="font-size: 0.8em; margin-left: 5px;"></i>
+                                <i class="fas fa-external-link-alt external-link-icon"></i>
                             </a>
-                        </h2>
+                        </h3>
                         <div class="branch-pr-counter" title="${totalPullRequestCount} total pull request${totalPullRequestCount !== 1 ? 's' : ''} (including all descendants)">
                             ${totalPullRequestCount}
                         </div>
@@ -1028,7 +905,7 @@ function renderPullRequest(pullRequest, jiraIssuesMap, jiraIssuesDetails, pullRe
     const renderedDescription = pullRequest.rendered.description.html || 'No description provided.';
 
     let html = `
-        <div class="pull-request ${statusClass}" data-id="${pullRequest.id}">
+        <div class="pull-request ${statusClass}${isRootPullRequest ? ' pull-request-root' : ''}" data-id="${pullRequest.id}">
             ${countersHtml}
             <div class="pull-request-content">
                 <div class="pull-request-main">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,6 @@
 :root {
     --primary-color: #0052CC;
-    --secondary-color: #FF5630;
+    --attention-color: #FF5630;
     --background-color: #F4F5F7;
     --text-color: #172B4D;
     --border-color: #DFE1E6;
@@ -263,6 +263,10 @@ select {
 
 .pull-request a:hover {
     text-decoration: underline;
+}
+
+.pull-request.needs-attention .pull-request-link {
+    color: var(--attention-color);
 }
 
 .participants {

--- a/public/styles.css
+++ b/public/styles.css
@@ -415,12 +415,12 @@ select {
     position: relative;  /* Add this line */
 }
 
-.root-branch-header h2 {
+.root-branch-name {
     margin: 0;
     font-size: 18px;
     font-weight: bold;
     color: var(--primary-color);
-    flex-grow: 1;  /* Add this line to push the counter to the right */
+    flex-grow: 1;
 }
 
 .branch-pr-counter {
@@ -468,13 +468,11 @@ select {
     position: relative;
 }
 
-.repository-header h1 {
+.repository-name {
     margin: 0;
     font-size: 24px;
     font-weight: bold;
     color: white;
-    border-bottom: none;
-    padding-bottom: 0;
     flex-grow: 1;
 }
 
@@ -859,22 +857,22 @@ select {
     border-top: 1px solid #eee;
 }
 
-.root-branch-header h2 a:hover {
+.root-branch-link {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
     text-decoration: none;
 }
 
-.root-branch-header h2 a:hover .fa-external-link-alt {
-    opacity: 1;
-}
-
-.root-branch-header h2 .fa-external-link-alt {
+.external-link-icon {
+    margin-left: 5px;
+    font-size: 0.8em;
     opacity: 0.6;
     transition: opacity 0.2s ease;
 }
 
-.root-branch-header h2 a {
-    display: inline-flex;
-    align-items: center;
+.root-branch-link:hover .external-link-icon {
+    opacity: 1;
 }
 
 .jira-priority-icon {

--- a/public/tree-toggle.js
+++ b/public/tree-toggle.js
@@ -1,0 +1,129 @@
+/**
+ * Collapse and expand helpers for the pull-request tree.
+ *
+ * Repositories, root branches and pull requests with children can be
+ * collapsed. Every code path that changes a collapsed state goes through the
+ * set*Collapsed helpers, so the collapsed class, the children container and
+ * the child counter always change together. The chevrons are pure CSS, driven
+ * by the "collapsed" class.
+ */
+
+export function setRepositoryCollapsed(repository, collapsed) {
+    repository.classList.toggle('collapsed', collapsed);
+}
+
+export function setRootBranchCollapsed(rootBranch, collapsed) {
+    rootBranch.classList.toggle('collapsed', collapsed);
+}
+
+export function setPullRequestCollapsed(pullRequest, collapsed) {
+    const children = pullRequest.nextElementSibling;
+    if (!children || !children.classList.contains('children')) {
+        return;
+    }
+    pullRequest.classList.toggle('collapsed', collapsed);
+    children.hidden = collapsed;
+    // The child counter is shown on root pull requests permanently, and on
+    // other pull requests only while they are collapsed. counter-utils only
+    // refreshes counters carrying the "visible" class.
+    const childCounter = pullRequest.querySelector('.child-counter');
+    if (childCounter) {
+        const isRoot = pullRequest.classList.contains('pull-request-root');
+        childCounter.classList.toggle('visible', collapsed || isRoot);
+    }
+}
+
+export function toggleRepository(button) {
+    const repository = button.closest('.repository');
+    setRepositoryCollapsed(repository, !repository.classList.contains('collapsed'));
+}
+
+export function toggleRootBranch(button) {
+    const rootBranch = button.closest('.root-branch');
+    setRootBranchCollapsed(rootBranch, !rootBranch.classList.contains('collapsed'));
+}
+
+export function toggleChildren(button) {
+    const pullRequest = button.closest('.pull-request');
+    setPullRequestCollapsed(pullRequest, !pullRequest.classList.contains('collapsed'));
+}
+
+function setAllCollapsed(collapsed) {
+    document.querySelectorAll('.repository').forEach(repository => setRepositoryCollapsed(repository, collapsed));
+    document.querySelectorAll('.root-branch').forEach(rootBranch => setRootBranchCollapsed(rootBranch, collapsed));
+    document.querySelectorAll('.pull-request').forEach(pullRequest => setPullRequestCollapsed(pullRequest, collapsed));
+}
+
+export function collapseAll() {
+    setAllCollapsed(true);
+}
+
+export function expandAll() {
+    setAllCollapsed(false);
+}
+
+/**
+ * Snapshot of what is collapsed, keyed by repository name, root branch name
+ * and pull request id, so a re-render can put the tree back as the user left it.
+ */
+export function captureToggleStates() {
+    const states = { repositories: [], rootBranches: [], pullRequests: [] };
+
+    document.querySelectorAll('.repository').forEach(repository => {
+        const name = repository.querySelector('.repository-name');
+        if (name) {
+            states.repositories.push({
+                name: name.textContent.trim(),
+                collapsed: repository.classList.contains('collapsed')
+            });
+        }
+    });
+
+    document.querySelectorAll('.root-branch').forEach(rootBranch => {
+        const link = rootBranch.querySelector('.root-branch-name a');
+        if (link) {
+            // The first text node is the branch name; the external-link icon follows it
+            states.rootBranches.push({
+                name: link.childNodes[0].textContent.trim(),
+                collapsed: rootBranch.classList.contains('collapsed')
+            });
+        }
+    });
+
+    document.querySelectorAll('.pull-request').forEach(pullRequest => {
+        const children = pullRequest.nextElementSibling;
+        if (children && children.classList.contains('children')) {
+            states.pullRequests.push({
+                id: pullRequest.dataset.id,
+                collapsed: pullRequest.classList.contains('collapsed')
+            });
+        }
+    });
+
+    return states;
+}
+
+export function restoreToggleStates(states) {
+    if (!states) return;
+
+    states.repositories.filter(state => state.collapsed).forEach(state => {
+        const repository = Array.from(document.querySelectorAll('.repository')).find(candidate => {
+            const name = candidate.querySelector('.repository-name');
+            return name && name.textContent.trim() === state.name;
+        });
+        if (repository) setRepositoryCollapsed(repository, true);
+    });
+
+    states.rootBranches.filter(state => state.collapsed).forEach(state => {
+        const rootBranch = Array.from(document.querySelectorAll('.root-branch')).find(candidate => {
+            const link = candidate.querySelector('.root-branch-name a');
+            return link && link.childNodes[0].textContent.trim() === state.name;
+        });
+        if (rootBranch) setRootBranchCollapsed(rootBranch, true);
+    });
+
+    states.pullRequests.filter(state => state.collapsed).forEach(state => {
+        const pullRequest = document.querySelector(`.pull-request[data-id="${state.id}"]`);
+        if (pullRequest) setPullRequestCollapsed(pullRequest, true);
+    });
+}

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeAttention, countActiveFilters } from '../public/app-filter.js';
+
+const author = { uuid: 'author-uuid', display_name: 'Author' };
+const jane = { uuid: 'jane-uuid', display_name: 'Jane' };
+const bob = { uuid: 'bob-uuid', display_name: 'Bob' };
+
+function pullRequest(participants) {
+    return { id: 1, author, participants };
+}
+
+const issueAssignedToJane = { key: 'PROJ-1', fields: { assignee: { displayName: 'Jane' } } };
+const issueUnassigned = { key: 'PROJ-2', fields: { assignee: null } };
+
+const noFilters = { linkedIssues: [], assignees: [], reviewers: [] };
+
+test('reviewer attention when a selected reviewer has not approved an in-review PR', () => {
+    const pr = pullRequest([{ user: author, approved: false }, { user: jane, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: false, statusInReview: true, reviewers: ['Jane'] });
+    assert.deepEqual(attention, { assignee: false, reviewer: true, any: true });
+});
+
+test('no reviewer attention once the selected reviewer approved', () => {
+    const pr = pullRequest([{ user: author, approved: false }, { user: jane, approved: true }, { user: bob, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: false, statusInReview: true, reviewers: ['Jane'] });
+    assert.equal(attention.reviewer, false);
+    assert.equal(attention.any, false);
+});
+
+test('reviewer attention matches any of several selected reviewers', () => {
+    const pr = pullRequest([{ user: author, approved: false }, { user: jane, approved: true }, { user: bob, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: false, statusInReview: true, reviewers: ['Jane', 'Bob'] });
+    assert.equal(attention.reviewer, true);
+});
+
+test('the author never counts as a reviewer', () => {
+    const pr = pullRequest([{ user: author, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: false, statusInReview: true, reviewers: ['Author'] });
+    assert.equal(attention.reviewer, false);
+});
+
+test('reviewer attention only applies to PRs in review', () => {
+    const pr = pullRequest([{ user: author, approved: false }, { user: jane, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: true, statusInReview: false, reviewers: ['Jane'] });
+    assert.equal(attention.reviewer, false);
+});
+
+test('assignee attention when a selected assignee owns an issue of an in-progress PR', () => {
+    const pr = pullRequest([{ user: author, approved: false }]);
+    const attention = computeAttention(pr, {
+        statusInProgress: true, statusInReview: false,
+        linkedIssues: [issueUnassigned, issueAssignedToJane], assignees: ['Jane'], reviewers: []
+    });
+    assert.deepEqual(attention, { assignee: true, reviewer: false, any: true });
+});
+
+test('assignee attention only applies to PRs in progress', () => {
+    const pr = pullRequest([{ user: author, approved: false }]);
+    const attention = computeAttention(pr, {
+        statusInProgress: false, statusInReview: true,
+        linkedIssues: [issueAssignedToJane], assignees: ['Jane'], reviewers: []
+    });
+    assert.equal(attention.assignee, false);
+});
+
+test('no attention without assignee or reviewer filters', () => {
+    const pr = pullRequest([{ user: author, approved: false }, { user: jane, approved: false }]);
+    const attention = computeAttention(pr, { ...noFilters, statusInProgress: true, statusInReview: true, linkedIssues: [issueAssignedToJane] });
+    assert.deepEqual(attention, { assignee: false, reviewer: false, any: false });
+});
+
+test('countActiveFilters counts filters, not selected values', () => {
+    const defaults = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+    assert.equal(countActiveFilters(defaults), 0);
+    assert.equal(countActiveFilters({ ...defaults, reviewers: ['Jane', 'Bob'], ready: true }), 2);
+    assert.equal(countActiveFilters({ ...defaults, sync: 'requested' }), 1);
+    assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
+});


### PR DESCRIPTION
`app.js` held three toggle functions and the capture/restore of toggle states, each changing the DOM in its own way; the repository toggle swapped icon classes in JavaScript, so the chevron vanished after an automatic refresh restored a collapsed repository. The new `public/tree-toggle.js` module routes every change through `setRepositoryCollapsed`, `setRootBranchCollapsed` and `setPullRequestCollapsed`, adds `collapseAll` / `expandAll` (wired to buttons later in the stack), and the rendered headings get class names (`repository-name`, `root-branch-name`, `root-branch-link`, `pull-request-root`) so nothing depends on heading tags any more. Repository headers now render both chevrons like the other levels.

Verified in the browser: every level collapses and expands with the right chevron, a repository collapsed the way a restore does it shows the right chevron and expands cleanly, root PR counters stay visible, nested PR counters appear only while collapsed, and `collapseAll()` / `expandAll()` act on all three levels.

Closes #10
Part of #16
Stacked on #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZCANUDoVq6pd6b9i8vGbg