### PR TITLE
feat: dark theme with banner toggle

### DIFF
--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -11,6 +11,7 @@ import { collapseAll, expandAll } from './tree-toggle.js';
 export const APP_NAME = 'Bitbucket Pull-Requests Tree';
 
 const SIDEBAR_STORAGE_KEY = 'prTree.sidebarHidden';
+const THEME_STORAGE_KEY = 'prTree.theme';
 const WIDE_LAYOUT_QUERY = '(min-width: 900px)';
 
 let wideLayout = null;
@@ -89,6 +90,42 @@ function initializeSidebar() {
     wideLayout.addEventListener('change', applyLayoutMode);
     document.getElementById('sidebarToggle').addEventListener('click', toggleSidebar);
     document.getElementById('sidebarBackdrop').addEventListener('click', closeSidebarDrawer);
+}
+
+// ------------------------------------------------------------------- theme
+
+function currentTheme() {
+    return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+}
+
+function applyTheme(theme) {
+    document.documentElement.dataset.theme = theme;
+    const button = document.getElementById('themeToggle');
+    if (!button) {
+        return;
+    }
+    const dark = theme === 'dark';
+    const icon = button.querySelector('i');
+    icon.classList.toggle('fa-moon', !dark);
+    icon.classList.toggle('fa-sun', dark);
+    button.title = dark ? 'Switch to light theme' : 'Switch to dark theme';
+}
+
+function initializeTheme() {
+    // The inline script in <head> already chose the theme; this syncs the button with it
+    applyTheme(currentTheme());
+    document.getElementById('themeToggle').addEventListener('click', () => {
+        const next = currentTheme() === 'dark' ? 'light' : 'dark';
+        writeStorage(THEME_STORAGE_KEY, next);
+        applyTheme(next);
+    });
+    // Follow the OS setting live as long as no preference has been stored
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        const stored = readStorage(THEME_STORAGE_KEY);
+        if (stored !== 'light' && stored !== 'dark') {
+            applyTheme(event.matches ? 'dark' : 'light');
+        }
+    });
 }
 
 // -------------------------------------------------------------- help modal
@@ -194,6 +231,7 @@ function initializeToolbar() {
 
 export function initializeAppShell({ onClearFilters }) {
     initializeSidebar();
+    initializeTheme();
     initializeHelpModal();
     initializeToolbar();
     document.getElementById('clearFiltersButton').addEventListener('click', onClearFilters);

--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -6,6 +6,8 @@
  * unit-tested with node:test.
  */
 
+import { collapseAll, expandAll } from './tree-toggle.js';
+
 export const APP_NAME = 'Bitbucket Pull-Requests Tree';
 
 const SIDEBAR_STORAGE_KEY = 'prTree.sidebarHidden';
@@ -161,10 +163,39 @@ function handleKeydown(event) {
     }
 }
 
+// -------------------------------------------------------- filters and tree
+
+/** Shows the number of active filters on the sidebar toggle and the clear button in the sidebar. */
+export function updateActiveFilterBadge(count) {
+    const badge = document.getElementById('activeFilterBadge');
+    if (badge) {
+        badge.textContent = String(count);
+        badge.hidden = count === 0;
+    }
+    const clearButton = document.getElementById('clearFiltersButton');
+    if (clearButton) {
+        clearButton.hidden = count === 0;
+    }
+}
+
+export function setToolbarVisible(visible) {
+    const toolbar = document.getElementById('treeToolbar');
+    if (toolbar) {
+        toolbar.hidden = !visible;
+    }
+}
+
+function initializeToolbar() {
+    document.getElementById('collapseAllButton').addEventListener('click', collapseAll);
+    document.getElementById('expandAllButton').addEventListener('click', expandAll);
+}
+
 // -------------------------------------------------------------------- init
 
-export function initializeAppShell() {
+export function initializeAppShell({ onClearFilters }) {
     initializeSidebar();
     initializeHelpModal();
+    initializeToolbar();
+    document.getElementById('clearFiltersButton').addEventListener('click', onClearFilters);
     document.addEventListener('keydown', handleKeydown, true);
 }

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,7 @@
-import { initializeFilter, filterBranches } from './app-filter.js';
+import { initializeFilter, filterBranches, countActiveFilters } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
-import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer } from './app-shell.js';
+import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
 
 let currentProject = null;
 let currentSprints = [];
@@ -17,6 +17,41 @@ let reloadInterval = 100;
 let currentSyncStatuses = null;
 let syncStatusLoading = false;
 let syncLoadFailed = false;
+
+function currentFilters() {
+    return {
+        assignees: currentAssignees,
+        reviewers: currentReviewers,
+        sprints: currentSprints,
+        fixVersions: currentFixVersions,
+        sync: currentSync,
+        ready: currentReadyForReviewer
+    };
+}
+
+// Runs the filter pass and refreshes everything that depends on it: the
+// counters (inside filterBranches), the active-filter badge, the clear button
+// and the attention count in the tab title.
+function applyFilters() {
+    const filters = currentFilters();
+    const attentionCount = filterBranches(filters.assignees, filters.reviewers, filters.sprints, filters.fixVersions, filters.sync, filters.ready);
+    updateActiveFilterBadge(countActiveFilters(filters));
+    updateDocumentTitle({ project: currentProject, attentionCount });
+}
+
+// Resets every filter control to its default and applies the result once.
+// The project and the loaded SYNC statuses are kept.
+function clearAllFilters() {
+    ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'].forEach(id => {
+        const multiSelect = getMultiSelect(id);
+        if (multiSelect) multiSelect.clearAll(false);
+    });
+    const readyCheck = document.getElementById('readyForReviewerCheck');
+    if (readyCheck) readyCheck.checked = false;
+    const syncSelect = document.getElementById('syncSelect');
+    if (syncSelect) syncSelect.value = 'Show all';
+    handleFilterChange();
+}
 
 function updateUrlWithFilters() {
     const url = new URL(window.location);
@@ -210,7 +245,8 @@ async function handleProjectChange(event, isInitialLoad = false) {
         syncLoadFailed = false;
         updateSyncControls();
         updateUrlWithFilters();
-        updateDocumentTitle({ project: null, attentionCount: 0 });
+        setToolbarVisible(false);
+        applyFilters(); // no tree to filter: refreshes the badge and the tab title
         showEmptyState();
 
         // Stop periodic checking
@@ -271,7 +307,7 @@ function handleFilterChange() {
         }
     }
 
-    filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
+    applyFilters();
     updateUrlWithFilters();
 }
 
@@ -320,13 +356,8 @@ function populateFilters(pullRequests) {
         readyCheck.checked = currentReadyForReviewer;
     }
 
-    // Restore filter values and apply them
+    // Restore filter values; renderEverything applies them once every filter is populated
     restoreFiltersFromUrl();
-    if (currentAssignees.length > 0 || currentReviewers.length > 0 ||
-        currentSprints.length > 0 || currentFixVersions.length > 0 ||
-        currentSync !== "Show all" || currentReadyForReviewer) {
-        filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
-    }
 }
 
 // Function to format the refresh time
@@ -397,6 +428,7 @@ function renderEverything(apiResult) {
     }
     if (!apiResult) {
         currentApiResult = null;
+        setToolbarVisible(false);
         showErrorState();
         return;
     }
@@ -432,6 +464,10 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
+
+    // Every filter is populated and restored from the URL: apply them once
+    applyFilters();
+    setToolbarVisible(true);
 
     // Update the last refresh time
     const lastRefreshElement = document.getElementById('lastRefreshTime');
@@ -737,7 +773,7 @@ async function loadSyncStatuses() {
     updateSyncControls();
     applySyncStatuses();
     // Re-apply filters so an already selected SYNC filter uses the new statuses
-    filterBranches(currentAssignees, currentReviewers, currentSprints, currentFixVersions, currentSync, currentReadyForReviewer);
+    applyFilters();
 }
 
 // Renders the stored SYNC statuses onto the conflicts counters
@@ -1106,7 +1142,7 @@ function initializeMultiSelects() {
 
 // Update the DOMContentLoaded event listener
 document.addEventListener('DOMContentLoaded', function() {
-    initializeAppShell();
+    initializeAppShell({ onClearFilters: clearAllFilters });
     initializeMultiSelects();
     showEmptyState();
     loadProjects();

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,7 @@
   <button type="button" id="sidebarToggle" class="icon-button" aria-expanded="true" aria-controls="sidebar"
           title="Toggle filters (F)">
     <i class="fas fa-bars"></i>
+    <span id="activeFilterBadge" class="header-badge" hidden></span>
   </button>
   <h1 class="app-brand">
     <img src="favicon.svg" alt="" class="app-logo">
@@ -52,6 +53,7 @@
 <aside id="sidebar" class="sidebar" aria-label="Filters">
   <div class="sidebar-header">
     <h2>Filters</h2>
+    <button type="button" id="clearFiltersButton" class="link-button" hidden>Clear filters</button>
   </div>
 
   <div class="filter-item">
@@ -164,6 +166,14 @@
 <div id="sidebarBackdrop" class="sidebar-backdrop"></div>
 
 <main id="main" class="main-pane">
+  <div id="treeToolbar" class="tree-toolbar" hidden>
+    <button type="button" id="collapseAllButton" class="link-button">
+      <i class="fas fa-compress-alt"></i> Collapse all
+    </button>
+    <button type="button" id="expandAllButton" class="link-button">
+      <i class="fas fa-expand-alt"></i> Expand all
+    </button>
+  </div>
   <div id="pull-requests" class="tree-pane"></div>
 </main>
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,14 +6,21 @@
   <title>Bitbucket Pull-Requests Tree</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <script>
-    // Runs before the stylesheet so a hidden sidebar does not flash open on load.
+    // Runs before the stylesheet so neither the theme nor a hidden sidebar flashes on load.
     (function () {
+      var theme = null;
       var sidebarHidden = null;
       try {
+        theme = localStorage.getItem('prTree.theme');
         sidebarHidden = localStorage.getItem('prTree.sidebarHidden');
       } catch (error) { /* storage unavailable */ }
+      var root = document.documentElement;
+      if (theme !== 'light' && theme !== 'dark') {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      root.dataset.theme = theme;
       if (sidebarHidden === 'true' || !window.matchMedia('(min-width: 900px)').matches) {
-        document.documentElement.classList.add('sidebar-hidden');
+        root.classList.add('sidebar-hidden');
       }
     })();
   </script>
@@ -40,6 +47,9 @@
     <i class="fas fa-sync refresh-icon" id="refreshIcon" title="Checking for updates"></i>
     <span class="last-refresh" id="lastRefreshTime"></span>
   </div>
+  <button type="button" id="themeToggle" class="icon-button" title="Switch to dark theme">
+    <i class="fas fa-moon"></i>
+  </button>
   <button type="button" id="helpButton" class="icon-button" title="Help">
     <i class="fas fa-question-circle"></i>
   </button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -149,6 +149,22 @@ input {
     background-color: var(--header-control-bg);
 }
 
+.header-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 8px;
+    background-color: var(--attention-color);
+    color: var(--on-accent-text);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 16px;
+    text-align: center;
+}
+
 .project-select {
     max-width: 240px;
     padding: 5px 28px 5px 10px;
@@ -301,6 +317,18 @@ html.sidebar-hidden .sidebar {
     padding: 24px;
 }
 
+.tree-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px 0;
+}
+
+/* With the toolbar shown, the tree needs less room above its first header */
+.tree-toolbar:not([hidden]) + .tree-pane {
+    padding-top: 12px;
+}
+
 /* 4. Controls ------------------------------------------------------------- */
 select {
     padding: 8px 32px 8px 12px;
@@ -361,6 +389,23 @@ select:disabled {
     color: var(--text-muted);
     opacity: 0.7;
     cursor: not-allowed;
+}
+
+.link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--primary-color);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.link-button:hover {
+    background-color: var(--surface-muted);
 }
 
 .sync-warning {

--- a/public/styles.css
+++ b/public/styles.css
@@ -48,6 +48,35 @@
     --chevron-icon-on-header: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' fill='%23FFFFFF'%3E%3Cpath d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/%3E%3C/svg%3E");
 }
 
+:root[data-theme="dark"] {
+    color-scheme: dark;
+
+    --primary-color: #579DFF;
+    --attention-color: #FF7452;
+    --background-color: #161A1D;
+    --surface-color: #1D2125;
+    --surface-muted: #22272B;
+    --text-color: #B6C2CF;
+    --text-muted: #8C9BAB;
+    --border-color: #38414A;
+    --success-color: #4BCE97;
+    --warning-color: #F5CD47;
+    --error-color: #F87168;
+    --in-review-color: #579DFF;
+    --danger-bg: #42221F;
+    --danger-text: #FD9891;
+    --on-accent-text: #1D2125;
+    --shadow-color: rgba(0, 0, 0, 0.5);
+    --focus-ring: rgba(87, 157, 255, 0.35);
+    --backdrop-color: rgba(0, 0, 0, 0.6);
+    --header-bg: #1D2125;
+    --header-text: #B6C2CF;
+    --header-muted: #8C9BAB;
+    --header-border: #38414A;
+    --header-control-bg: #22272B;
+    --header-control-border: #38414A;
+}
+
 /* 2. Base ----------------------------------------------------------------- */
 *,
 *::before,


### PR DESCRIPTION
Every colour has been a token since #11, so the dark theme is a second token block selected by `data-theme="dark"` on `<html>`, plus a moon/sun toggle in the banner. The inline script in `<head>` picks the theme before the first paint from the stored preference (`prTree.theme`) or, failing that, the OS setting; while nothing is stored the page follows OS changes live. `color-scheme` follows the theme so native selects and scrollbars match.

Verified in the browser: the toggle switches every surface at once (banner, project selector, sidebar and dropdowns, cards with status borders and orange attention titles, SYNC and commit badges, warnings box, orphaned-issues block, popover, help modal, empty state); the choice survives reloads in both directions; with the stored key removed the page follows the OS setting on load. Not verified: a live OS appearance change while the page is open, which I could not trigger from the session.

Closes #14
Part of #16
Stacked on #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZCANUDoVq6pd6b9i8vGbg