### PR TITLE
feat: app shell with top banner, filter sidebar and scrolling tree pane

### DIFF
--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -1,0 +1,170 @@
+/**
+ * Application shell: banner, sidebar visibility, help modal, keyboard
+ * shortcuts and document title. Knows nothing about pull requests.
+ *
+ * Nothing here touches the DOM at import time, so the pure helpers can be
+ * unit-tested with node:test.
+ */
+
+export const APP_NAME = 'Bitbucket Pull-Requests Tree';
+
+const SIDEBAR_STORAGE_KEY = 'prTree.sidebarHidden';
+const WIDE_LAYOUT_QUERY = '(min-width: 900px)';
+
+let wideLayout = null;
+
+// ---------------------------------------------------------- document title
+
+export function buildDocumentTitle({ project, attentionCount }) {
+    const prefix = attentionCount > 0 ? `(${attentionCount}) ` : '';
+    const projectPart = project ? `${project} · ` : '';
+    return `${prefix}${projectPart}${APP_NAME}`;
+}
+
+export function updateDocumentTitle(state) {
+    document.title = buildDocumentTitle(state);
+}
+
+// ----------------------------------------------------------------- storage
+
+function readStorage(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch (error) {
+        return null;
+    }
+}
+
+function writeStorage(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch (error) {
+        // Storage unavailable (private window, blocked site data): the preference is not remembered
+    }
+}
+
+// ----------------------------------------------------------------- sidebar
+
+function isSidebarHidden() {
+    return document.documentElement.classList.contains('sidebar-hidden');
+}
+
+// The stored preference only applies to the wide layout; the drawer of the
+// narrow layout always starts closed and never writes the preference.
+function setSidebarHidden(hidden, { persist = true } = {}) {
+    document.documentElement.classList.toggle('sidebar-hidden', hidden);
+    const toggle = document.getElementById('sidebarToggle');
+    if (toggle) {
+        toggle.setAttribute('aria-expanded', String(!hidden));
+    }
+    if (persist && wideLayout.matches) {
+        writeStorage(SIDEBAR_STORAGE_KEY, String(hidden));
+    }
+}
+
+function toggleSidebar() {
+    setSidebarHidden(!isSidebarHidden());
+}
+
+/** Closes the sidebar when it is shown as a drawer (narrow layout). No-op otherwise. */
+export function closeSidebarDrawer() {
+    if (!wideLayout.matches && !isSidebarHidden()) {
+        setSidebarHidden(true, { persist: false });
+    }
+}
+
+function applyLayoutMode() {
+    if (wideLayout.matches) {
+        setSidebarHidden(readStorage(SIDEBAR_STORAGE_KEY) === 'true', { persist: false });
+    } else {
+        setSidebarHidden(true, { persist: false });
+    }
+}
+
+function initializeSidebar() {
+    wideLayout = window.matchMedia(WIDE_LAYOUT_QUERY);
+    applyLayoutMode();
+    wideLayout.addEventListener('change', applyLayoutMode);
+    document.getElementById('sidebarToggle').addEventListener('click', toggleSidebar);
+    document.getElementById('sidebarBackdrop').addEventListener('click', closeSidebarDrawer);
+}
+
+// -------------------------------------------------------------- help modal
+
+function openHelp() {
+    document.getElementById('helpModal').hidden = false;
+    const content = document.getElementById('helpContent');
+    if (!content.innerHTML) {
+        fetchAndRenderReadme(content);
+    }
+}
+
+function closeHelp() {
+    document.getElementById('helpModal').hidden = true;
+}
+
+async function fetchAndRenderReadme(content) {
+    content.textContent = 'Loading...';
+    try {
+        const response = await fetch('README.md');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const markdown = await response.text();
+        content.innerHTML = marked.parse(markdown);
+    } catch (error) {
+        console.error('Error fetching README:', error);
+        content.textContent = 'Error loading help content. Please try again later.';
+    }
+}
+
+function initializeHelpModal() {
+    const modal = document.getElementById('helpModal');
+    document.getElementById('helpButton').addEventListener('click', openHelp);
+    document.getElementById('helpClose').addEventListener('click', closeHelp);
+    modal.addEventListener('click', event => {
+        if (event.target === modal) {
+            closeHelp();
+        }
+    });
+}
+
+// ---------------------------------------------------------------- keyboard
+
+function isTypingTarget(target) {
+    return target instanceof Element &&
+        (target.matches('input, select, textarea') || target.isContentEditable);
+}
+
+// Registered in the capture phase: an open multi-select is still open here and
+// handles Escape itself, so the shell stays out of its way.
+function handleKeydown(event) {
+    if (document.querySelector('.multi-select.open')) {
+        return;
+    }
+
+    if (event.key === 'Escape') {
+        const modal = document.getElementById('helpModal');
+        if (modal && !modal.hidden) {
+            closeHelp();
+        } else {
+            closeSidebarDrawer();
+        }
+        return;
+    }
+
+    if ((event.key === 'f' || event.key === 'F') &&
+        !event.ctrlKey && !event.metaKey && !event.altKey &&
+        !isTypingTarget(event.target)) {
+        event.preventDefault();
+        toggleSidebar();
+    }
+}
+
+// -------------------------------------------------------------------- init
+
+export function initializeAppShell() {
+    initializeSidebar();
+    initializeHelpModal();
+    document.addEventListener('keydown', handleKeydown, true);
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,7 @@
 import { initializeFilter, filterBranches } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
+import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer } from './app-shell.js';
 
 let currentProject = null;
 let currentSprints = [];
@@ -152,6 +153,8 @@ async function handleProjectChange(event, isInitialLoad = false) {
     const projectName = event.target.value;
     if (projectName) {
         currentProject = projectName;
+        updateDocumentTitle({ project: currentProject, attentionCount: 0 });
+        closeSidebarDrawer();
 
         // Only clear filters from URL when manually switching projects, not during initial page load
         if (!isInitialLoad) {
@@ -195,34 +198,49 @@ async function handleProjectChange(event, isInitialLoad = false) {
             }
         }
 
-        showLoading();
-        await renderEverything();
-        hideLoading();
+        showLoadingState();
+        renderEverything(await fetchData());
         updateUrlWithFilters();
 
         // Start periodic checking
         startPeriodicChecking();
     } else {
-        document.getElementById('pull-requests').innerHTML = 'Please select a project';
         currentProject = null;
         currentSyncStatuses = null;
         syncLoadFailed = false;
         updateSyncControls();
         updateUrlWithFilters();
+        updateDocumentTitle({ project: null, attentionCount: 0 });
+        showEmptyState();
 
         // Stop periodic checking
         stopPeriodicChecking();
     }
 }
 
-function showLoading() {
-    document.getElementById('pull-requests').style.display = 'none';
-    document.getElementById('loading').style.display = 'block';
+// Messages shown in the main pane instead of the tree. Built with DOM nodes so
+// project names never go through innerHTML.
+function showStateMessage(iconClass, text, modifier = '') {
+    const message = document.createElement('div');
+    message.className = `state-message ${modifier}`.trim();
+    const icon = document.createElement('i');
+    icon.className = iconClass;
+    const label = document.createElement('span');
+    label.textContent = text;
+    message.append(icon, label);
+    document.getElementById('pull-requests').replaceChildren(message);
 }
 
-function hideLoading() {
-    document.getElementById('loading').style.display = 'none';
-    document.getElementById('pull-requests').style.display = 'block';
+function showEmptyState() {
+    showStateMessage('fas fa-code-branch', 'Select a project to display its pull requests');
+}
+
+function showLoadingState() {
+    showStateMessage('fas fa-spinner fa-spin', `Loading ${currentProject}…`);
+}
+
+function showErrorState() {
+    showStateMessage('fas fa-exclamation-triangle', `Could not load ${currentProject}. The next automatic check will retry.`, 'error');
 }
 
 function handleFilterChange() {
@@ -373,15 +391,20 @@ function renderOrphanedIssues(issues) {
 }
 
 
-async function renderEverything() {
+function renderEverything(apiResult) {
     if (!currentProject) {
+        return;
+    }
+    if (!apiResult) {
+        currentApiResult = null;
+        showErrorState();
         return;
     }
 
     // Capture current toggle states before re-rendering
     const toggleStates = captureToggleStates();
 
-    currentApiResult = await fetchData();
+    currentApiResult = apiResult;
     initializeFilter(currentApiResult);
     const container = document.getElementById('pull-requests');
 
@@ -453,10 +476,10 @@ async function checkForUpdates() {
             lastRefreshElement.textContent = formatRefreshTime(newData.lastRefreshTime);
         }
 
-        // Update the full content only if data has changed
-        if (newData.dataHash !== currentApiResult.dataHash) {
+        // Re-render when the data changed, or when nothing is displayed yet because the last fetch failed
+        if (!currentApiResult || newData.dataHash !== currentApiResult.dataHash) {
             console.log('Data has changed. Updating...');
-            await renderEverything();
+            renderEverything(newData);
         }
     } catch (error) {
         console.error('Error checking for updates:', error);
@@ -789,7 +812,7 @@ function updateSyncControls() {
                 : '';
             warningText = `Atlassian rate limit reached - SYNC status may be incomplete${until ? `, requests are paused until ${until}` : ''}`;
         }
-        syncWarning.style.display = warningText ? '' : 'none';
+        syncWarning.hidden = !warningText;
         syncWarning.title = warningText;
     }
 }
@@ -976,48 +999,6 @@ function renderParticipant(participant, status) {
     `;
 }
 
-function initializeHelpModal() {
-    const modal = document.getElementById("helpModal");
-    const btn = document.getElementById("helpButton");
-    const span = document.getElementsByClassName("close")[0];
-    const helpContent = document.getElementById("helpContent");
-
-    btn.onclick = function() {
-        modal.style.display = "block";
-        if (!helpContent.innerHTML) {
-            fetchAndRenderReadme();
-        }
-    }
-
-    span.onclick = function() {
-        modal.style.display = "none";
-    }
-
-    window.onclick = function(event) {
-        if (event.target == modal) {
-            modal.style.display = "none";
-        }
-    }
-}
-
-async function fetchAndRenderReadme() {
-    const helpContent = document.getElementById("helpContent");
-    helpContent.innerHTML = 'Loading...';
-
-    try {
-        const response = await fetch('README.md');
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const markdown = await response.text();
-        const html = marked.parse(markdown);
-        helpContent.innerHTML = html;
-    } catch (error) {
-        console.error('Error fetching README:', error);
-        helpContent.innerHTML = 'Error loading help content. Please try again later.';
-    }
-}
-
 async function fetchAndDisplayVersion() {
     try {
         const response = await fetch('/api/version');
@@ -1026,20 +1007,9 @@ async function fetchAndDisplayVersion() {
         }
         const data = await response.json();
         const versionElement = document.getElementById('versionNumber');
-        const dateElement = document.getElementById('versionDate');
-        const authorElement = document.getElementById('authorInfo');
-        const licenseElement = document.getElementById('licenseInfo');
-
-        if (versionElement && dateElement && authorElement && licenseElement) {
+        if (versionElement) {
             versionElement.textContent = `v${data.version}`;
-            dateElement.textContent = `Released: ${data.releaseDate}`;
-            authorElement.textContent = `Created by ${data.author}`;
-            licenseElement.textContent = `${data.license}`;
-
-            versionElement.style.animation = 'versionPulse 0.5s ease';
-            setTimeout(() => {
-                versionElement.style.animation = '';
-            }, 500);
+            versionElement.title = `Version ${data.version}, released ${data.releaseDate}\nCreated by ${data.author}\n${data.license}`;
         }
     } catch (error) {
         console.error('Error fetching version:', error);
@@ -1054,8 +1024,6 @@ function initializePopovers() {
     document.body.appendChild(popover);
 
     function showPopover(link) {
-        const rect = link.getBoundingClientRect();
-
         if (link.classList.contains('jira-issue-link')) {
             const key = link.dataset.issueKey;
             const summary = link.dataset.issueSummary;
@@ -1074,9 +1042,15 @@ function initializePopovers() {
             `;
         }
 
-        popover.style.left = `${rect.left}px`;
-        popover.style.top = `${rect.bottom + window.scrollY}px`;
+        // The popover is fixed: viewport coordinates, kept inside the viewport
         popover.style.display = 'block';
+        const rect = link.getBoundingClientRect();
+        const margin = 8;
+        const left = Math.max(margin, Math.min(rect.left, window.innerWidth - popover.offsetWidth - margin));
+        const fitsBelow = rect.bottom + popover.offsetHeight + margin <= window.innerHeight;
+        const top = fitsBelow ? rect.bottom : Math.max(margin, rect.top - popover.offsetHeight);
+        popover.style.left = `${left}px`;
+        popover.style.top = `${top}px`;
     }
 
     function hidePopover() {
@@ -1117,6 +1091,9 @@ function initializePopovers() {
         clearTimeout(popoverTimeout);
         popoverTimeout = setTimeout(hidePopover, 300);
     });
+
+    // A popover left open while the tree scrolls would float away from its link
+    document.getElementById('main').addEventListener('scroll', hidePopover, { passive: true });
 }
 
 // Initialize multi-select components
@@ -1129,28 +1106,14 @@ function initializeMultiSelects() {
 
 // Update the DOMContentLoaded event listener
 document.addEventListener('DOMContentLoaded', function() {
+    initializeAppShell();
     initializeMultiSelects();
+    showEmptyState();
     loadProjects();
-    initializeHelpModal();
     fetchAndDisplayVersion();
     initializePopovers();
     initializeReadyForReviewerFilter();
     initializeSyncControls();
-
-    // Add event listener for the footer help button
-    const footerHelpButton = document.querySelector('.footer-link#helpButton');
-    if (footerHelpButton) {
-        footerHelpButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            const helpModal = document.getElementById('helpModal');
-            if (helpModal) {
-                helpModal.style.display = 'block';
-                if (!document.getElementById('helpContent').innerHTML) {
-                    fetchAndRenderReadme();
-                }
-            }
-        });
-    }
 });
 
 // Export functions that need to be accessible globally

--- a/public/index.html
+++ b/public/index.html
@@ -109,17 +109,13 @@
         <div class="filter-label">
           <input type="checkbox" id="readyForReviewerCheck" disabled>
           <label for="readyForReviewerCheck">Ready for reviewer
-            <i class="fas fa-info-circle"
-             style="color: var(--primary-color); cursor: help;"
-             title="This filter will be reset when the page is reloaded"></i>
+            <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
           </label>
         </div>
       </div>
       <div class="filter-item">
         <span class="filter-label">SYNC
-          <i class="fas fa-info-circle"
-             style="color: var(--primary-color); cursor: help;"
-             title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
+          <i class="fas fa-info-circle info-icon" title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
         </span>
         <select id="syncSelect" disabled>
           <option value="Show all">SYNC status not loaded</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3,183 +3,180 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bitbucket Pull Requests Review Dashboard</title>
+  <title>Bitbucket Pull-Requests Tree</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <script>
+    // Runs before the stylesheet so a hidden sidebar does not flash open on load.
+    (function () {
+      var sidebarHidden = null;
+      try {
+        sidebarHidden = localStorage.getItem('prTree.sidebarHidden');
+      } catch (error) { /* storage unavailable */ }
+      if (sidebarHidden === 'true' || !window.matchMedia('(min-width: 900px)').matches) {
+        document.documentElement.classList.add('sidebar-hidden');
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
-<div class="container">
-  <div class="header-container">
-    <h1>Bitbucket Pull Requests Review Dashboard</h1>
-    <div class="refresh-container">
-      <i class="fas fa-sync refresh-icon" id="refreshIcon"></i>
-      <div class="last-refresh" id="lastRefreshTime"></div>
-    </div>
+<header class="app-header">
+  <button type="button" id="sidebarToggle" class="icon-button" aria-expanded="true" aria-controls="sidebar"
+          title="Toggle filters (F)">
+    <i class="fas fa-bars"></i>
+  </button>
+  <h1 class="app-brand">
+    <img src="favicon.svg" alt="" class="app-logo">
+    <span class="app-name">Bitbucket Pull-Requests Tree</span>
+  </h1>
+  <select id="projectSelect" class="project-select" aria-label="Project">
+    <option value="">Select a project</option>
+  </select>
+  <div class="header-spacer"></div>
+  <div class="refresh-container">
+    <i class="fas fa-sync refresh-icon" id="refreshIcon" title="Checking for updates"></i>
+    <span class="last-refresh" id="lastRefreshTime"></span>
+  </div>
+  <button type="button" id="helpButton" class="icon-button" title="Help">
+    <i class="fas fa-question-circle"></i>
+  </button>
+  <a href="https://github.com/frejfrej/pr-tree" target="_blank" rel="noopener" class="icon-button"
+     title="GitHub repository">
+    <i class="fab fa-github"></i>
+  </a>
+  <span id="versionNumber" class="version-number"></span>
+</header>
+
+<aside id="sidebar" class="sidebar" aria-label="Filters">
+  <div class="sidebar-header">
+    <h2>Filters</h2>
   </div>
 
-  <div class="filters-container">
-    <div class="filters-row">
-      <div class="filter-item">
-        <span class="filter-label">Project</span>
-        <select id="projectSelect">
-          <option value="">Select a project</option>
-        </select>
+  <div class="filter-item">
+    <span class="filter-label">Sprint</span>
+    <div class="multi-select" id="sprintSelect" data-filter="sprint">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
       </div>
-      <div class="filter-item">
-        <span class="filter-label">Sprint</span>
-        <div class="multi-select" id="sprintSelect" data-filter="sprint">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
         </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">Fix Version</span>
-        <div class="multi-select" id="fixVersionSelect" data-filter="fixVersion">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
         </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">Assignee</span>
-        <div class="multi-select" id="assigneeSelect" data-filter="assignee">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="filters-row">
-      <div class="filter-item">
-        <span class="filter-label">Reviewer</span>
-        <div class="multi-select" id="reviewerSelect" data-filter="reviewer">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="filter-item">
-        <div class="filter-label">
-          <input type="checkbox" id="readyForReviewerCheck" disabled>
-          <label for="readyForReviewerCheck">Ready for reviewer
-            <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
-          </label>
-        </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">SYNC
-          <i class="fas fa-info-circle info-icon" title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
-        </span>
-        <select id="syncSelect" disabled>
-          <option value="Show all">SYNC status not loaded</option>
-        </select>
-        <button id="loadSyncButton" class="load-sync-button" disabled
-                title="Load SYNC status for all pull requests">
-          <i class="fas fa-sync-alt"></i> Load
-        </button>
-        <span id="syncWarning" class="sync-warning" style="display: none;">
-          <i class="fas fa-exclamation-triangle"></i>
-        </span>
       </div>
     </div>
   </div>
 
-  <div id="pull-requests">
-    Please select a project
-  </div>
-  <div id="loading" style="display: none;">
-    <i class="fas fa-spinner fa-spin"></i> Loading...
+  <div class="filter-item">
+    <span class="filter-label">Fix version</span>
+    <div class="multi-select" id="fixVersionSelect" data-filter="fixVersion">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <div id="helpModal" class="modal">
-    <div class="modal-content">
-      <span class="close">&times;</span>
-      <!-- The closing tag must absolutely remain immediately next to the open tag -->
-      <div id="helpContent" class="help-content"></div>
+  <div class="filter-item">
+    <span class="filter-label">Assignee</span>
+    <div class="multi-select" id="assigneeSelect" data-filter="assignee">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
     </div>
+  </div>
+
+  <div class="filter-item">
+    <span class="filter-label">Reviewer</span>
+    <div class="multi-select" id="reviewerSelect" data-filter="reviewer">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item filter-item-checkbox">
+    <input type="checkbox" id="readyForReviewerCheck" disabled>
+    <label for="readyForReviewerCheck">Ready for reviewer</label>
+    <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
+  </div>
+
+  <hr class="sidebar-divider">
+
+  <div class="filter-item">
+    <span class="filter-label">SYNC
+      <i class="fas fa-info-circle info-icon"
+         title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
+    </span>
+    <select id="syncSelect" disabled>
+      <option value="Show all">SYNC status not loaded</option>
+    </select>
+    <div class="filter-row">
+      <button type="button" id="loadSyncButton" class="button" disabled
+              title="Load SYNC status for all pull requests">
+        <i class="fas fa-sync-alt"></i> Load
+      </button>
+      <span id="syncWarning" class="sync-warning" hidden>
+        <i class="fas fa-exclamation-triangle"></i>
+      </span>
+    </div>
+  </div>
+</aside>
+<div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+<main id="main" class="main-pane">
+  <div id="pull-requests" class="tree-pane"></div>
+</main>
+
+<div id="helpModal" class="modal" hidden>
+  <div class="modal-content" role="dialog" aria-modal="true" aria-label="Help">
+    <button type="button" id="helpClose" class="icon-button modal-close" aria-label="Close help">
+      <i class="fas fa-times"></i>
+    </button>
+    <!-- The closing tag must absolutely remain immediately next to the open tag -->
+    <div id="helpContent" class="help-content"></div>
   </div>
 </div>
 
-<footer id="appFooter" class="app-footer">
-  <div class="footer-content">
-    <div class="footer-section">
-      <h3>About</h3>
-      <p id="authorInfo" class="author-info"></p>
-      <p id="licenseInfo" class="license-info"></p>
-    </div>
-    <div class="footer-section">
-      <h3>Version</h3>
-      <div class="version-info">
-        <span id="versionNumber" class="version-number"></span>
-        <span id="versionDate" class="version-date"></span>
-      </div>
-    </div>
-    <div class="footer-section">
-      <h3>Links</h3>
-      <ul class="footer-links">
-        <li><a href="#" id="helpButton" class="footer-link">
-          <i class="fas fa-question-circle"></i> Help
-        </a></li>
-        <li><a href="https://github.com/frejfrej/pr-tree" target="_blank" class="footer-link">
-          <i class="fab fa-github"></i> GitHub
-        </a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="footer-bottom">
-    <p>&copy; 2024 Bitbucket Pull-Requests Tree. All rights reserved.</p>
-  </div>
-</footer>
-
-<script type="module" src="multi-select.js"></script>
-<script type="module" src="app-filter.js"></script>
 <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,61 +1,114 @@
+/* ==========================================================================
+   Bitbucket Pull-Requests Tree
+   1. Tokens          2. Base             3. Page layout
+   4. Controls        5. Multi-select     6. Tree
+   7. Orphaned issues 8. Popovers         9. Modal and help
+   ========================================================================== */
+
+/* 1. Tokens --------------------------------------------------------------- */
 :root {
+    color-scheme: light;
+
     --primary-color: #0052CC;
     --attention-color: #FF5630;
     --background-color: #F4F5F7;
+    --surface-color: #FFFFFF;
+    --surface-muted: #EBECF0;
     --text-color: #172B4D;
+    --text-muted: #6B778C;
     --border-color: #DFE1E6;
     --success-color: #36B37E;
     --warning-color: #FFAB00;
     --error-color: #FF5630;
-    --in-review-color: #0065FF; /* New color for in-review status */
+    --in-review-color: #0065FF;
+    --danger-bg: #FFEBE6;
+    --danger-text: #BF2600;
+    --on-accent-text: #FFFFFF;
+    --shadow-color: rgba(9, 30, 66, 0.15);
+    --focus-ring: rgba(0, 82, 204, 0.25);
+    --backdrop-color: rgba(9, 30, 66, 0.45);
+
+    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+    /* FontAwesome chevron-down, mid grey, readable on light and dark surfaces */
+    --chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%238993A4'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
+}
+
+/* 2. Base ----------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
 }
 
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    font-family: var(--font-family);
     line-height: 1.6;
     color: var(--text-color);
     background-color: var(--background-color);
-    margin: 0;
+}
+
+button,
+select,
+input {
+    font-family: inherit;
+    font-size: inherit;
+}
+
+:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* 3. Page layout (replaced by the app shell in Task 4) -------------------- */
+body {
     padding: 20px;
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 20px;
-    background-color: white;
+    padding: 20px 20px 60px;
+    background-color: var(--surface-color);
     border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-
-h1 {
-    color: var(--primary-color);
+    box-shadow: 0 0 10px var(--shadow-color);
 }
 
 .header-container {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    border-bottom: 2px solid var(--border-color);
-    padding-bottom: 10px;
     margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--border-color);
 }
 
-.container h1 {
-    color: var(--primary-color);
+.header-container h1 {
     margin: 0;
-}
-
-.last-refresh {
-    color: #666;
-    font-size: 0.9em;
-    font-style: italic;
+    color: var(--primary-color);
 }
 
 .refresh-container {
     display: flex;
     align-items: center;
     gap: 8px;
+}
+
+.last-refresh {
+    color: var(--text-muted);
+    font-size: 0.9em;
+    font-style: italic;
 }
 
 .refresh-icon {
@@ -70,25 +123,20 @@ h1 {
     animation: spin 1s linear infinite;
 }
 
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
 .filters-container {
     margin-bottom: 20px;
-    background-color: white;
     padding: 15px;
+    background-color: var(--surface-color);
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px var(--shadow-color);
 }
 
 .filters-row {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 20px;
     margin-bottom: 15px;
-    align-items: center;
 }
 
 .filters-row:last-child {
@@ -96,54 +144,31 @@ h1 {
 }
 
 .filter-item {
-    flex: 1 1 auto;
-    min-width: 200px;
+    position: relative;
     display: flex;
     align-items: center;
     gap: 10px;
-    position: relative;
-    overflow: visible;
+    flex: 1 1 auto;
+    min-width: 200px;
 }
 
 .filter-label {
-    color: var(--text-color);
-    font-weight: 500;
-    font-size: 14px;
-    white-space: nowrap;
-    min-width: 70px;
     flex-shrink: 0;
+    min-width: 70px;
+    color: var(--text-color);
+    font-size: 14px;
+    font-weight: 500;
+    white-space: nowrap;
 }
 
 .filter-item select {
     flex: 1;
     min-width: 0;
-    appearance: none;
-    -webkit-appearance: none;
-    padding: 8px 32px 8px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-family: inherit;
-    font-size: 14px;
-    line-height: inherit;
-    background-color: white;
-    /* same chevron as .multi-select-arrow (FontAwesome chevron-down, 12px, #666) */
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%23666666'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    background-size: 12px;
-    color: var(--text-color);
-    cursor: pointer;
-    transition: border-color 0.2s ease;
 }
 
-.filter-item select:hover {
-    border-color: var(--primary-color);
-}
-
-.filter-item select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(0, 82, 204, 0.1);
+.filter-item .multi-select {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .filter-item input[type="checkbox"] {
@@ -151,7 +176,7 @@ h1 {
 }
 
 .filter-item input[type="checkbox"]:disabled + label {
-    color: var(--border-color);
+    color: var(--text-muted);
     cursor: not-allowed;
 }
 
@@ -160,21 +185,145 @@ h1 {
     user-select: none;
 }
 
-.filter-item select:disabled {
-    background-color: #f5f5f5;
-    cursor: not-allowed;
-    opacity: 0.7;
+.app-footer {
+    padding: 30px 0 10px;
+    background-color: var(--primary-color);
+    color: var(--on-accent-text);
+    font-size: 14px;
+    box-shadow: 0 -2px 10px var(--shadow-color);
 }
 
-.filter-item select:disabled option {
-    color: #666;
+.footer-content {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
 }
 
+.footer-section {
+    flex: 1;
+    min-width: 200px;
+    margin-bottom: 20px;
+}
+
+.footer-section h3 {
+    margin-bottom: 10px;
+    padding-bottom: 5px;
+    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+    color: var(--on-accent-text);
+    font-size: 18px;
+}
+
+.footer-links {
+    list-style-type: none;
+    padding: 0;
+}
+
+.footer-link {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+    color: var(--on-accent-text);
+    opacity: 0.8;
+    text-decoration: none;
+    transition: opacity 0.3s ease;
+}
+
+.footer-link:hover {
+    opacity: 1;
+}
+
+.footer-link i {
+    width: 20px;
+    margin-right: 5px;
+    text-align: center;
+}
+
+.version-info,
+.author-info,
+.license-info {
+    margin-bottom: 5px;
+    opacity: 0.8;
+}
+
+.version-number {
+    margin-right: 5px;
+    font-weight: bold;
+}
+
+.version-date {
+    font-style: italic;
+}
+
+.footer-bottom {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    text-align: center;
+}
+
+@keyframes versionPulse {
+    0% { opacity: 0.7; }
+    50% { opacity: 1; }
+    100% { opacity: 0.7; }
+}
+
+@media (max-width: 768px) {
+    .footer-content {
+        flex-direction: column;
+    }
+
+    .footer-section {
+        width: 100%;
+        margin-bottom: 30px;
+    }
+
+    .filters-row {
+        flex-direction: column;
+        gap: 15px;
+    }
+
+    .filter-item {
+        width: 100%;
+    }
+}
+
+/* 4. Controls ------------------------------------------------------------- */
 select {
-    padding: 8px;
+    padding: 8px 32px 8px 12px;
     border: 1px solid var(--border-color);
     border-radius: 4px;
+    background-color: var(--surface-color);
+    background-image: var(--chevron-icon);
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 12px;
+    color: var(--text-color);
     font-size: 14px;
+    line-height: inherit;
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+}
+
+select:hover:not(:disabled) {
+    border-color: var(--primary-color);
+}
+
+select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+select:disabled {
+    background-color: var(--surface-muted);
+    color: var(--text-muted);
+    opacity: 0.7;
+    cursor: not-allowed;
 }
 
 .load-sync-button {
@@ -182,13 +331,12 @@ select {
     padding: 8px 12px;
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    font-family: inherit;
+    background-color: var(--surface-color);
+    color: var(--text-color);
     font-size: 14px;
     line-height: inherit;
-    background-color: white;
-    color: var(--text-color);
-    cursor: pointer;
     white-space: nowrap;
+    cursor: pointer;
     transition: border-color 0.2s ease;
 }
 
@@ -198,9 +346,10 @@ select {
 }
 
 .load-sync-button:disabled {
-    background-color: #f5f5f5;
-    cursor: not-allowed;
+    background-color: var(--surface-muted);
+    color: var(--text-muted);
     opacity: 0.7;
+    cursor: not-allowed;
 }
 
 .sync-warning {
@@ -209,21 +358,339 @@ select {
     cursor: help;
 }
 
-.pull-request {
-    border: 2px solid var(--border-color);
-    border-radius: 4px;
-    margin-bottom: 10px;
-    padding: 15px;
-    transition: all 0.3s ease;
+.info-icon {
+    color: var(--primary-color);
+    cursor: help;
+}
+
+/* 5. Multi-select --------------------------------------------------------- */
+.multi-select {
     position: relative;
 }
 
+.multi-select-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    font-size: 14px;
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.2s ease;
+}
+
+.multi-select-trigger:hover {
+    border-color: var(--primary-color);
+}
+
+.multi-select-trigger:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.multi-select.disabled .multi-select-trigger {
+    background-color: var(--surface-muted);
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+.multi-select-display {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.multi-select-display.has-selection {
+    font-weight: 500;
+}
+
+.multi-select-arrow {
+    margin-left: 8px;
+    color: var(--text-muted);
+    font-size: 12px;
+    transition: transform 0.2s ease;
+}
+
+.multi-select.open .multi-select-arrow {
+    transform: rotate(180deg);
+}
+
+.multi-select-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    margin-top: 4px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    box-shadow: 0 4px 12px var(--shadow-color);
+    overflow: hidden;
+}
+
+.multi-select.open .multi-select-dropdown {
+    display: block;
+}
+
+.multi-select-search {
+    padding: 8px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.multi-select-search-input {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    font-size: 14px;
+    outline: none;
+}
+
+.multi-select-search-input:focus {
+    border-color: var(--primary-color);
+}
+
+.multi-select-options {
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.multi-select-option {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.multi-select-option:hover {
+    background-color: var(--surface-muted);
+}
+
+.multi-select-option input[type="checkbox"] {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+.multi-select-option-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.multi-select-no-results {
+    padding: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+}
+
+.multi-select-actions {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--surface-muted);
+}
+
+.multi-select-actions button {
+    padding: 4px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.multi-select-actions button:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+/* 6. Tree ----------------------------------------------------------------- */
+.repository {
+    margin-bottom: 30px;
+}
+
+.repository-header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    background-color: var(--primary-color);
+    color: var(--on-accent-text);
+    border-radius: 4px 4px 0 0;
+    cursor: pointer;
+}
+
+.repository-name {
+    flex-grow: 1;
+    margin: 0;
+    color: inherit;
+    font-size: 24px;
+    font-weight: bold;
+}
+
+.repo-pr-counter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    margin-left: 15px;
+    padding: 0 8px;
+    border-radius: 12px;
+    background-color: var(--surface-color);
+    color: var(--primary-color);
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.repository-content {
+    padding: 20px;
+    border: 1px solid var(--border-color);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    background-color: var(--surface-color);
+}
+
+.repository.collapsed .repository-content {
+    display: none;
+}
+
+.root-branch {
+    margin-bottom: 20px;
+}
+
+.root-branch-header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    background-color: var(--background-color);
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.root-branch-name {
+    flex-grow: 1;
+    margin: 0;
+    color: var(--primary-color);
+    font-size: 18px;
+    font-weight: bold;
+}
+
+.root-branch-link {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+}
+
+.external-link-icon {
+    margin-left: 5px;
+    font-size: 0.8em;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+}
+
+.root-branch-link:hover .external-link-icon {
+    opacity: 1;
+}
+
+.branch-pr-counter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    margin-left: 10px;
+    padding: 0 5px;
+    border-radius: 10px;
+    background-color: var(--primary-color);
+    color: var(--on-accent-text);
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.root-branch-content {
+    margin-top: 10px;
+}
+
+.root-branch.collapsed .root-branch-content {
+    display: none;
+}
+
+.toggle-button {
+    margin-right: 10px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.pull-request .toggle-button,
+.root-branch-header .toggle-button {
+    color: var(--text-color);
+}
+
+.pull-request .toggle-button:hover,
+.root-branch-header .toggle-button:hover {
+    color: var(--primary-color);
+}
+
+.repository-header .toggle-button:hover {
+    opacity: 0.8;
+}
+
+/* Chevrons: down when open, right when collapsed, one pair per level */
+.toggle-button .fa-chevron-right {
+    display: none;
+}
+
+.repository.collapsed > .repository-header .fa-chevron-down,
+.root-branch.collapsed > .root-branch-header .fa-chevron-down,
+.pull-request.collapsed .pull-request-header .fa-chevron-down {
+    display: none;
+}
+
+.repository.collapsed > .repository-header .fa-chevron-right,
+.root-branch.collapsed > .root-branch-header .fa-chevron-right,
+.pull-request.collapsed .pull-request-header .fa-chevron-right {
+    display: inline;
+}
+
+.pull-request {
+    position: relative;
+    margin-bottom: 10px;
+    padding: 15px;
+    border: 2px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    transition: box-shadow 0.3s ease;
+}
+
 .pull-request:hover {
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 5px var(--shadow-color);
 }
 
 .pull-request-content {
-    padding-right: 70px; /* Make space for the conflicts counter */
+    padding-right: 70px; /* Make space for the counters */
 }
 
 .pull-request-main {
@@ -248,7 +715,7 @@ select {
 
 .pull-request.filtered {
     opacity: 0.5;
-    background-color: #f0f0f0;
+    background-color: var(--surface-muted);
 }
 
 .pull-request.filtered .pull-request-details {
@@ -257,8 +724,8 @@ select {
 
 .pull-request a {
     color: var(--primary-color);
-    text-decoration: none;
     font-weight: bold;
+    text-decoration: none;
 }
 
 .pull-request a:hover {
@@ -269,6 +736,12 @@ select {
     color: var(--attention-color);
 }
 
+.pull-request-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
 .participants {
     display: flex;
     align-items: center;
@@ -277,9 +750,9 @@ select {
 }
 
 .image-container {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    position: relative;
     height: 24px; /* Match the height of the avatar */
 }
 
@@ -290,13 +763,13 @@ select {
 }
 
 .icon {
-    font-size: 12px;
     position: absolute;
-    bottom: -2px;
     right: -2px;
-    background-color: white;
-    border-radius: 50%;
+    bottom: -2px;
     padding: 2px;
+    border-radius: 50%;
+    background-color: var(--surface-color);
+    font-size: 12px;
 }
 
 .icon.fa-check-circle { color: var(--success-color); }
@@ -310,11 +783,11 @@ select {
 .status-resolved { border-color: var(--primary-color); }
 
 .warnings {
-    background-color: #FFEBE6;
+    margin-top: 10px;
+    padding: 10px;
     border: 1px solid var(--error-color);
     border-radius: 4px;
-    padding: 10px;
-    margin-top: 10px;
+    background-color: var(--danger-bg);
 }
 
 .warnings li {
@@ -323,24 +796,28 @@ select {
 
 .children {
     margin-left: 10px;
-    border-left: 2px solid var(--border-color);
     padding-left: 10px;
+    border-left: 2px solid var(--border-color);
 }
 
 .jira-issues {
     list-style-type: none;
-    padding: 0;
     margin: 0;
+    padding: 0;
 }
 
 .jira-issues li {
+    display: flex;
+    align-items: center;
     margin-bottom: 5px;
 }
 
-.pull-request-header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 10px;
+.jira-priority-icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    vertical-align: middle;
 }
 
 .counters-container {
@@ -349,166 +826,27 @@ select {
     right: 15px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
     align-items: flex-end;
+    gap: 8px;
 }
 
 .child-counter {
-    background-color: var(--primary-color);
-    color: white;
-    font-size: 12px;
-    font-weight: bold;
+    display: none;
+    align-items: center;
+    justify-content: center;
     min-width: 20px;
     height: 20px;
-    border-radius: 10px;
-    display: none;
-    justify-content: center;
-    align-items: center;
     padding: 0 5px;
+    border-radius: 10px;
+    background-color: var(--primary-color);
+    color: var(--on-accent-text);
+    font-size: 12px;
+    font-weight: bold;
 }
 
-.child-counter.visible {
-    display: flex;
-}
-
+.child-counter.visible,
 .pull-request.collapsed .child-counter {
     display: flex;
-}
-
-.toggle-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    margin-right: 10px;
-    font-size: 16px;
-    color: var(--text-color);
-}
-
-.toggle-button:hover {
-    color: var(--primary-color);
-}
-
-.toggle-button .fa-chevron-right {
-    display: none;
-}
-
-.collapsed .toggle-button .fa-chevron-down {
-    display: none;
-}
-
-.collapsed .toggle-button .fa-chevron-right {
-    display: inline;
-}
-
-.root-branch {
-    margin-bottom: 20px;
-}
-
-.root-branch-header {
-    display: flex;
-    align-items: center;
-    background-color: var(--background-color);
-    padding: 10px;
-    border-radius: 4px;
-    cursor: pointer;
-    position: relative;  /* Add this line */
-}
-
-.root-branch-name {
-    margin: 0;
-    font-size: 18px;
-    font-weight: bold;
-    color: var(--primary-color);
-    flex-grow: 1;
-}
-
-.branch-pr-counter {
-    background-color: var(--primary-color);
-    color: white;
-    font-size: 12px;
-    font-weight: bold;
-    min-width: 20px;
-    height: 20px;
-    border-radius: 10px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0 5px;
-    margin-left: 10px;  /* Add some space between the branch name and the counter */
-}
-
-.root-branch-content {
-    margin-top: 10px;
-}
-
-.root-branch.collapsed .root-branch-content {
-    display: none;
-}
-
-.root-branch.collapsed .toggle-button .fa-chevron-down {
-    display: none;
-}
-
-.root-branch.collapsed .toggle-button .fa-chevron-right {
-    display: inline;
-}
-
-.repository {
-    margin-bottom: 30px;
-}
-
-.repository-header {
-    display: flex;
-    align-items: center;
-    background-color: var(--primary-color);
-    padding: 10px;
-    border-radius: 4px 4px 0 0;
-    cursor: pointer;
-    position: relative;
-}
-
-.repository-name {
-    margin: 0;
-    font-size: 24px;
-    font-weight: bold;
-    color: white;
-    flex-grow: 1;
-}
-
-.repo-pr-counter {
-    background-color: white;
-    color: var(--primary-color);
-    font-size: 14px;
-    font-weight: bold;
-    min-width: 24px;
-    height: 24px;
-    border-radius: 12px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0 8px;
-    margin-left: 15px;  /* Add some space between the repository name and the counter */
-}
-
-.repository-content {
-    background-color: white;
-    border: 1px solid var(--border-color);
-    border-top: none;
-    border-radius: 0 0 4px 4px;
-    padding: 20px;
-}
-
-.repository.collapsed .repository-content {
-    display: none;
-}
-
-.repository.collapsed .toggle-button .fa-chevron-down {
-    display: none;
-}
-
-.repository.collapsed .toggle-button .fa-chevron-right {
-    display: inline;
 }
 
 .conflicts-counter {
@@ -518,398 +856,56 @@ select {
 }
 
 .conflicts-count {
-    background-color: var(--error-color);
-    color: white;
-    font-size: 12px;
-    font-weight: bold;
-    padding: 2px 8px;
-    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 2px 8px;
+    border-radius: 12px;
+    background-color: var(--error-color);
+    color: var(--on-accent-text);
+    font-size: 12px;
+    font-weight: bold;
 }
 
 .conflicts-spinner {
     width: 20px;
     height: 20px;
     border: 2px solid var(--border-color);
-    border-top: 2px solid var(--primary-color);
+    border-top-color: var(--primary-color);
     border-radius: 50%;
     animation: spin 1s linear infinite;
 }
 
 .conflicts-error {
-    background-color: var(--warning-color);
-    color: white;
-    font-size: 12px;
-    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
-@media (min-width: 768px) {
-    .help-button {
-        bottom: 30px;
-        right: 30px;
-    }
-
-    .help-button span {
-        display: inline;
-    }
-}
-
-.modal {
-    display: none;
-    position: fixed;
-    z-index: 1;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.4);
-}
-
-.modal-content {
-    background-color: #fefefe;
-    margin: 5% auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%;
-    max-width: 800px;
-    border-radius: 5px;
-    max-height: 80vh;
-    overflow-y: auto;
-}
-
-.close {
-    color: #aaa;
-    float: right;
-    font-size: 28px;
+    background-color: var(--warning-color);
+    color: var(--on-accent-text);
+    font-size: 12px;
     font-weight: bold;
-    cursor: pointer;
-}
-
-.close:hover,
-.close:focus {
-    color: #000;
-    text-decoration: none;
-    cursor: pointer;
-}
-
-.help-content {
-    margin-top: 20px;
-}
-
-.help-content h1, .help-content h2, .help-content h3, .help-content h4, .help-content h5, .help-content h6 {
-    color: var(--primary-color);
-    margin-top: 20px;
-    margin-bottom: 10px;
-}
-
-.help-content p {
-    margin-bottom: 10px;
-}
-
-.help-content ul, .help-content ol {
-    padding-left: 20px;
-    margin-bottom: 10px;
-}
-
-.help-content li {
-    margin-bottom: 5px;
-}
-
-.help-content code {
-    background-color: #f4f4f4;
-    padding: 2px 4px;
-    border-radius: 4px;
-}
-
-.help-content pre {
-    background-color: #f4f4f4;
-    padding: 10px;
-    border-radius: 4px;
-    overflow-x: auto;
-}
-
-.help-content a {
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-.help-content a:hover {
-    text-decoration: underline;
-}
-
-.help-content blockquote {
-    border-left: 4px solid var(--primary-color);
-    padding-left: 10px;
-    margin-left: 0;
-    color: #666;
-}
-
-.help-content img {
-    max-width: 100%;
-    height: auto;
-}
-
-.app-footer {
-    background-color: var(--primary-color);
-    color: white;
-    padding: 30px 0 10px;
-    font-size: 14px;
-    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
-}
-
-.footer-content {
-    display: flex;
-    justify-content: space-around;
-    flex-wrap: wrap;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
-.footer-section {
-    flex: 1;
-    min-width: 200px;
-    margin-bottom: 20px;
-}
-
-.footer-section h3 {
-    font-size: 18px;
-    margin-bottom: 10px;
-    color: #ffffff;
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-    padding-bottom: 5px;
-}
-
-.footer-links {
-    list-style-type: none;
-    padding: 0;
-}
-
-.footer-link {
-    color: rgba(255, 255, 255, 0.8);
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    margin-bottom: 5px;
-    transition: color 0.3s ease;
-}
-
-.footer-link:hover {
-    color: #ffffff;
-}
-
-.footer-link i {
-    margin-right: 5px;
-    width: 20px;
-    text-align: center;
-}
-
-.version-info, .author-info, .license-info {
-    color: rgba(255, 255, 255, 0.8);
-    margin-bottom: 5px;
-}
-
-.version-number {
-    font-weight: bold;
-    margin-right: 5px;
-}
-
-.version-date {
-    font-style: italic;
-}
-
-.footer-bottom {
-    text-align: center;
-    padding-top: 20px;
-    margin-top: 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-@keyframes versionPulse {
-    0% { color: rgba(255, 255, 255, 0.8); }
-    50% { color: #ffffff; }
-    100% { color: rgba(255, 255, 255, 0.8); }
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-    .footer-content {
-        flex-direction: column;
-    }
-
-    .footer-section {
-        width: 100%;
-        margin-bottom: 30px;
-    }
-
-    .filters-row {
-        flex-direction: column;
-        gap: 15px;
-    }
-
-    .filter-item {
-        width: 100%;
-    }
-
-    .filter-label {
-        min-width: 70px;
-    }
-}
-
-/* Update container padding to account for footer */
-.container {
-    padding-bottom: 60px; /* Adjust this value based on the footer height */
-}
-
-@keyframes versionPulse {
-    0% { opacity: 0.7; }
-    50% { opacity: 1; }
-    100% { opacity: 0.7; }
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-    .footer-content {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-    }
-
-    .version-info, .author-license-info, .footer-links {
-        width: 100%;
-    }
-
-    .author-license-info {
-        text-align: left;
-    }
-
-    .footer-links {
-        justify-content: space-between;
-    }
-}
-
-.jira-issue-popover {
-    position: absolute;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    padding: 10px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-    z-index: 1000;
-    max-width: 300px;
-    font-size: 14px;
-    display: none;
-}
-
-.jira-issue-popover-key {
-    font-weight: bold;
-    margin-bottom: 5px;
-}
-
-.jira-issue-popover-summary {
-    color: #555;
-}
-
-.jira-issue-popover,
-.pull-request-popover {
-    position: absolute;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    padding: 10px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-    z-index: 1000;
-    max-width: 500px;
-    font-size: 14px;
-    display: none;
-}
-
-.jira-issue-popover-key,
-.pull-request-popover-title {
-    font-weight: bold;
-    margin-bottom: 5px;
-}
-
-.jira-issue-popover-summary,
-.pull-request-popover-description {
-    color: #555;
-    max-height: 200px;
-    overflow-y: auto;
-}
-
-.pull-request-popover-description {
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid #eee;
-}
-
-.root-branch-link {
-    display: inline-flex;
-    align-items: center;
-    color: inherit;
-    text-decoration: none;
-}
-
-.external-link-icon {
-    margin-left: 5px;
-    font-size: 0.8em;
-    opacity: 0.6;
-    transition: opacity 0.2s ease;
-}
-
-.root-branch-link:hover .external-link-icon {
-    opacity: 1;
-}
-
-.jira-priority-icon {
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    vertical-align: middle;
-    margin-right: 4px;
-}
-
-.jira-issues li {
-    display: flex;
-    align-items: center;
 }
 
 .commit-badge {
-    color: var(--text-color);
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
     display: inline-flex;
     align-items: center;
     gap: 4px;
     margin-left: 8px;
-    border-width: 1px;
-    border-style: solid;
-    background-color: transparent;
+    padding: 2px 8px;
+    border: 1px solid;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
 }
 
-/* Ahead commits badge */
 .commit-badge-ahead {
     border-color: var(--success-color);
     color: var(--success-color);
 }
 
-/* Behind commits badge */
 .commit-badge-behind {
     border-color: var(--error-color);
     color: var(--error-color);
@@ -924,28 +920,29 @@ select {
     align-items: center;
 }
 
+/* 7. Orphaned issues ------------------------------------------------------ */
 .orphaned-issues {
     margin-top: 30px;
-    background-color: white;
     border: 1px solid var(--border-color);
     border-radius: 8px;
+    background-color: var(--surface-color);
+    box-shadow: 0 1px 3px var(--shadow-color);
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .orphaned-issues-header {
-    background-color: #FEF2F2;
-    border-bottom: 1px solid #FEE2E2;
     padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--danger-bg);
 }
 
 .orphaned-issues-title {
-    color: #B91C1C;
-    font-size: 1.125rem;
-    font-weight: 600;
     display: flex;
     align-items: center;
     gap: 8px;
+    color: var(--danger-text);
+    font-size: 1.125rem;
+    font-weight: 600;
 }
 
 .orphaned-issues-content {
@@ -953,10 +950,10 @@ select {
 }
 
 .orphaned-issue {
+    margin-bottom: 12px;
+    padding: 12px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
-    padding: 12px;
-    margin-bottom: 12px;
     transition: background-color 0.2s ease;
 }
 
@@ -965,7 +962,7 @@ select {
 }
 
 .orphaned-issue:hover {
-    background-color: var(--background-color);
+    background-color: var(--surface-muted);
 }
 
 .orphaned-issue-header {
@@ -982,8 +979,8 @@ select {
 
 .orphaned-issue-key {
     color: var(--primary-color);
-    text-decoration: none;
     font-weight: 500;
+    text-decoration: none;
 }
 
 .orphaned-issue-key:hover {
@@ -991,173 +988,155 @@ select {
 }
 
 .orphaned-issue-summary {
-    color: var(--text-color);
     margin: 4px 0;
+    color: var(--text-color);
 }
 
 .orphaned-issue-status {
-    color: #6B7280;
-    font-size: 0.875rem;
     margin-top: 8px;
+    color: var(--text-muted);
+    font-size: 0.875rem;
 }
 
-/* Multi-Select Component Styles */
-.multi-select {
-    position: relative;
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow: visible;
+/* 8. Popovers ------------------------------------------------------------- */
+.popover {
+    display: none;
 }
 
-.multi-select-trigger {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    max-width: 100%;
-    padding: 8px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-size: 14px;
-    background-color: white;
-    color: var(--text-color);
-    cursor: pointer;
-    transition: border-color 0.2s ease;
-    outline: none;
-    box-sizing: border-box;
-}
-
-.multi-select-trigger:hover {
-    border-color: var(--primary-color);
-}
-
-.multi-select-trigger:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(0, 82, 204, 0.1);
-}
-
-.multi-select.disabled .multi-select-trigger {
-    background-color: #f5f5f5;
-    cursor: not-allowed;
-    opacity: 0.7;
-}
-
-.multi-select-display {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.multi-select-display.has-selection {
-    font-weight: 500;
-}
-
-.multi-select-arrow {
-    margin-left: 8px;
-    font-size: 12px;
-    color: #666;
-    transition: transform 0.2s ease;
-}
-
-.multi-select.open .multi-select-arrow {
-    transform: rotate(180deg);
-}
-
-.multi-select-dropdown {
+.jira-issue-popover,
+.pull-request-popover {
     display: none;
     position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin-top: 4px;
-    background-color: white;
+    z-index: 1000;
+    max-width: 500px;
+    padding: 10px;
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    z-index: 100;
-    overflow: hidden;
-}
-
-.multi-select.open .multi-select-dropdown {
-    display: block;
-}
-
-.multi-select-search {
-    padding: 8px;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.multi-select-search-input {
-    width: 100%;
-    padding: 6px 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    box-shadow: 0 2px 5px var(--shadow-color);
     font-size: 14px;
-    outline: none;
-    box-sizing: border-box;
 }
 
-.multi-select-search-input:focus {
-    border-color: var(--primary-color);
+.jira-issue-popover-key,
+.pull-request-popover-title {
+    margin-bottom: 5px;
+    font-weight: bold;
 }
 
-.multi-select-options {
-    max-height: 250px;
+.jira-issue-popover-summary,
+.pull-request-popover-description {
+    max-height: 200px;
+    overflow-y: auto;
+    color: var(--text-muted);
+}
+
+.pull-request-popover-description {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+}
+
+/* 9. Modal and help ------------------------------------------------------- */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 200;
+    width: 100%;
+    height: 100%;
+    background-color: var(--backdrop-color);
+    overflow: auto;
+}
+
+.modal-content {
+    width: 80%;
+    max-width: 800px;
+    max-height: 80vh;
+    margin: 5% auto;
+    padding: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    background-color: var(--surface-color);
     overflow-y: auto;
 }
 
-.multi-select-option {
-    display: flex;
-    align-items: center;
-    padding: 8px 12px;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.multi-select-option:hover {
-    background-color: var(--background-color);
-}
-
-.multi-select-option input[type="checkbox"] {
-    margin-right: 8px;
+.close {
+    float: right;
+    color: var(--text-muted);
+    font-size: 28px;
+    font-weight: bold;
     cursor: pointer;
 }
 
-.multi-select-option-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.multi-select-no-results {
-    padding: 12px;
-    text-align: center;
-    color: #666;
-    font-style: italic;
-}
-
-.multi-select-actions {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px;
-    border-top: 1px solid var(--border-color);
-    background-color: var(--background-color);
-}
-
-.multi-select-actions button {
-    padding: 4px 12px;
-    font-size: 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background-color: white;
+.close:hover,
+.close:focus {
     color: var(--text-color);
-    cursor: pointer;
-    transition: all 0.15s ease;
+    text-decoration: none;
 }
 
-.multi-select-actions button:hover {
-    border-color: var(--primary-color);
+.help-content {
+    margin-top: 20px;
+}
+
+.help-content h1,
+.help-content h2,
+.help-content h3,
+.help-content h4,
+.help-content h5,
+.help-content h6 {
+    margin-top: 20px;
+    margin-bottom: 10px;
     color: var(--primary-color);
+}
+
+.help-content p {
+    margin-bottom: 10px;
+}
+
+.help-content ul,
+.help-content ol {
+    margin-bottom: 10px;
+    padding-left: 20px;
+}
+
+.help-content li {
+    margin-bottom: 5px;
+}
+
+.help-content code {
+    padding: 2px 4px;
+    border-radius: 4px;
+    background-color: var(--surface-muted);
+    font-family: var(--font-mono);
+}
+
+.help-content pre {
+    padding: 10px;
+    border-radius: 4px;
+    background-color: var(--surface-muted);
+    font-family: var(--font-mono);
+    overflow-x: auto;
+}
+
+.help-content a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.help-content a:hover {
+    text-decoration: underline;
+}
+
+.help-content blockquote {
+    margin-left: 0;
+    padding-left: 10px;
+    border-left: 4px solid var(--primary-color);
+    color: var(--text-muted);
+}
+
+.help-content img {
+    max-width: 100%;
+    height: auto;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,8 +1,9 @@
 /* ==========================================================================
    Bitbucket Pull-Requests Tree
-   1. Tokens          2. Base             3. Page layout
+   1. Tokens          2. Base             3. App shell
    4. Controls        5. Multi-select     6. Tree
    7. Orphaned issues 8. Popovers         9. Modal and help
+   10. State messages 11. Responsive
    ========================================================================== */
 
 /* 1. Tokens --------------------------------------------------------------- */
@@ -27,12 +28,24 @@
     --shadow-color: rgba(9, 30, 66, 0.15);
     --focus-ring: rgba(0, 82, 204, 0.25);
     --backdrop-color: rgba(9, 30, 66, 0.45);
+    --header-bg: #0052CC;
+    --header-text: #FFFFFF;
+    --header-muted: rgba(255, 255, 255, 0.75);
+    --header-border: transparent;
+    --header-control-bg: rgba(255, 255, 255, 0.14);
+    --header-control-border: rgba(255, 255, 255, 0.35);
+
+    --header-height: 48px;
+    --sidebar-width: 280px;
+    --repo-header-height: 48px;
+    --branch-header-height: 40px;
 
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 
     /* FontAwesome chevron-down, mid grey, readable on light and dark surfaces */
     --chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%238993A4'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
+    --chevron-icon-on-header: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%23FFFFFF'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
 }
 
 /* 2. Base ----------------------------------------------------------------- */
@@ -47,7 +60,16 @@
 }
 
 body {
+    display: grid;
+    grid-template-rows: var(--header-height) minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+        "header header"
+        "sidebar main";
+    height: 100vh;
+    height: 100dvh;
     margin: 0;
+    overflow: hidden;
     font-family: var(--font-family);
     line-height: 1.6;
     color: var(--text-color);
@@ -71,49 +93,96 @@ input {
     to { transform: rotate(360deg); }
 }
 
-/* 3. Page layout (replaced by the app shell in Task 4) -------------------- */
-body {
-    padding: 20px;
-}
-
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px 20px 60px;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 0 10px var(--shadow-color);
-}
-
-.header-container {
+/* 3. App shell ------------------------------------------------------------ */
+.app-header {
+    grid-area: header;
+    z-index: 20;
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: 20px;
-    padding-bottom: 10px;
-    border-bottom: 2px solid var(--border-color);
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px;
+    border-bottom: 1px solid var(--header-border);
+    background-color: var(--header-bg);
+    color: var(--header-text);
+    box-shadow: 0 1px 3px var(--shadow-color);
+    font-size: 14px;
 }
 
-.header-container h1 {
+.app-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin: 0;
-    color: var(--primary-color);
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.app-logo {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+}
+
+.header-spacer {
+    flex: 1;
+}
+
+.icon-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    font-size: 16px;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.app-header .icon-button:hover {
+    background-color: var(--header-control-bg);
+}
+
+.project-select {
+    max-width: 240px;
+    padding: 5px 28px 5px 10px;
+    border-color: var(--header-control-border);
+    background-color: var(--header-control-bg);
+    background-image: var(--chevron-icon-on-header);
+    background-position: right 10px center;
+    color: var(--header-text);
+}
+
+.project-select:hover:not(:disabled),
+.project-select:focus {
+    border-color: var(--header-text);
+    box-shadow: none;
+}
+
+.project-select option {
+    background-color: var(--surface-color);
+    color: var(--text-color);
 }
 
 .refresh-container {
     display: flex;
     align-items: center;
     gap: 8px;
+    color: var(--header-muted);
 }
 
 .last-refresh {
-    color: var(--text-muted);
-    font-size: 0.9em;
     font-style: italic;
+    white-space: nowrap;
 }
 
 .refresh-icon {
-    color: var(--primary-color);
-    font-size: 0.9em;
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -123,171 +192,113 @@ body {
     animation: spin 1s linear infinite;
 }
 
-.filters-container {
-    margin-bottom: 20px;
-    padding: 15px;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px var(--shadow-color);
+.version-number {
+    color: var(--header-muted);
+    white-space: nowrap;
+    cursor: help;
 }
 
-.filters-row {
+.sidebar {
+    grid-area: sidebar;
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 15px;
+    flex-direction: column;
+    gap: 16px;
+    width: var(--sidebar-width);
+    padding: 16px;
+    border-right: 1px solid var(--border-color);
+    background-color: var(--surface-color);
+    font-size: 14px;
+    overflow-y: auto;
 }
 
-.filters-row:last-child {
-    margin-bottom: 0;
+html.sidebar-hidden .sidebar {
+    display: none;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 24px;
+}
+
+.sidebar-header h2 {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.sidebar-divider {
+    margin: 0;
+    border: none;
+    border-top: 1px solid var(--border-color);
 }
 
 .filter-item {
     position: relative;
     display: flex;
-    align-items: center;
-    gap: 10px;
-    flex: 1 1 auto;
-    min-width: 200px;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .filter-label {
-    flex-shrink: 0;
-    min-width: 70px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
     color: var(--text-color);
-    font-size: 14px;
     font-weight: 500;
-    white-space: nowrap;
 }
 
 .filter-item select {
-    flex: 1;
-    min-width: 0;
+    width: 100%;
 }
 
-.filter-item .multi-select {
-    flex: 1 1 auto;
-    min-width: 0;
+.filter-item-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
 }
 
-.filter-item input[type="checkbox"] {
-    margin-right: 8px;
+.filter-item-checkbox input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
 }
 
-.filter-item input[type="checkbox"]:disabled + label {
-    color: var(--text-muted);
-    cursor: not-allowed;
-}
-
-.filter-item label {
+.filter-item-checkbox label {
     cursor: pointer;
     user-select: none;
 }
 
-.app-footer {
-    padding: 30px 0 10px;
-    background-color: var(--primary-color);
-    color: var(--on-accent-text);
-    font-size: 14px;
-    box-shadow: 0 -2px 10px var(--shadow-color);
+.filter-item-checkbox input[type="checkbox"]:disabled,
+.filter-item-checkbox input[type="checkbox"]:disabled + label {
+    color: var(--text-muted);
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
-.footer-content {
-    display: flex;
-    justify-content: space-around;
-    flex-wrap: wrap;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
-.footer-section {
-    flex: 1;
-    min-width: 200px;
-    margin-bottom: 20px;
-}
-
-.footer-section h3 {
-    margin-bottom: 10px;
-    padding-bottom: 5px;
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-    color: var(--on-accent-text);
-    font-size: 18px;
-}
-
-.footer-links {
-    list-style-type: none;
-    padding: 0;
-}
-
-.footer-link {
+.filter-row {
     display: flex;
     align-items: center;
-    margin-bottom: 5px;
-    color: var(--on-accent-text);
-    opacity: 0.8;
-    text-decoration: none;
-    transition: opacity 0.3s ease;
+    gap: 8px;
 }
 
-.footer-link:hover {
-    opacity: 1;
+.sidebar-backdrop {
+    display: none;
 }
 
-.footer-link i {
-    width: 20px;
-    margin-right: 5px;
-    text-align: center;
+.main-pane {
+    grid-area: main;
+    min-width: 0;
+    overflow-y: auto;
 }
 
-.version-info,
-.author-info,
-.license-info {
-    margin-bottom: 5px;
-    opacity: 0.8;
-}
-
-.version-number {
-    margin-right: 5px;
-    font-weight: bold;
-}
-
-.version-date {
-    font-style: italic;
-}
-
-.footer-bottom {
-    margin-top: 20px;
-    padding-top: 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    text-align: center;
-}
-
-@keyframes versionPulse {
-    0% { opacity: 0.7; }
-    50% { opacity: 1; }
-    100% { opacity: 0.7; }
-}
-
-@media (max-width: 768px) {
-    .footer-content {
-        flex-direction: column;
-    }
-
-    .footer-section {
-        width: 100%;
-        margin-bottom: 30px;
-    }
-
-    .filters-row {
-        flex-direction: column;
-        gap: 15px;
-    }
-
-    .filter-item {
-        width: 100%;
-    }
+/* Padding lives on the content, not on the scroll container: the container's own
+   padding would inset the sticky area and leave a strip above the sticky headers */
+.tree-pane {
+    padding: 24px;
 }
 
 /* 4. Controls ------------------------------------------------------------- */
@@ -326,7 +337,7 @@ select:disabled {
     cursor: not-allowed;
 }
 
-.load-sync-button {
+.button {
     flex-shrink: 0;
     padding: 8px 12px;
     border: 1px solid var(--border-color);
@@ -340,12 +351,12 @@ select:disabled {
     transition: border-color 0.2s ease;
 }
 
-.load-sync-button:hover:not(:disabled) {
+.button:hover:not(:disabled) {
     border-color: var(--primary-color);
     color: var(--primary-color);
 }
 
-.load-sync-button:disabled {
+.button:disabled {
     background-color: var(--surface-muted);
     color: var(--text-muted);
     opacity: 0.7;
@@ -526,22 +537,33 @@ select:disabled {
 }
 
 .repository-header {
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 3;
     display: flex;
     align-items: center;
-    padding: 10px;
+    height: var(--repo-header-height);
+    padding: 0 10px;
     background-color: var(--primary-color);
     color: var(--on-accent-text);
     border-radius: 4px 4px 0 0;
     cursor: pointer;
 }
 
+.repository.collapsed > .repository-header {
+    border-radius: 4px;
+}
+
 .repository-name {
-    flex-grow: 1;
+    flex: 1;
+    min-width: 0;
     margin: 0;
     color: inherit;
-    font-size: 24px;
+    font-size: 20px;
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .repo-pr-counter {
@@ -576,21 +598,27 @@ select:disabled {
 }
 
 .root-branch-header {
-    position: relative;
+    position: sticky;
+    top: var(--repo-header-height);
+    z-index: 2;
     display: flex;
     align-items: center;
-    padding: 10px;
+    height: var(--branch-header-height);
+    padding: 0 10px;
     background-color: var(--background-color);
     border-radius: 4px;
     cursor: pointer;
 }
 
 .root-branch-name {
-    flex-grow: 1;
+    flex: 1;
+    min-width: 0;
     margin: 0;
     color: var(--primary-color);
     font-size: 18px;
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .root-branch-link {
@@ -1006,7 +1034,7 @@ select:disabled {
 .jira-issue-popover,
 .pull-request-popover {
     display: none;
-    position: absolute;
+    position: fixed;
     z-index: 1000;
     max-width: 500px;
     padding: 10px;
@@ -1039,22 +1067,25 @@ select:disabled {
 
 /* 9. Modal and help ------------------------------------------------------- */
 .modal {
-    display: none;
     position: fixed;
     top: 0;
+    right: 0;
+    bottom: 0;
     left: 0;
     z-index: 200;
-    width: 100%;
-    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 5vh 16px;
     background-color: var(--backdrop-color);
     overflow: auto;
 }
 
 .modal-content {
-    width: 80%;
+    position: relative;
+    width: 100%;
     max-width: 800px;
-    max-height: 80vh;
-    margin: 5% auto;
+    max-height: 90vh;
     padding: 20px;
     border: 1px solid var(--border-color);
     border-radius: 5px;
@@ -1062,18 +1093,16 @@ select:disabled {
     overflow-y: auto;
 }
 
-.close {
-    float: right;
+.modal-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
     color: var(--text-muted);
-    font-size: 28px;
-    font-weight: bold;
-    cursor: pointer;
 }
 
-.close:hover,
-.close:focus {
+.modal-close:hover {
+    background-color: var(--surface-muted);
     color: var(--text-color);
-    text-decoration: none;
 }
 
 .help-content {
@@ -1139,4 +1168,53 @@ select:disabled {
 .help-content img {
     max-width: 100%;
     height: auto;
+}
+
+/* 10. State messages ------------------------------------------------------ */
+.state-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-height: 50vh;
+    color: var(--text-muted);
+    font-size: 16px;
+    text-align: center;
+}
+
+.state-message i {
+    font-size: 32px;
+}
+
+.state-message.error i {
+    color: var(--error-color);
+}
+
+/* 11. Responsive: below 900px the sidebar is a drawer over the tree -------- */
+@media (max-width: 899.98px) {
+    .app-name,
+    .last-refresh {
+        display: none;
+    }
+
+    .sidebar {
+        position: fixed;
+        top: var(--header-height);
+        bottom: 0;
+        left: 0;
+        z-index: 15;
+        box-shadow: 4px 0 12px var(--shadow-color);
+    }
+
+    html:not(.sidebar-hidden) .sidebar-backdrop {
+        position: fixed;
+        top: var(--header-height);
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 14;
+        display: block;
+        background-color: var(--backdrop-color);
+    }
 }

--- a/test/app-shell.test.mjs
+++ b/test/app-shell.test.mjs
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDocumentTitle } from '../public/app-shell.js';
+
+test('title without a project is the app name', () => {
+    assert.equal(buildDocumentTitle({ project: null, attentionCount: 0 }), 'Bitbucket Pull-Requests Tree');
+});
+
+test('title with a project puts the project first', () => {
+    assert.equal(buildDocumentTitle({ project: 'PROJ', attentionCount: 0 }), 'PROJ · Bitbucket Pull-Requests Tree');
+});
+
+test('title with an attention count prefixes the count', () => {
+    assert.equal(buildDocumentTitle({ project: 'PROJ', attentionCount: 3 }), '(3) PROJ · Bitbucket Pull-Requests Tree');
+});


### PR DESCRIPTION
The page becomes a grid: a 48px banner (sidebar toggle, logo and app name "Bitbucket Pull-Requests Tree", project selector, refresh status, help, GitHub link, version with the former footer text in its tooltip), a 280px filter sidebar with the filters stacked one below the other, and a main pane that is the only scroll container, with sticky repository and branch headers. The sidebar can be hidden with the banner button or the `F` key, the choice is remembered, and below 900px it becomes a drawer with a backdrop that closes on backdrop click, Escape or project change. The tab title reads `PROJECT · Bitbucket Pull-Requests Tree`. The footer is gone. Empty, loading and error states render in the pane, and a failed load no longer leaves the spinner forever: the next check re-renders as soon as data comes back. Popovers use fixed positioning, stay inside the viewport (flipping above the link when needed) and hide when the pane scrolls. New `public/app-shell.js` module with a `node:test` for the title builder.

Two deviations from the plan found while verifying: the pane padding lives on the tree container (`.tree-pane`) instead of the scroll container, because a scroll container's own padding insets the sticky area and left a 24px strip above the sticky headers; and `renderEverything(apiResult)` takes the data from its caller, so a failed refresh never wipes a valid tree and data is no longer fetched twice.

Verified in the browser: banner and sidebar contents, tab title, loading/empty/error states and recovery, independent scrolling with sticky headers, toggle by button and `F` (ignored while typing in a search box), persistence across reloads, popovers after scrolling and near the viewport edges, help modal (button, backdrop, Escape), and the drawer in an 800px viewport.

Closes #12
Part of #16
Stacked on #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZCANUDoVq6pd6b9i8vGbg