### PR TITLE
feat: active-filter badge, clear filters, attention count and collapse/expand all

### DIFF
--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -6,6 +6,8 @@
  * unit-tested with node:test.
  */
 
+import { collapseAll, expandAll } from './tree-toggle.js';
+
 export const APP_NAME = 'Bitbucket Pull-Requests Tree';
 
 const SIDEBAR_STORAGE_KEY = 'prTree.sidebarHidden';
@@ -161,10 +163,39 @@ function handleKeydown(event) {
     }
 }
 
+// -------------------------------------------------------- filters and tree
+
+/** Shows the number of active filters on the sidebar toggle and the clear button in the sidebar. */
+export function updateActiveFilterBadge(count) {
+    const badge = document.getElementById('activeFilterBadge');
+    if (badge) {
+        badge.textContent = String(count);
+        badge.hidden = count === 0;
+    }
+    const clearButton = document.getElementById('clearFiltersButton');
+    if (clearButton) {
+        clearButton.hidden = count === 0;
+    }
+}
+
+export function setToolbarVisible(visible) {
+    const toolbar = document.getElementById('treeToolbar');
+    if (toolbar) {
+        toolbar.hidden = !visible;
+    }
+}
+
+function initializeToolbar() {
+    document.getElementById('collapseAllButton').addEventListener('click', collapseAll);
+    document.getElementById('expandAllButton').addEventListener('click', expandAll);
+}
+
 // -------------------------------------------------------------------- init
 
-export function initializeAppShell() {
+export function initializeAppShell({ onClearFilters }) {
     initializeSidebar();
     initializeHelpModal();
+    initializeToolbar();
+    document.getElementById('clearFiltersButton').addEventListener('click', onClearFilters);
     document.addEventListener('keydown', handleKeydown, true);
 }

--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -1,0 +1,170 @@
+/**
+ * Application shell: banner, sidebar visibility, help modal, keyboard
+ * shortcuts and document title. Knows nothing about pull requests.
+ *
+ * Nothing here touches the DOM at import time, so the pure helpers can be
+ * unit-tested with node:test.
+ */
+
+export const APP_NAME = 'Bitbucket Pull-Requests Tree';
+
+const SIDEBAR_STORAGE_KEY = 'prTree.sidebarHidden';
+const WIDE_LAYOUT_QUERY = '(min-width: 900px)';
+
+let wideLayout = null;
+
+// ---------------------------------------------------------- document title
+
+export function buildDocumentTitle({ project, attentionCount }) {
+    const prefix = attentionCount > 0 ? `(${attentionCount}) ` : '';
+    const projectPart = project ? `${project} · ` : '';
+    return `${prefix}${projectPart}${APP_NAME}`;
+}
+
+export function updateDocumentTitle(state) {
+    document.title = buildDocumentTitle(state);
+}
+
+// ----------------------------------------------------------------- storage
+
+function readStorage(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch (error) {
+        return null;
+    }
+}
+
+function writeStorage(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch (error) {
+        // Storage unavailable (private window, blocked site data): the preference is not remembered
+    }
+}
+
+// ----------------------------------------------------------------- sidebar
+
+function isSidebarHidden() {
+    return document.documentElement.classList.contains('sidebar-hidden');
+}
+
+// The stored preference only applies to the wide layout; the drawer of the
+// narrow layout always starts closed and never writes the preference.
+function setSidebarHidden(hidden, { persist = true } = {}) {
+    document.documentElement.classList.toggle('sidebar-hidden', hidden);
+    const toggle = document.getElementById('sidebarToggle');
+    if (toggle) {
+        toggle.setAttribute('aria-expanded', String(!hidden));
+    }
+    if (persist && wideLayout.matches) {
+        writeStorage(SIDEBAR_STORAGE_KEY, String(hidden));
+    }
+}
+
+function toggleSidebar() {
+    setSidebarHidden(!isSidebarHidden());
+}
+
+/** Closes the sidebar when it is shown as a drawer (narrow layout). No-op otherwise. */
+export function closeSidebarDrawer() {
+    if (!wideLayout.matches && !isSidebarHidden()) {
+        setSidebarHidden(true, { persist: false });
+    }
+}
+
+function applyLayoutMode() {
+    if (wideLayout.matches) {
+        setSidebarHidden(readStorage(SIDEBAR_STORAGE_KEY) === 'true', { persist: false });
+    } else {
+        setSidebarHidden(true, { persist: false });
+    }
+}
+
+function initializeSidebar() {
+    wideLayout = window.matchMedia(WIDE_LAYOUT_QUERY);
+    applyLayoutMode();
+    wideLayout.addEventListener('change', applyLayoutMode);
+    document.getElementById('sidebarToggle').addEventListener('click', toggleSidebar);
+    document.getElementById('sidebarBackdrop').addEventListener('click', closeSidebarDrawer);
+}
+
+// -------------------------------------------------------------- help modal
+
+function openHelp() {
+    document.getElementById('helpModal').hidden = false;
+    const content = document.getElementById('helpContent');
+    if (!content.innerHTML) {
+        fetchAndRenderReadme(content);
+    }
+}
+
+function closeHelp() {
+    document.getElementById('helpModal').hidden = true;
+}
+
+async function fetchAndRenderReadme(content) {
+    content.textContent = 'Loading...';
+    try {
+        const response = await fetch('README.md');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const markdown = await response.text();
+        content.innerHTML = marked.parse(markdown);
+    } catch (error) {
+        console.error('Error fetching README:', error);
+        content.textContent = 'Error loading help content. Please try again later.';
+    }
+}
+
+function initializeHelpModal() {
+    const modal = document.getElementById('helpModal');
+    document.getElementById('helpButton').addEventListener('click', openHelp);
+    document.getElementById('helpClose').addEventListener('click', closeHelp);
+    modal.addEventListener('click', event => {
+        if (event.target === modal) {
+            closeHelp();
+        }
+    });
+}
+
+// ---------------------------------------------------------------- keyboard
+
+function isTypingTarget(target) {
+    return target instanceof Element &&
+        (target.matches('input, select, textarea') || target.isContentEditable);
+}
+
+// Registered in the capture phase: an open multi-select is still open here and
+// handles Escape itself, so the shell stays out of its way.
+function handleKeydown(event) {
+    if (document.querySelector('.multi-select.open')) {
+        return;
+    }
+
+    if (event.key === 'Escape') {
+        const modal = document.getElementById('helpModal');
+        if (modal && !modal.hidden) {
+            closeHelp();
+        } else {
+            closeSidebarDrawer();
+        }
+        return;
+    }
+
+    if ((event.key === 'f' || event.key === 'F') &&
+        !event.ctrlKey && !event.metaKey && !event.altKey &&
+        !isTypingTarget(event.target)) {
+        event.preventDefault();
+        toggleSidebar();
+    }
+}
+
+// -------------------------------------------------------------------- init
+
+export function initializeAppShell() {
+    initializeSidebar();
+    initializeHelpModal();
+    document.addEventListener('keydown', handleKeydown, true);
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
-import { initializeFilter, filterBranches } from './app-filter.js';
+import { initializeFilter, filterBranches, countActiveFilters } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
-import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer } from './app-shell.js';
+import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
 
 let currentProject = null;
 let currentSprints = [];
@@ -17,6 +17,41 @@ let reloadInterval = 100;
 let currentSyncStatuses = null;
 let syncStatusLoading = false;
 let syncLoadFailed = false;
+
+function currentFilters() {
+    return {
+        assignees: currentAssignees,
+        reviewers: currentReviewers,
+        sprints: currentSprints,
+        fixVersions: currentFixVersions,
+        sync: currentSync,
+        ready: currentReadyForReviewer
+    };
+}
+
+// Runs the filter pass and refreshes everything that depends on it: the
+// counters (inside filterBranches), the active-filter badge, the clear button
+// and the attention count in the tab title.
+function applyFilters() {
+    const filters = currentFilters();
+    const attentionCount = filterBranches(filters.assignees, filters.reviewers, filters.sprints, filters.fixVersions, filters.sync, filters.ready);
+    updateActiveFilterBadge(countActiveFilters(filters));
+    updateDocumentTitle({ project: currentProject, attentionCount });
+}
+
+// Resets every filter control to its default and applies the result once.
+// The project and the loaded SYNC statuses are kept.
+function clearAllFilters() {
+    ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'].forEach(id => {
+        const multiSelect = getMultiSelect(id);
+        if (multiSelect) multiSelect.clearAll(false);
+    });
+    const readyCheck = document.getElementById('readyForReviewerCheck');
+    if (readyCheck) readyCheck.checked = false;
+    const syncSelect = document.getElementById('syncSelect');
+    if (syncSelect) syncSelect.value = 'Show all';
+    handleFilterChange();
+}
 
 function updateUrlWithFilters() {
     const url = new URL(window.location);
@@ -210,7 +245,8 @@ async function handleProjectChange(event, isInitialLoad = false) {
         syncLoadFailed = false;
         updateSyncControls();
         updateUrlWithFilters();
-        updateDocumentTitle({ project: null, attentionCount: 0 });
+        setToolbarVisible(false);
+        applyFilters(); // no tree to filter: refreshes the badge and the tab title
         showEmptyState();
 
         // Stop periodic checking
@@ -271,7 +307,7 @@ function handleFilterChange() {
         }
     }
 
-    filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
+    applyFilters();
     updateUrlWithFilters();
 }
 
@@ -320,13 +356,8 @@ function populateFilters(pullRequests) {
         readyCheck.checked = currentReadyForReviewer;
     }
 
-    // Restore filter values and apply them
+    // Restore filter values; renderEverything applies them once every filter is populated
     restoreFiltersFromUrl();
-    if (currentAssignees.length > 0 || currentReviewers.length > 0 ||
-        currentSprints.length > 0 || currentFixVersions.length > 0 ||
-        currentSync !== "Show all" || currentReadyForReviewer) {
-        filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
-    }
 }
 
 // Function to format the refresh time
@@ -397,6 +428,7 @@ function renderEverything(apiResult) {
     }
     if (!apiResult) {
         currentApiResult = null;
+        setToolbarVisible(false);
         showErrorState();
         return;
     }
@@ -432,6 +464,10 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
+
+    // Every filter is populated and restored from the URL: apply them once
+    applyFilters();
+    setToolbarVisible(true);
 
     // Update the last refresh time
     const lastRefreshElement = document.getElementById('lastRefreshTime');
@@ -737,7 +773,7 @@ async function loadSyncStatuses() {
     updateSyncControls();
     applySyncStatuses();
     // Re-apply filters so an already selected SYNC filter uses the new statuses
-    filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
+    applyFilters();
 }
 
 // Renders the stored SYNC statuses onto the conflicts counters
@@ -1106,7 +1142,7 @@ function initializeMultiSelects() {
 
 // Update the DOMContentLoaded event listener
 document.addEventListener('DOMContentLoaded', function() {
-    initializeAppShell();
+    initializeAppShell({ onClearFilters: clearAllFilters });
     initializeMultiSelects();
     showEmptyState();
     loadProjects();

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,7 @@
 import { initializeFilter, filterBranches } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
+import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer } from './app-shell.js';
 
 let currentProject = null;
 let currentSprints = [];
@@ -152,6 +153,8 @@ async function handleProjectChange(event, isInitialLoad = false) {
     const projectName = event.target.value;
     if (projectName) {
         currentProject = projectName;
+        updateDocumentTitle({ project: currentProject, attentionCount: 0 });
+        closeSidebarDrawer();
 
         // Only clear filters from URL when manually switching projects, not during initial page load
         if (!isInitialLoad) {
@@ -195,34 +198,49 @@ async function handleProjectChange(event, isInitialLoad = false) {
             }
         }
 
-        showLoading();
-        await renderEverything();
-        hideLoading();
+        showLoadingState();
+        renderEverything(await fetchData());
         updateUrlWithFilters();
 
         // Start periodic checking
         startPeriodicChecking();
     } else {
-        document.getElementById('pull-requests').innerHTML = 'Please select a project';
         currentProject = null;
         currentSyncStatuses = null;
         syncLoadFailed = false;
         updateSyncControls();
         updateUrlWithFilters();
+        updateDocumentTitle({ project: null, attentionCount: 0 });
+        showEmptyState();
 
         // Stop periodic checking
         stopPeriodicChecking();
     }
 }
 
-function showLoading() {
-    document.getElementById('pull-requests').style.display = 'none';
-    document.getElementById('loading').style.display = 'block';
+// Messages shown in the main pane instead of the tree. Built with DOM nodes so
+// project names never go through innerHTML.
+function showStateMessage(iconClass, text, modifier = '') {
+    const message = document.createElement('div');
+    message.className = `state-message ${modifier}`.trim();
+    const icon = document.createElement('i');
+    icon.className = iconClass;
+    const label = document.createElement('span');
+    label.textContent = text;
+    message.append(icon, label);
+    document.getElementById('pull-requests').replaceChildren(message);
 }
 
-function hideLoading() {
-    document.getElementById('loading').style.display = 'none';
-    document.getElementById('pull-requests').style.display = 'block';
+function showEmptyState() {
+    showStateMessage('fas fa-code-branch', 'Select a project to display its pull requests');
+}
+
+function showLoadingState() {
+    showStateMessage('fas fa-spinner fa-spin', `Loading ${currentProject}…`);
+}
+
+function showErrorState() {
+    showStateMessage('fas fa-exclamation-triangle', `Could not load ${currentProject}. The next automatic check will retry.`, 'error');
 }
 
 function handleFilterChange() {
@@ -373,15 +391,20 @@ function renderOrphanedIssues(issues) {
 }
 
 
-async function renderEverything() {
+function renderEverything(apiResult) {
     if (!currentProject) {
+        return;
+    }
+    if (!apiResult) {
+        currentApiResult = null;
+        showErrorState();
         return;
     }
 
     // Capture current toggle states before re-rendering
     const toggleStates = captureToggleStates();
 
-    currentApiResult = await fetchData();
+    currentApiResult = apiResult;
     initializeFilter(currentApiResult);
     const container = document.getElementById('pull-requests');
 
@@ -453,10 +476,10 @@ async function checkForUpdates() {
             lastRefreshElement.textContent = formatRefreshTime(newData.lastRefreshTime);
         }
 
-        // Update the full content only if data has changed
-        if (newData.dataHash !== currentApiResult.dataHash) {
+        // Re-render when the data changed, or when nothing is displayed yet because the last fetch failed
+        if (!currentApiResult || newData.dataHash !== currentApiResult.dataHash) {
             console.log('Data has changed. Updating...');
-            await renderEverything();
+            renderEverything(newData);
         }
     } catch (error) {
         console.error('Error checking for updates:', error);
@@ -789,7 +812,7 @@ function updateSyncControls() {
                 : '';
             warningText = `Atlassian rate limit reached - SYNC status may be incomplete${until ? `, requests are paused until ${until}` : ''}`;
         }
-        syncWarning.style.display = warningText ? '' : 'none';
+        syncWarning.hidden = !warningText;
         syncWarning.title = warningText;
     }
 }
@@ -976,48 +999,6 @@ function renderParticipant(participant, status) {
     `;
 }
 
-function initializeHelpModal() {
-    const modal = document.getElementById("helpModal");
-    const btn = document.getElementById("helpButton");
-    const span = document.getElementsByClassName("close")[0];
-    const helpContent = document.getElementById("helpContent");
-
-    btn.onclick = function() {
-        modal.style.display = "block";
-        if (!helpContent.innerHTML) {
-            fetchAndRenderReadme();
-        }
-    }
-
-    span.onclick = function() {
-        modal.style.display = "none";
-    }
-
-    window.onclick = function(event) {
-        if (event.target == modal) {
-            modal.style.display = "none";
-        }
-    }
-}
-
-async function fetchAndRenderReadme() {
-    const helpContent = document.getElementById("helpContent");
-    helpContent.innerHTML = 'Loading...';
-
-    try {
-        const response = await fetch('README.md');
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const markdown = await response.text();
-        const html = marked.parse(markdown);
-        helpContent.innerHTML = html;
-    } catch (error) {
-        console.error('Error fetching README:', error);
-        helpContent.innerHTML = 'Error loading help content. Please try again later.';
-    }
-}
-
 async function fetchAndDisplayVersion() {
     try {
         const response = await fetch('/api/version');
@@ -1026,20 +1007,9 @@ async function fetchAndDisplayVersion() {
         }
         const data = await response.json();
         const versionElement = document.getElementById('versionNumber');
-        const dateElement = document.getElementById('versionDate');
-        const authorElement = document.getElementById('authorInfo');
-        const licenseElement = document.getElementById('licenseInfo');
-
-        if (versionElement && dateElement && authorElement && licenseElement) {
+        if (versionElement) {
             versionElement.textContent = `v${data.version}`;
-            dateElement.textContent = `Released: ${data.releaseDate}`;
-            authorElement.textContent = `Created by ${data.author}`;
-            licenseElement.textContent = `${data.license}`;
-
-            versionElement.style.animation = 'versionPulse 0.5s ease';
-            setTimeout(() => {
-                versionElement.style.animation = '';
-            }, 500);
+            versionElement.title = `Version ${data.version}, released ${data.releaseDate}\nCreated by ${data.author}\n${data.license}`;
         }
     } catch (error) {
         console.error('Error fetching version:', error);
@@ -1054,8 +1024,6 @@ function initializePopovers() {
     document.body.appendChild(popover);
 
     function showPopover(link) {
-        const rect = link.getBoundingClientRect();
-
         if (link.classList.contains('jira-issue-link')) {
             const key = link.dataset.issueKey;
             const summary = link.dataset.issueSummary;
@@ -1074,9 +1042,15 @@ function initializePopovers() {
             `;
         }
 
-        popover.style.left = `${rect.left}px`;
-        popover.style.top = `${rect.bottom + window.scrollY}px`;
+        // The popover is fixed: viewport coordinates, kept inside the viewport
         popover.style.display = 'block';
+        const rect = link.getBoundingClientRect();
+        const margin = 8;
+        const left = Math.max(margin, Math.min(rect.left, window.innerWidth - popover.offsetWidth - margin));
+        const fitsBelow = rect.bottom + popover.offsetHeight + margin <= window.innerHeight;
+        const top = fitsBelow ? rect.bottom : Math.max(margin, rect.top - popover.offsetHeight);
+        popover.style.left = `${left}px`;
+        popover.style.top = `${top}px`;
     }
 
     function hidePopover() {
@@ -1117,6 +1091,9 @@ function initializePopovers() {
         clearTimeout(popoverTimeout);
         popoverTimeout = setTimeout(hidePopover, 300);
     });
+
+    // A popover left open while the tree scrolls would float away from its link
+    document.getElementById('main').addEventListener('scroll', hidePopover, { passive: true });
 }
 
 // Initialize multi-select components
@@ -1129,28 +1106,14 @@ function initializeMultiSelects() {
 
 // Update the DOMContentLoaded event listener
 document.addEventListener('DOMContentLoaded', function() {
+    initializeAppShell();
     initializeMultiSelects();
+    showEmptyState();
     loadProjects();
-    initializeHelpModal();
     fetchAndDisplayVersion();
     initializePopovers();
     initializeReadyForReviewerFilter();
     initializeSyncControls();
-
-    // Add event listener for the footer help button
-    const footerHelpButton = document.querySelector('.footer-link#helpButton');
-    if (footerHelpButton) {
-        footerHelpButton.addEventListener('click', function(e) {
-            e.preventDefault();
-            const helpModal = document.getElementById('helpModal');
-            if (helpModal) {
-                helpModal.style.display = 'block';
-                if (!document.getElementById('helpContent').innerHTML) {
-                    fetchAndRenderReadme();
-                }
-            }
-        });
-    }
 });
 
 // Export functions that need to be accessible globally

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
   <button type="button" id="sidebarToggle" class="icon-button" aria-expanded="true" aria-controls="sidebar"
           title="Toggle filters (F)">
     <i class="fas fa-bars"></i>
+    <span id="activeFilterBadge" class="header-badge" hidden></span>
   </button>
   <h1 class="app-brand">
     <img src="favicon.svg" alt="" class="app-logo">
@@ -52,6 +53,7 @@
 <aside id="sidebar" class="sidebar" aria-label="Filters">
   <div class="sidebar-header">
     <h2>Filters</h2>
+    <button type="button" id="clearFiltersButton" class="link-button" hidden>Clear filters</button>
   </div>
 
   <div class="filter-item">
@@ -164,6 +166,14 @@
 <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
 
 <main id="main" class="main-pane">
+  <div id="treeToolbar" class="tree-toolbar" hidden>
+    <button type="button" id="collapseAllButton" class="link-button">
+      <i class="fas fa-compress-alt"></i> Collapse all
+    </button>
+    <button type="button" id="expandAllButton" class="link-button">
+      <i class="fas fa-expand-alt"></i> Expand all
+    </button>
+  </div>
   <div id="pull-requests" class="tree-pane"></div>
 </main>
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,183 +3,180 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bitbucket Pull Requests Review Dashboard</title>
+  <title>Bitbucket Pull-Requests Tree</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <script>
+    // Runs before the stylesheet so a hidden sidebar does not flash open on load.
+    (function () {
+      var sidebarHidden = null;
+      try {
+        sidebarHidden = localStorage.getItem('prTree.sidebarHidden');
+      } catch (error) { /* storage unavailable */ }
+      if (sidebarHidden === 'true' || !window.matchMedia('(min-width: 900px)').matches) {
+        document.documentElement.classList.add('sidebar-hidden');
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
-<div class="container">
-  <div class="header-container">
-    <h1>Bitbucket Pull Requests Review Dashboard</h1>
-    <div class="refresh-container">
-      <i class="fas fa-sync refresh-icon" id="refreshIcon"></i>
-      <div class="last-refresh" id="lastRefreshTime"></div>
-    </div>
+<header class="app-header">
+  <button type="button" id="sidebarToggle" class="icon-button" aria-expanded="true" aria-controls="sidebar"
+          title="Toggle filters (F)">
+    <i class="fas fa-bars"></i>
+  </button>
+  <h1 class="app-brand">
+    <img src="favicon.svg" alt="" class="app-logo">
+    <span class="app-name">Bitbucket Pull-Requests Tree</span>
+  </h1>
+  <select id="projectSelect" class="project-select" aria-label="Project">
+    <option value="">Select a project</option>
+  </select>
+  <div class="header-spacer"></div>
+  <div class="refresh-container">
+    <i class="fas fa-sync refresh-icon" id="refreshIcon" title="Checking for updates"></i>
+    <span class="last-refresh" id="lastRefreshTime"></span>
+  </div>
+  <button type="button" id="helpButton" class="icon-button" title="Help">
+    <i class="fas fa-question-circle"></i>
+  </button>
+  <a href="https://github.com/frejfrej/pr-tree" target="_blank" rel="noopener" class="icon-button"
+     title="GitHub repository">
+    <i class="fab fa-github"></i>
+  </a>
+  <span id="versionNumber" class="version-number"></span>
+</header>
+
+<aside id="sidebar" class="sidebar" aria-label="Filters">
+  <div class="sidebar-header">
+    <h2>Filters</h2>
   </div>
 
-  <div class="filters-container">
-    <div class="filters-row">
-      <div class="filter-item">
-        <span class="filter-label">Project</span>
-        <select id="projectSelect">
-          <option value="">Select a project</option>
-        </select>
+  <div class="filter-item">
+    <span class="filter-label">Sprint</span>
+    <div class="multi-select" id="sprintSelect" data-filter="sprint">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
       </div>
-      <div class="filter-item">
-        <span class="filter-label">Sprint</span>
-        <div class="multi-select" id="sprintSelect" data-filter="sprint">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
         </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">Fix Version</span>
-        <div class="multi-select" id="fixVersionSelect" data-filter="fixVersion">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
         </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">Assignee</span>
-        <div class="multi-select" id="assigneeSelect" data-filter="assignee">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="filters-row">
-      <div class="filter-item">
-        <span class="filter-label">Reviewer</span>
-        <div class="multi-select" id="reviewerSelect" data-filter="reviewer">
-          <div class="multi-select-trigger" tabindex="0">
-            <span class="multi-select-display">Show all</span>
-            <i class="fas fa-chevron-down multi-select-arrow"></i>
-          </div>
-          <div class="multi-select-dropdown">
-            <div class="multi-select-search">
-              <input type="text" placeholder="Search..." class="multi-select-search-input">
-            </div>
-            <div class="multi-select-options"></div>
-            <div class="multi-select-actions">
-              <button type="button" class="multi-select-clear">Clear all</button>
-              <button type="button" class="multi-select-select-all">Select all</button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="filter-item">
-        <div class="filter-label">
-          <input type="checkbox" id="readyForReviewerCheck" disabled>
-          <label for="readyForReviewerCheck">Ready for reviewer
-            <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
-          </label>
-        </div>
-      </div>
-      <div class="filter-item">
-        <span class="filter-label">SYNC
-          <i class="fas fa-info-circle info-icon" title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
-        </span>
-        <select id="syncSelect" disabled>
-          <option value="Show all">SYNC status not loaded</option>
-        </select>
-        <button id="loadSyncButton" class="load-sync-button" disabled
-                title="Load SYNC status for all pull requests">
-          <i class="fas fa-sync-alt"></i> Load
-        </button>
-        <span id="syncWarning" class="sync-warning" style="display: none;">
-          <i class="fas fa-exclamation-triangle"></i>
-        </span>
       </div>
     </div>
   </div>
 
-  <div id="pull-requests">
-    Please select a project
-  </div>
-  <div id="loading" style="display: none;">
-    <i class="fas fa-spinner fa-spin"></i> Loading...
+  <div class="filter-item">
+    <span class="filter-label">Fix version</span>
+    <div class="multi-select" id="fixVersionSelect" data-filter="fixVersion">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <div id="helpModal" class="modal">
-    <div class="modal-content">
-      <span class="close">&times;</span>
-      <!-- The closing tag must absolutely remain immediately next to the open tag -->
-      <div id="helpContent" class="help-content"></div>
+  <div class="filter-item">
+    <span class="filter-label">Assignee</span>
+    <div class="multi-select" id="assigneeSelect" data-filter="assignee">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
     </div>
+  </div>
+
+  <div class="filter-item">
+    <span class="filter-label">Reviewer</span>
+    <div class="multi-select" id="reviewerSelect" data-filter="reviewer">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item filter-item-checkbox">
+    <input type="checkbox" id="readyForReviewerCheck" disabled>
+    <label for="readyForReviewerCheck">Ready for reviewer</label>
+    <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
+  </div>
+
+  <hr class="sidebar-divider">
+
+  <div class="filter-item">
+    <span class="filter-label">SYNC
+      <i class="fas fa-info-circle info-icon"
+         title="SYNC status is only fetched when you click the load button. This filter will be reset when the page is reloaded"></i>
+    </span>
+    <select id="syncSelect" disabled>
+      <option value="Show all">SYNC status not loaded</option>
+    </select>
+    <div class="filter-row">
+      <button type="button" id="loadSyncButton" class="button" disabled
+              title="Load SYNC status for all pull requests">
+        <i class="fas fa-sync-alt"></i> Load
+      </button>
+      <span id="syncWarning" class="sync-warning" hidden>
+        <i class="fas fa-exclamation-triangle"></i>
+      </span>
+    </div>
+  </div>
+</aside>
+<div id="sidebarBackdrop" class="sidebar-backdrop"></div>
+
+<main id="main" class="main-pane">
+  <div id="pull-requests" class="tree-pane"></div>
+</main>
+
+<div id="helpModal" class="modal" hidden>
+  <div class="modal-content" role="dialog" aria-modal="true" aria-label="Help">
+    <button type="button" id="helpClose" class="icon-button modal-close" aria-label="Close help">
+      <i class="fas fa-times"></i>
+    </button>
+    <!-- The closing tag must absolutely remain immediately next to the open tag -->
+    <div id="helpContent" class="help-content"></div>
   </div>
 </div>
 
-<footer id="appFooter" class="app-footer">
-  <div class="footer-content">
-    <div class="footer-section">
-      <h3>About</h3>
-      <p id="authorInfo" class="author-info"></p>
-      <p id="licenseInfo" class="license-info"></p>
-    </div>
-    <div class="footer-section">
-      <h3>Version</h3>
-      <div class="version-info">
-        <span id="versionNumber" class="version-number"></span>
-        <span id="versionDate" class="version-date"></span>
-      </div>
-    </div>
-    <div class="footer-section">
-      <h3>Links</h3>
-      <ul class="footer-links">
-        <li><a href="#" id="helpButton" class="footer-link">
-          <i class="fas fa-question-circle"></i> Help
-        </a></li>
-        <li><a href="https://github.com/frejfrej/pr-tree" target="_blank" class="footer-link">
-          <i class="fab fa-github"></i> GitHub
-        </a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="footer-bottom">
-    <p>&copy; 2024 Bitbucket Pull-Requests Tree. All rights reserved.</p>
-  </div>
-</footer>
-
-<script type="module" src="multi-select.js"></script>
-<script type="module" src="app-filter.js"></script>
 <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,8 +1,9 @@
 /* ==========================================================================
    Bitbucket Pull-Requests Tree
-   1. Tokens          2. Base             3. Page layout
+   1. Tokens          2. Base             3. App shell
    4. Controls        5. Multi-select     6. Tree
    7. Orphaned issues 8. Popovers         9. Modal and help
+   10. State messages 11. Responsive
    ========================================================================== */
 
 /* 1. Tokens --------------------------------------------------------------- */
@@ -27,12 +28,24 @@
     --shadow-color: rgba(9, 30, 66, 0.15);
     --focus-ring: rgba(0, 82, 204, 0.25);
     --backdrop-color: rgba(9, 30, 66, 0.45);
+    --header-bg: #0052CC;
+    --header-text: #FFFFFF;
+    --header-muted: rgba(255, 255, 255, 0.75);
+    --header-border: transparent;
+    --header-control-bg: rgba(255, 255, 255, 0.14);
+    --header-control-border: rgba(255, 255, 255, 0.35);
+
+    --header-height: 48px;
+    --sidebar-width: 280px;
+    --repo-header-height: 48px;
+    --branch-header-height: 40px;
 
     --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 
     /* FontAwesome chevron-down, mid grey, readable on light and dark surfaces */
     --chevron-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%238993A4'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
+    --chevron-icon-on-header: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%23FFFFFF'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
 }
 
 /* 2. Base ----------------------------------------------------------------- */
@@ -47,7 +60,16 @@
 }
 
 body {
+    display: grid;
+    grid-template-rows: var(--header-height) minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+        "header header"
+        "sidebar main";
+    height: 100vh;
+    height: 100dvh;
     margin: 0;
+    overflow: hidden;
     font-family: var(--font-family);
     line-height: 1.6;
     color: var(--text-color);
@@ -71,49 +93,96 @@ input {
     to { transform: rotate(360deg); }
 }
 
-/* 3. Page layout (replaced by the app shell in Task 4) -------------------- */
-body {
-    padding: 20px;
-}
-
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px 20px 60px;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 0 10px var(--shadow-color);
-}
-
-.header-container {
+/* 3. App shell ------------------------------------------------------------ */
+.app-header {
+    grid-area: header;
+    z-index: 20;
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: 20px;
-    padding-bottom: 10px;
-    border-bottom: 2px solid var(--border-color);
+    align-items: center;
+    gap: 12px;
+    padding: 0 12px;
+    border-bottom: 1px solid var(--header-border);
+    background-color: var(--header-bg);
+    color: var(--header-text);
+    box-shadow: 0 1px 3px var(--shadow-color);
+    font-size: 14px;
 }
 
-.header-container h1 {
+.app-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin: 0;
-    color: var(--primary-color);
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.app-logo {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+}
+
+.header-spacer {
+    flex: 1;
+}
+
+.icon-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    font-size: 16px;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.app-header .icon-button:hover {
+    background-color: var(--header-control-bg);
+}
+
+.project-select {
+    max-width: 240px;
+    padding: 5px 28px 5px 10px;
+    border-color: var(--header-control-border);
+    background-color: var(--header-control-bg);
+    background-image: var(--chevron-icon-on-header);
+    background-position: right 10px center;
+    color: var(--header-text);
+}
+
+.project-select:hover:not(:disabled),
+.project-select:focus {
+    border-color: var(--header-text);
+    box-shadow: none;
+}
+
+.project-select option {
+    background-color: var(--surface-color);
+    color: var(--text-color);
 }
 
 .refresh-container {
     display: flex;
     align-items: center;
     gap: 8px;
+    color: var(--header-muted);
 }
 
 .last-refresh {
-    color: var(--text-muted);
-    font-size: 0.9em;
     font-style: italic;
+    white-space: nowrap;
 }
 
 .refresh-icon {
-    color: var(--primary-color);
-    font-size: 0.9em;
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -123,171 +192,113 @@ body {
     animation: spin 1s linear infinite;
 }
 
-.filters-container {
-    margin-bottom: 20px;
-    padding: 15px;
-    background-color: var(--surface-color);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px var(--shadow-color);
+.version-number {
+    color: var(--header-muted);
+    white-space: nowrap;
+    cursor: help;
 }
 
-.filters-row {
+.sidebar {
+    grid-area: sidebar;
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 20px;
-    margin-bottom: 15px;
+    flex-direction: column;
+    gap: 16px;
+    width: var(--sidebar-width);
+    padding: 16px;
+    border-right: 1px solid var(--border-color);
+    background-color: var(--surface-color);
+    font-size: 14px;
+    overflow-y: auto;
 }
 
-.filters-row:last-child {
-    margin-bottom: 0;
+html.sidebar-hidden .sidebar {
+    display: none;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 24px;
+}
+
+.sidebar-header h2 {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.sidebar-divider {
+    margin: 0;
+    border: none;
+    border-top: 1px solid var(--border-color);
 }
 
 .filter-item {
     position: relative;
     display: flex;
-    align-items: center;
-    gap: 10px;
-    flex: 1 1 auto;
-    min-width: 200px;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .filter-label {
-    flex-shrink: 0;
-    min-width: 70px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
     color: var(--text-color);
-    font-size: 14px;
     font-weight: 500;
-    white-space: nowrap;
 }
 
 .filter-item select {
-    flex: 1;
-    min-width: 0;
+    width: 100%;
 }
 
-.filter-item .multi-select {
-    flex: 1 1 auto;
-    min-width: 0;
+.filter-item-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
 }
 
-.filter-item input[type="checkbox"] {
-    margin-right: 8px;
+.filter-item-checkbox input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
 }
 
-.filter-item input[type="checkbox"]:disabled + label {
-    color: var(--text-muted);
-    cursor: not-allowed;
-}
-
-.filter-item label {
+.filter-item-checkbox label {
     cursor: pointer;
     user-select: none;
 }
 
-.app-footer {
-    padding: 30px 0 10px;
-    background-color: var(--primary-color);
-    color: var(--on-accent-text);
-    font-size: 14px;
-    box-shadow: 0 -2px 10px var(--shadow-color);
+.filter-item-checkbox input[type="checkbox"]:disabled,
+.filter-item-checkbox input[type="checkbox"]:disabled + label {
+    color: var(--text-muted);
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
-.footer-content {
-    display: flex;
-    justify-content: space-around;
-    flex-wrap: wrap;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
-.footer-section {
-    flex: 1;
-    min-width: 200px;
-    margin-bottom: 20px;
-}
-
-.footer-section h3 {
-    margin-bottom: 10px;
-    padding-bottom: 5px;
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-    color: var(--on-accent-text);
-    font-size: 18px;
-}
-
-.footer-links {
-    list-style-type: none;
-    padding: 0;
-}
-
-.footer-link {
+.filter-row {
     display: flex;
     align-items: center;
-    margin-bottom: 5px;
-    color: var(--on-accent-text);
-    opacity: 0.8;
-    text-decoration: none;
-    transition: opacity 0.3s ease;
+    gap: 8px;
 }
 
-.footer-link:hover {
-    opacity: 1;
+.sidebar-backdrop {
+    display: none;
 }
 
-.footer-link i {
-    width: 20px;
-    margin-right: 5px;
-    text-align: center;
+.main-pane {
+    grid-area: main;
+    min-width: 0;
+    overflow-y: auto;
 }
 
-.version-info,
-.author-info,
-.license-info {
-    margin-bottom: 5px;
-    opacity: 0.8;
-}
-
-.version-number {
-    margin-right: 5px;
-    font-weight: bold;
-}
-
-.version-date {
-    font-style: italic;
-}
-
-.footer-bottom {
-    margin-top: 20px;
-    padding-top: 20px;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    text-align: center;
-}
-
-@keyframes versionPulse {
-    0% { opacity: 0.7; }
-    50% { opacity: 1; }
-    100% { opacity: 0.7; }
-}
-
-@media (max-width: 768px) {
-    .footer-content {
-        flex-direction: column;
-    }
-
-    .footer-section {
-        width: 100%;
-        margin-bottom: 30px;
-    }
-
-    .filters-row {
-        flex-direction: column;
-        gap: 15px;
-    }
-
-    .filter-item {
-        width: 100%;
-    }
+/* Padding lives on the content, not on the scroll container: the container's own
+   padding would inset the sticky area and leave a strip above the sticky headers */
+.tree-pane {
+    padding: 24px;
 }
 
 /* 4. Controls ------------------------------------------------------------- */
@@ -326,7 +337,7 @@ select:disabled {
     cursor: not-allowed;
 }
 
-.load-sync-button {
+.button {
     flex-shrink: 0;
     padding: 8px 12px;
     border: 1px solid var(--border-color);
@@ -340,12 +351,12 @@ select:disabled {
     transition: border-color 0.2s ease;
 }
 
-.load-sync-button:hover:not(:disabled) {
+.button:hover:not(:disabled) {
     border-color: var(--primary-color);
     color: var(--primary-color);
 }
 
-.load-sync-button:disabled {
+.button:disabled {
     background-color: var(--surface-muted);
     color: var(--text-muted);
     opacity: 0.7;
@@ -526,22 +537,33 @@ select:disabled {
 }
 
 .repository-header {
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 3;
     display: flex;
     align-items: center;
-    padding: 10px;
+    height: var(--repo-header-height);
+    padding: 0 10px;
     background-color: var(--primary-color);
     color: var(--on-accent-text);
     border-radius: 4px 4px 0 0;
     cursor: pointer;
 }
 
+.repository.collapsed > .repository-header {
+    border-radius: 4px;
+}
+
 .repository-name {
-    flex-grow: 1;
+    flex: 1;
+    min-width: 0;
     margin: 0;
     color: inherit;
-    font-size: 24px;
+    font-size: 20px;
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .repo-pr-counter {
@@ -576,21 +598,27 @@ select:disabled {
 }
 
 .root-branch-header {
-    position: relative;
+    position: sticky;
+    top: var(--repo-header-height);
+    z-index: 2;
     display: flex;
     align-items: center;
-    padding: 10px;
+    height: var(--branch-header-height);
+    padding: 0 10px;
     background-color: var(--background-color);
     border-radius: 4px;
     cursor: pointer;
 }
 
 .root-branch-name {
-    flex-grow: 1;
+    flex: 1;
+    min-width: 0;
     margin: 0;
     color: var(--primary-color);
     font-size: 18px;
     font-weight: bold;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .root-branch-link {
@@ -1006,7 +1034,7 @@ select:disabled {
 .jira-issue-popover,
 .pull-request-popover {
     display: none;
-    position: absolute;
+    position: fixed;
     z-index: 1000;
     max-width: 500px;
     padding: 10px;
@@ -1039,22 +1067,25 @@ select:disabled {
 
 /* 9. Modal and help ------------------------------------------------------- */
 .modal {
-    display: none;
     position: fixed;
     top: 0;
+    right: 0;
+    bottom: 0;
     left: 0;
     z-index: 200;
-    width: 100%;
-    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 5vh 16px;
     background-color: var(--backdrop-color);
     overflow: auto;
 }
 
 .modal-content {
-    width: 80%;
+    position: relative;
+    width: 100%;
     max-width: 800px;
-    max-height: 80vh;
-    margin: 5% auto;
+    max-height: 90vh;
     padding: 20px;
     border: 1px solid var(--border-color);
     border-radius: 5px;
@@ -1062,18 +1093,16 @@ select:disabled {
     overflow-y: auto;
 }
 
-.close {
-    float: right;
+.modal-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
     color: var(--text-muted);
-    font-size: 28px;
-    font-weight: bold;
-    cursor: pointer;
 }
 
-.close:hover,
-.close:focus {
+.modal-close:hover {
+    background-color: var(--surface-muted);
     color: var(--text-color);
-    text-decoration: none;
 }
 
 .help-content {
@@ -1139,4 +1168,53 @@ select:disabled {
 .help-content img {
     max-width: 100%;
     height: auto;
+}
+
+/* 10. State messages ------------------------------------------------------ */
+.state-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-height: 50vh;
+    color: var(--text-muted);
+    font-size: 16px;
+    text-align: center;
+}
+
+.state-message i {
+    font-size: 32px;
+}
+
+.state-message.error i {
+    color: var(--error-color);
+}
+
+/* 11. Responsive: below 900px the sidebar is a drawer over the tree -------- */
+@media (max-width: 899.98px) {
+    .app-name,
+    .last-refresh {
+        display: none;
+    }
+
+    .sidebar {
+        position: fixed;
+        top: var(--header-height);
+        bottom: 0;
+        left: 0;
+        z-index: 15;
+        box-shadow: 4px 0 12px var(--shadow-color);
+    }
+
+    html:not(.sidebar-hidden) .sidebar-backdrop {
+        position: fixed;
+        top: var(--header-height);
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 14;
+        display: block;
+        background-color: var(--backdrop-color);
+    }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -149,6 +149,22 @@ input {
     background-color: var(--header-control-bg);
 }
 
+.header-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background-color: var(--attention-color);
+    color: var(--on-accent-text);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+}
+
 .project-select {
     max-width: 240px;
     padding: 5px 28px 5px 10px;
@@ -301,6 +317,18 @@ html.sidebar-hidden .sidebar {
     padding: 24px;
 }
 
+.tree-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px 0;
+}
+
+/* With the toolbar shown, the tree needs less room above its first header */
+.tree-toolbar:not([hidden]) + .tree-pane {
+    padding-top: 12px;
+}
+
 /* 4. Controls ------------------------------------------------------------- */
 select {
     padding: 8px 32px 8px 12px;
@@ -361,6 +389,23 @@ select:disabled {
     color: var(--text-muted);
     opacity: 0.7;
     cursor: not-allowed;
+}
+
+.link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--primary-color);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.link-button:hover {
+    background-color: var(--surface-muted);
 }
 
 .sync-warning {

--- a/test/app-shell.test.mjs
+++ b/test/app-shell.test.mjs
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDocumentTitle } from '../public/app-shell.js';
+
+test('title without a project is the app name', () => {
+    assert.equal(buildDocumentTitle({ project: null, attentionCount: 0 }), 'Bitbucket Pull-Requests Tree');
+});
+
+test('title with a project puts the project first', () => {
+    assert.equal(buildDocumentTitle({ project: 'PROJ', attentionCount: 0 }), 'PROJ · Bitbucket Pull-Requests Tree');
+});
+
+test('title with an attention count prefixes the count', () => {
+    assert.equal(buildDocumentTitle({ project: 'PROJ', attentionCount: 3 }), '(3) PROJ · Bitbucket Pull-Requests Tree');
+});


### PR DESCRIPTION
With the sidebar hideable, the user needs to see that filters are applied and to reset them in one click. The sidebar toggle now carries a badge with the number of active filters (filters, not values: a reviewer filter with three names counts once), the sidebar header gets a "Clear filters" button that resets every control and applies the result once (project and loaded SYNC statuses are kept), and the tab title is prefixed with the number of pull requests left visible that need the selected assignee's or reviewer's attention: `(6) OSLC · Bitbucket Pull-Requests Tree`. A toolbar above the tree wires "Collapse all" / "Expand all" to the helpers from #10. Every filter pass goes through a single `applyFilters()` in `app.js`, and `renderEverything` applies the filters once every control has been populated and restored from the URL, which also fixes a stale first pass when the URL carried a sprint or fix-version id that no longer existed.

Verified in the browser: badge and clear button follow reviewer, sprint, ready and SYNC selections; the badge stays visible with the sidebar hidden; clearing resets the controls, the URL and the title; a reload with filter parameters restores the badge; a (simulated) SYNC load feeds the count and its badges survive "Clear filters"; collapse all / expand all act on repositories, branches and PR subtrees; the toolbar is hidden while no project is selected.

Closes #13
Part of #16
Stacked on #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZCANUDoVq6pd6b9i8vGbg