### PR TITLE
perf: single-pass filtering and fixture mode for realistic offline data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.1.0** (as of 2026-08-12)
+Current version: **2.2.0** (as of 2026-09-05)
 
 ## Technology Stack
 
@@ -49,12 +49,16 @@ pr-tree/
 ├── package.json           # Dependencies & version metadata
 ├── .gitignore             # Excludes config.js, node_modules, logs
 ├── start.bat              # Windows startup script
+├── test/                  # node:test unit tests (npm test)
 ├── README.md              # User-facing documentation
 └── public/                # Frontend assets
-    ├── index.html         # Main HTML structure
-    ├── styles.css         # Application styles
-    ├── app.js             # Main application logic & state management
-    ├── app-filter.js      # Filtering logic for PRs
+    ├── index.html         # App shell: banner, filter sidebar, tree pane, help modal
+    ├── styles.css         # Application styles (colour tokens, light and dark themes)
+    ├── app.js             # Data loading, rendering, filter state
+    ├── app-filter.js      # Filtering logic for PRs (visibility, attention, active-filter count)
+    ├── app-shell.js       # Banner, sidebar, theme, keyboard shortcuts, help modal, tab title
+    ├── tree-toggle.js     # Collapse/expand helpers and toggle-state capture/restore
+    ├── multi-select.js    # Multi-select dropdown component
     └── counter-utils.js   # Counter utilities for filtered/total counts
 ```
 
@@ -127,11 +131,20 @@ pr-tree/
 - Counter calculations for filtered vs total PRs
 - Badge updates in UI
 
+**public/app-shell.js**
+- Banner and sidebar chrome, independent of pull-request data
+- Sidebar toggle (button, `F` key), stored in `localStorage` under `prTree.sidebarHidden` for the wide layout; below 900px the sidebar is a drawer that always starts closed
+- Theme toggle, stored under `prTree.theme`; the OS setting is followed until a choice is stored; an inline script in `index.html` applies both before the first paint
+- Help modal, active-filter badge, tree toolbar (collapse all / expand all), document title (`(attention) PROJECT · Bitbucket Pull-Requests Tree`)
+- No DOM access at import time, so its pure helpers are unit-tested
+
+**public/tree-toggle.js**
+- `setRepositoryCollapsed`, `setRootBranchCollapsed`, `setPullRequestCollapsed` are the only code paths that change a collapsed state
+- `collapseAll` / `expandAll`, `captureToggleStates` / `restoreToggleStates` used across re-renders
+
 **public/index.html**
-- Single-page application structure
-- Filter UI (dropdowns, checkboxes)
-- Modal for help content
-- Footer with version information
+- App shell: banner (project selector, refresh status, theme toggle, help, GitHub, version), filter sidebar, tree pane with the collapse/expand toolbar, help modal
+- Inline `<head>` script applies the stored theme and sidebar state before the first paint
 
 ## API Endpoints
 
@@ -261,18 +274,22 @@ log(message, logStream);  // Logs to both console and file
 State is managed through module-level variables in app.js:
 ```javascript
 let currentProject = null;
-let currentSprint = "Show all";
-let currentAuthor = "Show all";
-let currentReviewer = "Show all";
+let currentSprints = [];        // sprint ids
+let currentFixVersions = [];    // fix version ids
+let currentAssignees = [];
+let currentReviewers = [];
 let currentSync = "Show all";
 let currentReadyForReviewer = false;
 let currentApiResult = null;
+let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied on re-render
 ```
 
 State is synchronized with URL query parameters for deep linking:
 ```
 ?project=PROJ&author=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
 ```
+
+Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches()` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL.
 
 ### Filtering Architecture
 Hierarchical filtering in app-filter.js:
@@ -341,7 +358,7 @@ When adding/modifying endpoints:
 
 ### Testing Changes
 - **Manual testing**: Use the UI to verify functionality
-- **No automated tests**: Currently no test suite (scripts shows `echo "Error: no test specified"`)
+- **Unit tests**: `npm test` (node:test, pure logic only)
 - **API testing**: Use browser DevTools Network tab or curl
 - **Cache testing**: Check `/api/cache/stats` endpoint
 
@@ -445,9 +462,12 @@ Three streams available:
 3. **API rate limits**: Bitbucket can return HTTP 429 if too many requests
 4. **Filter restoration**: SYNC and "ready for reviewer" filters NOT restored from URL (calculated async)
 5. **Regex patterns**: Must match exact Jira issue key format in PR titles
+6. **Colours**: never hard-code a colour in styles.css; add a token to both the `:root` and `:root[data-theme="dark"]` blocks
+7. **Ready for reviewer**: computed by `computeAttention()` from the data, never from rendered styles
 
 ### Testing Approach
-- **No automated tests**: All testing is manual via UI
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`computeAttention`, `countActiveFilters`, `buildDocumentTitle`); no DOM, no extra dependency
+- **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes
 - **API testing**: Use browser DevTools or Postman
 - **Error scenarios**: Check error.log for unexpected issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.2.0** (as of 2026-09-05)
+Current version: **2.3.0** (as of 2026-09-05)
 
 ## Technology Stack
 
@@ -49,17 +49,20 @@ pr-tree/
 ├── package.json           # Dependencies & version metadata
 ├── .gitignore             # Excludes config.js, node_modules, logs
 ├── start.bat              # Windows startup script
+├── fixtures/              # Fixture mode: generated data served instead of Atlassian (npm run start:fixtures)
+│   ├── generate.mjs       # Deterministic generator modelled on the real projects
+│   └── index.mjs          # Command-line/env options, config replacement, data source
 ├── test/                  # node:test unit tests (npm test)
 ├── README.md              # User-facing documentation
 └── public/                # Frontend assets
     ├── index.html         # App shell: banner, filter sidebar, tree pane, help modal
     ├── styles.css         # Application styles (colour tokens, light and dark themes)
     ├── app.js             # Data loading, rendering, filter state
-    ├── app-filter.js      # Filtering logic for PRs (visibility, attention, active-filter count)
+    ├── app-filter.js      # Filter index, pure evaluation, single-pass tree filtering and counters
     ├── app-shell.js       # Banner, sidebar, theme, keyboard shortcuts, help modal, tab title
     ├── tree-toggle.js     # Collapse/expand helpers and toggle-state capture/restore
     ├── multi-select.js    # Multi-select dropdown component
-    └── counter-utils.js   # Counter utilities for filtered/total counts
+    └── counter-utils.js   # Display of a filtered/total counter
 ```
 
 ### Key Files Explained
@@ -122,14 +125,19 @@ pr-tree/
 - Event handlers for user interactions
 
 **public/app-filter.js**
-- Filtering logic for PRs based on multiple criteria
-- Hierarchical filtering (respects parent-child PR relationships)
-- Visual state updates (highlighting, hiding)
-- Counter updates after filtering
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against; built once per data load by `initializeFilter()`
+- `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
+- `filterBranches(...)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
-- Counter calculations for filtered vs total PRs
-- Badge updates in UI
+- `updateCounterDisplay(element, visible, total)`: the `n/total` text and tooltip of a counter; the counts come from the filter pass
+
+**fixtures/generate.mjs** and **fixtures/index.mjs**
+- `generateProjectData(projectName, projectConfig, { scale, chainDepth })` returns exactly the `/api/pull-requests/:project` response shape; `generateSyncStatuses(projectData)` the `/api/sync-statuses/:project` one
+- Volumes and structure follow the real projects (see the constants at the top of generate.mjs), including the 24-deep stack of `products.secollab` under `feat/ai_investigations` that made the old filtering explode
+- Seeded PRNG: the same repository always yields the same pull requests, so `dataHash` is stable and the smart reload stays quiet
+- `parseFixtureOptions()` reads `--fixtures`, `--fixture-scale=N`, `--fixture-chain-depth=N` or the `PR_TREE_FIXTURES*` environment variables; `fixtureConfig()` replaces config.js; `createFixtureSource()` is what index.mjs calls instead of Atlassian
 
 **public/app-shell.js**
 - Banner and sidebar chrome, independent of pull-request data
@@ -292,11 +300,13 @@ State is synchronized with URL query parameters for deep linking:
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches()` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL.
 
 ### Filtering Architecture
-Hierarchical filtering in app-filter.js:
-1. Start from root branches
-2. Filter recursively from bottom-up (children first)
-3. Hide parents if no visible children and parent doesn't match filter
-4. Update counters after visibility changes
+Single pass in app-filter.js:
+1. `initializeFilter(apiResult)` builds the index once per data load (Maps and Sets, no array search later)
+2. `filterBranches()` collects the SYNC badges once, then walks repositories → root branches → direct child pull requests → their `.children` container, recursively; every pull request is visited exactly once
+3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible
+4. Counters (repository, root branch, child counters shown) are summed on the way back up and written through `updateCounterDisplay`; DOM writes only happen when the value changes
+
+Never re-select descendants (`querySelectorAll('.pull-request')`) inside the recursion: the previous implementation did, and a pull request at depth *d* was visited 2^d times (16 million visits per filter change on SECOLLAB).
 
 ## Development Workflows
 
@@ -315,6 +325,9 @@ Hierarchical filtering in app-filter.js:
 6. Update `projects.js` with your projects
 7. Run `node index.mjs`
 8. Navigate to http://localhost:3000
+
+### Running Without Atlassian Access (Fixture Mode)
+`npm run start:fixtures` (or `node index.mjs --fixtures`) serves both configured projects from generated data and never calls Atlassian; no config.js is needed. `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (default 24, the real SECOLLAB value). Use it for UI work and for performance checks: SECOLLAB in fixture mode has the same volumes and tree shape as the real project.
 
 ### Adding a New Project
 1. Edit `projects.js`
@@ -357,8 +370,8 @@ When adding/modifying endpoints:
 4. Use browser DevTools for debugging
 
 ### Testing Changes
-- **Manual testing**: Use the UI to verify functionality
-- **Unit tests**: `npm test` (node:test, pure logic only)
+- **Manual testing**: Use the UI to verify functionality; `npm run start:fixtures` gives realistic data without credentials
+- **Unit tests**: `npm test` (node:test, pure logic and the fixture generator)
 - **API testing**: Use browser DevTools Network tab or curl
 - **Cache testing**: Check `/api/cache/stats` endpoint
 
@@ -409,7 +422,7 @@ try {
 2. **Frontend HTML**: Add filter UI element in index.html
 3. **Frontend State**: Add state variable in app.js
 4. **URL Sync**: Update `updateUrlWithFilters()` and `restoreFiltersFromUrl()`
-5. **Filter Logic**: Update `isPullRequestVisible()` in app-filter.js
+5. **Filter Logic**: Add the precomputed set to `buildFilterIndex()` and the match to `evaluatePullRequest()` in app-filter.js, with a unit test
 6. **Event Handler**: Wire up filter change event
 
 ### Add New Jira Field
@@ -464,9 +477,12 @@ Three streams available:
 5. **Regex patterns**: Must match exact Jira issue key format in PR titles
 6. **Colours**: never hard-code a colour in styles.css; add a token to both the `:root` and `:root[data-theme="dark"]` blocks
 7. **Ready for reviewer**: computed by `computeAttention()` from the data, never from rendered styles
+8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
+9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`computeAttention`, `countActiveFilters`, `buildDocumentTitle`); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack); no DOM, no extra dependency
+- **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes
 - **API testing**: Use browser DevTools or Postman

--- a/PRD.md
+++ b/PRD.md
@@ -373,8 +373,12 @@ The application integrates with a Jira workflow where:
 3. **Frontend** (public/)
    - Single-page application (vanilla JS)
    - State management in app.js
-   - Filtering logic in app-filter.js
-   - Counter utilities in counter-utils.js
+   - Filtering logic in app-filter.js (index built per data load, single pass over the tree)
+   - Counter display in counter-utils.js
+
+4. **Fixtures** (fixtures/)
+   - Generated data modelled on the real projects, served by `node index.mjs --fixtures` without Atlassian access
+   - Used for UI work and performance checks
 
 ### 7.2 Technology Stack
 

--- a/PRD.md
+++ b/PRD.md
@@ -465,25 +465,20 @@ The application integrates with a Jira workflow where:
 
 ### 8.1 Layout Structure
 ```
-+--------------------------------------------------+
-| Header: Project Selector | Help | Last Refresh  |
-+--------------------------------------------------+
-| Filters: Author | Reviewer | Sprint | Sync |... |
-+--------------------------------------------------+
-| Pull Requests (Hierarchical Tree View)           |
-|   Repository 1                        [X / Y]    |
-|     Branch A                          [X / Y]    |
-|       PR #1 [SYNC] [Ahead:3] [Behind:1]          |
-|         JIRA-123 [In Progress]                   |
-|       PR #2 [Conflicts:5]                        |
-|     Branch B                          [X / Y]    |
-|       PR #3 [Ahead:2]                            |
-+--------------------------------------------------+
-| Orphaned Issues                                   |
-|   JIRA-456 [In Review] - Issue Summary           |
-+--------------------------------------------------+
-| Footer: Version | GitHub Link                     |
-+--------------------------------------------------+
++------------------------------------------------------------------+
+| Banner: ☰ | App name | Project ▾ | Last refresh | ☾ | ? | GitHub | v |
++----------------+-------------------------------------------------+
+| Filters  Clear | [Collapse all] [Expand all]                     |
+|  Sprint        | Repository 1                          [X / Y]   |
+|  Fix version   |   Branch A                            [X / Y]   |
+|  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
+|  Reviewer      |       JIRA-123 [In Progress]                    |
+|  Ready         |     PR #2                                       |
+|  SYNC + Load   |   Branch B                            [X / Y]   |
+|                |     PR #3 [Ahead:2]                             |
+| (does not      | Orphaned Issues                                 |
+|  scroll)       |   JIRA-456 [In Review] - Issue Summary          |
++----------------+-------------------------------------------------+
 ```
 
 ### 8.2 Visual Design Requirements
@@ -507,10 +502,12 @@ The application integrates with a Jira workflow where:
 - Collapsible sections for repositories/branches
 
 ### 8.3 Responsive Behavior
-- Minimum width: 1024px (desktop-focused)
-- Scrollable main content area
-- Fixed header and filter bar
-- Modal overlays for help content
+- Desktop-first: the banner and the filter sidebar stay fixed while the pull-request pane scrolls
+- The sidebar can be hidden (button or `F` key); the state is remembered per browser
+- Below 900px the sidebar becomes a drawer over the pane and the banner hides its text labels
+- Repository and branch headers stick to the top of the pane while scrolling
+- Modal overlay for help content
+- Light and dark themes, following the OS setting until the toggle is used
 
 ### 8.4 Interactive Elements
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@
     * After an Atlassian HTTP 429 response, the server pauses all Atlassian requests and serves cached data until 10 minutes after the last 429
 * Hovering the title of the pull-request or the Jira issue displays a popover previewing their title and description.
 * Online help displays the README.md file
+* Filtering cost does not depend on how deep pull requests are stacked: one pass over the tree, whatever the project size
+* Fixture mode: `npm run start:fixtures` serves realistic generated data for the configured projects without any Atlassian credentials or network access
 
 ## Installation
 * Clone this repository
@@ -63,7 +65,21 @@
 * Run `node index.mjs`
 * Go to http://localhost:3000
 
+## Running without Atlassian access (fixture mode)
+* Run `npm run start:fixtures` (or `node index.mjs --fixtures`), no `config.js` needed
+* Both configured projects are served from generated data modelled on the real SECOLLAB and OSLC projects: same repositories, Jira projects, volumes, branch naming, sprints, fix versions and the 24-deep stack of pull requests; the people are fictional
+* The SYNC load button answers from the fixtures too; no request is ever sent to Atlassian
+* `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
+
 ## Changelog:
+* Version 2.3.0
+    * Filtering is now a single pass over the tree
+        * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change
+        * Lookups go through indexes built once per data load instead of array searches per pull request
+        * Counters are summed in the same pass instead of re-scanning the tree
+        * On the SECOLLAB-sized fixture with the 24-deep stack, a filter change takes under a millisecond of JavaScript (about 7 ms with layout) in the browser
+    * Fixture mode (`npm run start:fixtures`) serves generated data for the configured projects without Atlassian access, with scale and stack-depth options
+    * `npm test` covers the fixture generator and the pure filter logic (`buildFilterIndex`, `evaluatePullRequest`)
 * Version 2.2.0
     * New application layout
         * Top banner with the app name, project selector, refresh status, theme toggle, help, GitHub link and version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Bitbucket Pull-Requests tree
 
 ## Features
+* Application layout
+    * A top banner shows the app name, the project selector, the refresh status, the theme toggle, the help and GitHub links and the version
+    * Filters live in a left sidebar that stays in place while the pull-request tree scrolls
+    * The sidebar can be hidden with the banner button or the `F` key; the choice is remembered by the browser
+    * On windows narrower than 900px the sidebar becomes a drawer over the tree
+    * The badge on the sidebar button shows how many filters are active; "Clear filters" resets them all
+    * Repository and branch headers stick to the top of the tree while scrolling
+    * "Collapse all" and "Expand all" fold or unfold every repository, branch and pull request
+    * The tab title shows the selected project and, when an assignee or reviewer filter is active, the number of pull requests waiting for them
+* Light and dark themes, following the system setting until the theme toggle is used
 * Lists all projects from the configuration file in a dropdown selector
 * Upon selecting a project, lists all corresponding pull requests ordered by most recently updated
 * Displays a link to related issues with the corresponding status
@@ -54,6 +64,21 @@
 * Go to http://localhost:3000
 
 ## Changelog:
+* Version 2.2.0
+    * New application layout
+        * Top banner with the app name, project selector, refresh status, theme toggle, help, GitHub link and version
+        * Filters stacked in a left sidebar that does not scroll with the tree; the sidebar can be hidden (button or `F` key) and its state is remembered
+        * Below 900px the sidebar becomes a drawer over the tree
+        * Repository and branch headers stick to the top of the tree while scrolling
+        * Collapse all / expand all buttons above the tree
+        * Active-filter badge on the sidebar button and a "Clear filters" button
+        * The tab title shows the selected project and the number of pull requests needing attention
+        * Empty, loading and error states are shown in the tree pane; a failed load no longer leaves the spinner forever
+        * The footer is gone; its links and version moved to the banner
+    * Dark theme, following the system setting until the toggle is used
+    * "Ready for reviewer" is now computed from the data instead of the title colour
+    * Stylesheet rebuilt on colour tokens, duplicate rules removed, system font stack
+    * `npm test` runs unit tests for the pure filter and title logic (node:test)
 * Version 2.1.0
     * SYNC status is now loaded on demand instead of automatically
         * No conflict computation is triggered when a project loads or refreshes, only when clicking the new load button next to the SYNC filter

--- a/fixtures/generate.mjs
+++ b/fixtures/generate.mjs
@@ -1,0 +1,688 @@
+/**
+ * Deterministic fixture data for the two configured projects.
+ *
+ * Volumes, repository names, Jira project keys, branch naming, stacked
+ * pull-request chains, sprints and fix versions are modelled on the real
+ * SECOLLAB and OSLC projects (September 2026 access logs). People are
+ * fictional. The same repository always yields the same pull requests, so
+ * a repository shared by two projects (products.web.oslc) is consistent.
+ *
+ * Everything is generated from a seeded PRNG: the output is stable across
+ * runs, which keeps the server's dataHash stable and the smart reload quiet.
+ */
+
+import crypto from 'crypto';
+
+export const workspace = 'sodius';
+export const jiraSiteName = 'sodiuswillert';
+
+// Open pull requests per repository, as observed in the real projects
+export const repositoryVolumes = {
+    'products.secollab': 100,
+    'products.secollab.client': 2,
+    'products.secollab.packaging': 0,
+    'products.web.oslc': 10,
+    'products.web.common': 5,
+    'products.oslc': 9
+};
+
+// Which Jira projects the branches of a repository refer to, with a weight
+const repositoryJiraProjects = {
+    'products.secollab': [['SECOLLAB', 9], ['WEBCMN', 1]],
+    'products.secollab.client': [['SECOLLAB', 1]],
+    'products.secollab.packaging': [['SECOLLAB', 1]],
+    'products.web.oslc': [['PRDOSLC', 3], ['WEBCMN', 1]],
+    'products.web.common': [['WEBCMN', 1]],
+    'products.oslc': [['PRDOSLC', 1]]
+};
+
+const repositoryRootBranches = {
+    'products.secollab': [['master', 7], ['master_5.4.0', 2], ['master_1.16.x', 1]],
+    'products.secollab.client': [['develop', 1]],
+    'products.secollab.packaging': [['develop', 1]],
+    'products.web.oslc': [['develop', 3], ['release/3.1.x', 1]],
+    'products.web.common': [['main', 1]],
+    'products.oslc': [['develop', 2], ['release/3.1.x', 1]]
+};
+
+// The real SECOLLAB project carries one very deep stack: 26 pull requests
+// chained 24 levels deep under a long-lived feature branch. This is what made
+// the recursive filtering explode (2^depth visits), so the fixture keeps it.
+export const deepChain = {
+    repository: 'products.secollab',
+    rootBranch: 'feat/ai_investigations',
+    firstBranch: 'ai-mcp-tool-layer',
+    depth: 24,
+    sideBranches: 2
+};
+
+// Bitbucket pull-request ids are sequential per repository; the ranges are
+// disjoint here so a pull request is unambiguous in the fixtures
+const repositoryFirstId = {
+    'products.secollab': 2400,
+    'products.secollab.client': 180,
+    'products.secollab.packaging': 40,
+    'products.web.oslc': 610,
+    'products.web.common': 320,
+    'products.oslc': 1150
+};
+
+// Active sprints: the same boards serve both projects, so both projects
+// see the same sprints with different issue counts (as in the real logs)
+export const sprintDefinitions = [
+    { id: 100, name: 'Foundation Sprint 12', project: 'WEBCMN' },
+    { id: 5240, name: 'SECollab Sprint 142', project: 'SECOLLAB' },
+    { id: 5241, name: 'SECollab Sprint 143', project: 'SECOLLAB' },
+    { id: 2731, name: 'SECollab Hardening 2.7.x', project: 'SECOLLAB' },
+    { id: 5341, name: 'OSLCATL Sprint 88', project: 'PRDOSLC' },
+    { id: 5308, name: 'OSLCATL Sprint 87', project: 'PRDOSLC' },
+    { id: 5307, name: 'OSLCATL Sprint 89', project: 'PRDOSLC' }
+];
+
+const sprintIssueCounts = {
+    SECOLLAB: { 100: 3, 5240: 100, 5241: 61, 2731: 100, 5341: 7, 5308: 96, 5307: 0 },
+    OSLC: { 100: 0, 5240: 4, 5241: 2, 2731: 1, 5341: 0, 5308: 96, 5307: 0 }
+};
+
+const orphanedIssueCounts = { SECOLLAB: 13, OSLC: 0 };
+
+const fixVersionsByProject = {
+    SECOLLAB: [
+        { id: '10812', name: 'SECollab 2.8.0' },
+        { id: '10790', name: 'SECollab 2.7.3' },
+        { id: '10855', name: 'SECollab 3.0.0' }
+    ],
+    PRDOSLC: [
+        { id: '10820', name: 'OSLC Connect for Jira 3.2.0' },
+        { id: '10801', name: 'OSLC Connect for Windchill 1.5.0' },
+        { id: '10833', name: 'OSLC Connect for Jira 3.1.4' }
+    ],
+    WEBCMN: [
+        { id: '10760', name: 'Web Common 4.1.0' },
+        { id: '10842', name: 'Web Common 4.2.0' }
+    ],
+    WEBOSLC: [
+        { id: '10777', name: 'Web OSLC 2.3.0' }
+    ]
+};
+
+// Fictional team
+const people = [
+    'Amélie Roussel', 'Bastien Lefèvre', 'Chloé Marchand', 'Damien Garnier',
+    'Elise Fontaine', 'Florian Meunier', 'Gaëlle Perrin', 'Hugo Blanchard',
+    'Inès Carpentier', 'Julien Rey'
+];
+
+// Distribution observed on the real SECOLLAB issues
+const statuses = [
+    ['In Review', 55], ['In Progress', 37], ['Ready', 7], ['Created', 2], ['Reopened', 1]
+];
+
+const priorities = [
+    ['Highest', '#d04437', 1], ['High', '#e5493a', 3], ['Medium', '#e97f33', 8],
+    ['Low', '#2a8735', 3], ['Lowest', '#57a55a', 1]
+];
+
+const issueTypes = [['Bug', 4], ['Story', 3], ['Task', 3], ['Sub-task', 2]];
+
+const branchKinds = [['feature', 6], ['bugfix', 4], ['hotfix', 1], ['chore', 1]];
+
+const components = {
+    SECOLLAB: [
+        'baseline comparison', 'Rhapsody import', 'DOORS synchronisation', 'review workflow',
+        'requirement attributes', 'model diagrams', 'Capella connector', 'permission checks',
+        'change-set export', 'SysML block viewer', 'comment threads', 'traceability matrix',
+        'notification e-mails', 'project archiving', 'LDAP group mapping'
+    ],
+    PRDOSLC: [
+        'OSLC preview dialog', 'delegated UI selection', 'Windchill link discovery',
+        'Jira issue linking', 'OAuth 1.0a handshake', 'root services document',
+        'resource shape cache', 'TRS provider', 'query capability', 'configuration context'
+    ],
+    WEBCMN: [
+        'date picker', 'multi-select control', 'theme tokens', 'session keep-alive',
+        'error banner', 'REST client retries', 'i18n bundles', 'modal focus trap'
+    ],
+    WEBOSLC: ['link picker', 'preview card', 'selection dialog']
+};
+
+const problems = [
+    'fails when the module is baselined', 'ignores nested packages with unicode names',
+    'shows removed items as modified', 'loses the selection after pagination',
+    'times out on large projects', 'duplicates entries after a refresh',
+    'does not honour the configured locale', 'breaks keyboard navigation',
+    'leaks the HTTP client on error', 'rejects valid ETags', 'renders empty on Firefox',
+    'skips the last page of results', 'crashes on a null description'
+];
+
+const improvements = [
+    'add pagination', 'support configuration contexts', 'cache resource shapes',
+    'expose a REST endpoint', 'migrate to the v3 API', 'add a dark theme',
+    'batch the update requests', 'add an audit log entry', 'make the timeout configurable',
+    'show progress while loading', 'align spacing with the design tokens'
+];
+
+// ------------------------------------------------------------------ helpers
+
+function createRandom(seedText) {
+    let seed = crypto.createHash('md5').update(seedText).digest().readUInt32LE(0) || 1;
+    // mulberry32
+    return function random() {
+        seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+        let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+        t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+}
+
+function pick(random, items) {
+    return items[Math.floor(random() * items.length)];
+}
+
+// items: [[value, weight], ...]
+function pickWeighted(random, items) {
+    const total = items.reduce((sum, item) => sum + item[1], 0);
+    let roll = random() * total;
+    for (const item of items) {
+        roll -= item[1];
+        if (roll < 0) return item[0];
+    }
+    return items[items.length - 1][0];
+}
+
+function integer(random, min, max) {
+    return min + Math.floor(random() * (max - min + 1));
+}
+
+function hex(random, length) {
+    let out = '';
+    while (out.length < length) {
+        out += Math.floor(random() * 16).toString(16);
+    }
+    return out;
+}
+
+function slugify(text) {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+}
+
+function isoDaysAgo(days) {
+    const date = new Date(Date.UTC(2026, 8, 5, 8, 0, 0)); // fixed "now": 2026-09-05
+    date.setUTCDate(date.getUTCDate() - days);
+    return date.toISOString();
+}
+
+function initials(name) {
+    return name.split(/\s+/).map(part => part[0]).join('').toUpperCase();
+}
+
+function svgDataUri(svg) {
+    return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+function avatarUrl(name, index) {
+    const hue = (index * 47) % 360;
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="16" fill="hsl(${hue} 55% 45%)"/><text x="16" y="21" font-family="system-ui,sans-serif" font-size="14" font-weight="600" text-anchor="middle" fill="#fff">${initials(name)}</text></svg>`;
+    return svgDataUri(svg);
+}
+
+function priorityIconUrl(colour) {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M8 2 L14 12 H2 Z" fill="${colour}"/></svg>`;
+    return svgDataUri(svg);
+}
+
+function escapeHtml(text) {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ------------------------------------------------------------------- people
+
+function bitbucketUser(name, index) {
+    const uuid = `{${crypto.createHash('md5').update(`bb-${name}`).digest('hex').replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '$1-$2-$3-$4-$5')}}`;
+    const accountId = `712020:${crypto.createHash('md5').update(`account-${name}`).digest('hex').slice(0, 24)}`;
+    return {
+        type: 'user',
+        uuid,
+        account_id: accountId,
+        display_name: name,
+        nickname: slugify(name),
+        links: {
+            avatar: { href: avatarUrl(name, index) },
+            html: { href: `https://bitbucket.org/${accountId}/` }
+        }
+    };
+}
+
+function jiraUser(name, index) {
+    return {
+        accountId: `712020:${crypto.createHash('md5').update(`account-${name}`).digest('hex').slice(0, 24)}`,
+        displayName: name,
+        emailAddress: `${slugify(name).replace(/-/g, '.')}@example.com`,
+        active: true,
+        avatarUrls: { '48x48': avatarUrl(name, index) }
+    };
+}
+
+const team = people.map((name, index) => ({ bitbucket: bitbucketUser(name, index), jira: jiraUser(name, index) }));
+const rovoDev = {
+    type: 'user',
+    uuid: '{5e6a9c70-0000-4000-8000-00000000r0v0}',
+    account_id: '712020:rovo-dev-agent',
+    display_name: 'Rovo Dev',
+    nickname: 'rovo-dev',
+    links: { avatar: { href: avatarUrl('Rovo Dev', 42) }, html: { href: 'https://bitbucket.org/rovo-dev/' } }
+};
+
+// ------------------------------------------------------------------- issues
+
+function issueSummary(random, project) {
+    const component = pick(random, components[project] || components.WEBCMN);
+    const capitalised = component[0].toUpperCase() + component.slice(1);
+    return random() < 0.6
+        ? `${capitalised} ${pick(random, problems)}`
+        : `${capitalised}: ${pick(random, improvements)}`;
+}
+
+// Issue numbers: each generation (a repository, or the project-level sprint
+// fillers and orphans) owns a block of 1000 numbers per Jira project, so keys
+// never collide and every call yields the same keys
+const issueNumberBase = { SECOLLAB: 4800, PRDOSLC: 1320, WEBCMN: 610, WEBOSLC: 240 };
+function createIssueNumbering(block) {
+    const counters = new Map();
+    return function nextIssueNumber(project) {
+        const start = (issueNumberBase[project] || 100) + block * 1000;
+        const next = (counters.get(project) ?? start) + 1;
+        counters.set(project, next);
+        return next;
+    };
+}
+
+function createIssue(random, nextIssueNumber, project, { status, assignee, parent, type } = {}) {
+    const key = `${project}-${nextIssueNumber(project)}`;
+    const issueType = type || pickWeighted(random, issueTypes);
+    const [priorityName, priorityColour] = pickWeighted(random, priorities.map(p => [[p[0], p[1]], p[2]]));
+    const versions = fixVersionsByProject[project] || [];
+    // Sub-tasks mostly inherit their fix version from the parent (the server does that too)
+    const fixVersions = issueType === 'Sub-task' || random() < 0.25 ? [] : [pick(random, versions)];
+    const assigneePerson = assignee === null ? null : (assignee || (random() < 0.85 ? pick(random, team) : null));
+    return {
+        id: String(10000 + Number(key.split('-')[1])),
+        key,
+        self: `https://${jiraSiteName}.atlassian.net/rest/api/3/issue/${key}`,
+        fields: {
+            summary: issueSummary(random, project),
+            status: { name: status || pickWeighted(random, statuses), statusCategory: { key: 'indeterminate' } },
+            priority: { name: priorityName, iconUrl: priorityIconUrl(priorityColour), id: String(priorities.findIndex(p => p[0] === priorityName) + 1) },
+            fixVersions,
+            assignee: assigneePerson ? assigneePerson.jira : null,
+            issuetype: { name: issueType, subtask: issueType === 'Sub-task' },
+            ...(parent ? { parent: { key: parent.key, fields: { summary: parent.fields.summary } } } : {})
+        }
+    };
+}
+
+// ------------------------------------------------------------ pull requests
+
+function renderedDescription(random, title, issueKeys) {
+    const paragraphs = integer(random, 1, 4);
+    let html = `<p>${escapeHtml(title)}.</p>`;
+    for (let i = 0; i < paragraphs; i++) {
+        html += `<p>${escapeHtml(pick(random, [
+            'Root cause: the merge base was computed on the wrong side, so removed items were reported as modified.',
+            'This change refactors the loader to stream the pages instead of accumulating them in memory.',
+            'Tested manually against the QA instance with the 2.7.x dataset, and with the new unit tests.',
+            'Follow-up of the review comments: renamed the helper and added the missing null checks.',
+            'The migration is idempotent and can be replayed on an already migrated database.',
+            'Screenshots are attached to the Jira issue. No public API change.'
+        ]))}</p>`;
+    }
+    if (issueKeys.length > 0) {
+        html += '<ul>' + issueKeys.map(key => `<li><a href="https://${jiraSiteName}.atlassian.net/browse/${key}">${key}</a></li>`).join('') + '</ul>';
+    }
+    if (random() < 0.3) {
+        html += '<pre><code>mvn -pl products.secollab verify -Dsurefire.failIfNoSpecifiedTests=false</code></pre>';
+    }
+    // Bitbucket fills the description with the commit list: 3 to 60 lines
+    const commits = integer(random, 3, random() < 0.15 ? 60 : 20);
+    html += '<ul>';
+    for (let i = 0; i < commits; i++) {
+        html += `<li><a href="https://bitbucket.org/${workspace}/commits/${hex(random, 40)}">${hex(random, 7)}</a> ${escapeHtml(pick(random, [
+            'fix review comments', 'rename helper and add null checks', 'add unit tests', 'merge master into branch',
+            'wip', 'update third-party libraries', 'fix NPE on empty selection', 'i18n: add French strings',
+            'refactor loader to stream pages', 'add missing license headers', 'fix flaky test on CI'
+        ]))}</li>`;
+    }
+    html += '</ul>';
+    return html;
+}
+
+// Branch names follow the team convention INITIALS_YYMMDD_KEY_Slug (most of
+// the time), with a few fix/ and bare KEY-slug branches
+function branchName(random, kind, key, summary, createdDaysAgo) {
+    const slug = slugify(summary);
+    if (kind === 'convention') {
+        const initials = pick(random, people).split(/\s+/).map(part => part[0]).join('').toUpperCase() + pick(random, ['', 'R', 'E', 'A']);
+        const date = new Date(isoDaysAgo(createdDaysAgo));
+        const yymmdd = `${String(date.getUTCFullYear()).slice(2)}${String(date.getUTCMonth() + 1).padStart(2, '0')}${String(date.getUTCDate()).padStart(2, '0')}`;
+        const titleSlug = slug.split('-').filter(Boolean).map(part => part[0].toUpperCase() + part.slice(1)).join('-');
+        return `${initials}_${yymmdd}_${key || 'NOKEY'}_${titleSlug}`;
+    }
+    if (kind === 'bare') {
+        return `${key ? `${key}-` : ''}${slug}`;
+    }
+    return `${kind}/${key ? `${key}-` : ''}${slug}`;
+}
+
+function createParticipants(random, author) {
+    const others = team.filter(person => person.bitbucket !== author);
+    const count = pickWeighted(random, [[0, 3], [1, 6], [2, 3], [3, 1]]);
+    const chosen = [];
+    while (chosen.length < count) {
+        const candidate = pick(random, others);
+        if (!chosen.includes(candidate)) chosen.push(candidate);
+    }
+    const participants = [{
+        type: 'participant', user: author, role: 'PARTICIPANT', approved: false, state: null, participated_on: null
+    }];
+    for (const person of chosen) {
+        const state = pickWeighted(random, [['approved', 4], ['changes_requested', 1], [null, 4]]);
+        participants.push({
+            type: 'participant', user: person.bitbucket, role: 'REVIEWER',
+            approved: state === 'approved', state, participated_on: state ? isoDaysAgo(integer(random, 0, 20)) : null
+        });
+    }
+    if (random() < 0.3) {
+        participants.push({ type: 'participant', user: rovoDev, role: 'REVIEWER', approved: false, state: null, participated_on: null });
+    }
+    return participants;
+}
+
+/**
+ * Pull requests of one repository, with the Jira issues they refer to.
+ * Chains are built by targeting the source branch of an earlier pull request.
+ */
+export function generateRepository(repoName, { scale = 1, chainDepth = deepChain.depth } = {}) {
+    const random = createRandom(`repo-${repoName}`);
+    const count = Math.round((repositoryVolumes[repoName] ?? 5) * scale);
+    const chainLength = repoName === deepChain.repository ? Math.min(count, chainDepth + deepChain.sideBranches) : 0;
+    const jiraProjects = repositoryJiraProjects[repoName] || [['WEBCMN', 1]];
+    const rootBranches = repositoryRootBranches[repoName] || [['develop', 1]];
+    const repository = {
+        type: 'repository',
+        name: repoName,
+        full_name: `${workspace}/${repoName}`,
+        uuid: `{${hex(random, 8)}-${hex(random, 4)}-${hex(random, 4)}-${hex(random, 4)}-${hex(random, 12)}}`,
+        links: { html: { href: `https://bitbucket.org/${workspace}/${repoName}` } }
+    };
+
+    const pullRequests = [];
+    const issues = [];
+    const parentIssues = [];
+    let id = repositoryFirstId[repoName] ?? 1;
+    const nextIssueNumber = createIssueNumbering(Object.keys(repositoryVolumes).indexOf(repoName) + 1);
+
+    for (let i = 0; i < count; i++) {
+        const project = pickWeighted(random, jiraProjects);
+        const author = pick(random, team).bitbucket;
+        const status = pickWeighted(random, statuses);
+
+        // Issues referenced in the title: usually one, sometimes two, rarely none
+        const issueCount = pickWeighted(random, [[0, 1], [1, 12], [2, 3]]);
+        const linkedIssues = [];
+        for (let j = 0; j < issueCount; j++) {
+            const type = pickWeighted(random, issueTypes);
+            let parent = null;
+            if (type === 'Sub-task') {
+                // Half of the parents are only known through the sub-task (fetched separately by the server)
+                parent = random() < 0.5 && issues.length > 0 ? pick(random, issues) : createIssue(random, nextIssueNumber, project, { type: 'Story', status: 'In Progress' });
+                if (!issues.includes(parent)) parentIssues.push(parent);
+            }
+            const issue = createIssue(random, nextIssueNumber, project, { status: j === 0 ? status : (random() < 0.8 ? status : undefined), parent, type });
+            linkedIssues.push(issue);
+            issues.push(issue);
+        }
+
+        const summary = linkedIssues.length > 0 ? linkedIssues[0].fields.summary : issueSummary(random, project);
+        const keys = linkedIssues.map(issue => issue.key);
+        const title = keys.length > 0 ? `${keys.join(' ')} ${summary}` : summary;
+
+        const createdDaysAgo = integer(random, 1, 180);
+
+        // Destination: the deep chain first, then a root branch or the source
+        // of an earlier pull request (stacked, 2 to 5 levels)
+        let destinationBranch;
+        let sourceBranch;
+        if (i < chainLength) {
+            const chain = pullRequests.slice(0, i);
+            if (i === 0) {
+                destinationBranch = deepChain.rootBranch;
+                sourceBranch = deepChain.firstBranch;
+            } else if (i < chainDepth) {
+                destinationBranch = chain[i - 1].source.branch.name;
+            } else {
+                destinationBranch = chain[Math.floor(chain.length / 2) + (i - chainDepth)].source.branch.name; // side branch
+            }
+        } else {
+            const stackable = pullRequests.slice(chainLength).slice(-12);
+            if (stackable.length > 0 && random() < 0.3) {
+                destinationBranch = pick(random, stackable).source.branch.name;
+            } else {
+                destinationBranch = pickWeighted(random, rootBranches);
+            }
+        }
+        if (!sourceBranch) {
+            const kind = repoName.startsWith('products.secollab')
+                ? pickWeighted(random, [['convention', 8], ['fix', 1], ['bare', 1]])
+                : pickWeighted(random, branchKinds);
+            sourceBranch = branchName(random, kind, keys[0], summary, createdDaysAgo);
+        }
+
+        const updatedDaysAgo = integer(random, 0, Math.min(createdDaysAgo, 45));
+        const commitsAhead = pickWeighted(random, [[integer(random, 1, 6), 6], [integer(random, 7, 40), 3], [100, 1]]);
+        const commitsBehind = pickWeighted(random, [[0, 3], [integer(random, 1, 15), 5], [integer(random, 16, 99), 1], [100, 1]]);
+
+        const pullRequest = {
+            type: 'pullrequest',
+            id: id++,
+            title,
+            state: 'OPEN',
+            draft: random() < 0.1,
+            author,
+            created_on: isoDaysAgo(createdDaysAgo),
+            updated_on: isoDaysAgo(updatedDaysAgo),
+            comment_count: integer(random, 0, 14),
+            task_count: integer(random, 0, 3),
+            close_source_branch: true,
+            source: {
+                branch: { name: sourceBranch },
+                commit: { hash: hex(random, 12) },
+                repository
+            },
+            destination: {
+                branch: { name: destinationBranch },
+                commit: { hash: hex(random, 12) },
+                repository
+            },
+            participants: createParticipants(random, author),
+            rendered: {
+                title: { type: 'rendered', raw: title, markup: 'markdown', html: `<p>${escapeHtml(title)}</p>` },
+                description: { type: 'rendered', raw: '', markup: 'markdown', html: renderedDescription(random, summary, keys) }
+            },
+            links: {
+                html: { href: `https://bitbucket.org/${workspace}/${repoName}/pull-requests/${id - 1}` }
+            },
+            commitsAhead,
+            commitsBehind
+        };
+        pullRequests.push(pullRequest);
+    }
+
+    return { repository, pullRequests, issues, parentIssues };
+}
+
+// ------------------------------------------------------------------ project
+
+const repositoryCache = new Map();
+function repositoryData(repoName, options) {
+    const cacheKey = `${repoName}@${options.scale}@${options.chainDepth}`;
+    if (!repositoryCache.has(cacheKey)) {
+        repositoryCache.set(cacheKey, generateRepository(repoName, options));
+    }
+    return repositoryCache.get(cacheKey);
+}
+
+function extractJiraIssues(title, jiraRegex) {
+    return title.match(jiraRegex) || [];
+}
+
+/**
+ * Builds the /api/pull-requests/:project response for a project, in the exact
+ * shape produced by buildProjectData() in index.mjs.
+ */
+export function generateProjectData(projectName, projectConfig, { scale = 1, chainDepth = deepChain.depth } = {}) {
+    const random = createRandom(`project-${projectName}-${scale}`);
+    const nextIssueNumber = createIssueNumbering(9);
+    const pullRequests = [];
+    const knownIssues = new Map();
+    for (const repoName of projectConfig.repositories) {
+        const data = repositoryData(repoName, { scale, chainDepth });
+        pullRequests.push(...data.pullRequests);
+        for (const issue of [...data.issues, ...data.parentIssues]) {
+            knownIssues.set(issue.key, issue);
+        }
+    }
+
+    // Same regex-based extraction as the server: only keys matching the project regex count
+    const jiraIssuesMap = {};
+    for (const pullRequest of pullRequests) {
+        jiraIssuesMap[pullRequest.id] = extractJiraIssues(pullRequest.title, projectConfig.jiraRegex);
+    }
+    const allJiraIssues = Object.values(jiraIssuesMap).flat();
+
+    // Issue details only for the configured Jira projects (the JQL filters on project)
+    const jiraIssuesDetails = [];
+    const seen = new Set();
+    for (const key of allJiraIssues) {
+        const issue = knownIssues.get(key);
+        if (issue && !seen.has(key) && projectConfig.jiraProjects.includes(key.split('-')[0])) {
+            seen.add(key);
+            jiraIssuesDetails.push(structuredClone(issue));
+        }
+    }
+    // Parents of sub-tasks are fetched by the server with their fix versions only
+    for (const issue of [...jiraIssuesDetails]) {
+        const parentKey = issue.fields.parent?.key;
+        if (parentKey && !seen.has(parentKey) && knownIssues.has(parentKey)) {
+            seen.add(parentKey);
+            const parent = knownIssues.get(parentKey);
+            jiraIssuesDetails.push({ id: parent.id, key: parent.key, self: parent.self, fields: { fixVersions: parent.fields.fixVersions } });
+        }
+    }
+    // Sub-tasks inherit the fix versions of their parent
+    for (const issue of jiraIssuesDetails) {
+        if (issue.fields.parent && (!issue.fields.fixVersions || issue.fields.fixVersions.length === 0)) {
+            const parent = jiraIssuesDetails.find(candidate => candidate.key === issue.fields.parent.key);
+            if (parent?.fields.fixVersions?.length > 0) {
+                issue.fields.fixVersions = parent.fields.fixVersions;
+            }
+        }
+    }
+
+    const pullRequestsByDestination = {};
+    for (const pullRequest of pullRequests) {
+        const destination = pullRequest.destination.branch.name;
+        (pullRequestsByDestination[destination] ??= []).push(pullRequest);
+    }
+
+    // Sprints: the linked issues of the project are spread over the sprints,
+    // the remaining slots are filled with issues that have no pull request
+    const sprints = sprintDefinitions.map(({ id, name }) => ({ id, name }));
+    const counts = sprintIssueCounts[projectName] || {};
+    const sprintIssues = {};
+    const linkedKeys = jiraIssuesDetails.map(issue => issue.key).filter(key => key.split('-')[0] !== 'WEBOSLC');
+    for (const sprint of sprintDefinitions) {
+        const target = Math.round((counts[sprint.id] ?? 0) * scale);
+        const keys = [];
+        for (const key of linkedKeys) {
+            if (keys.length >= target) break;
+            if (key.startsWith(`${sprint.project}-`) && random() < 0.5) keys.push(key);
+        }
+        while (keys.length < target) {
+            keys.push(`${sprint.project}-${nextIssueNumber(sprint.project)}`);
+        }
+        sprintIssues[sprint.id] = keys;
+    }
+
+    // Issues "In Review" without a pull request
+    const orphanedIssues = [];
+    const orphanCount = Math.round((orphanedIssueCounts[projectName] ?? 0) * scale);
+    for (let i = 0; i < orphanCount; i++) {
+        const project = pick(random, projectConfig.jiraProjects);
+        const issue = createIssue(random, nextIssueNumber, project, { status: 'In Review' });
+        orphanedIssues.push({
+            id: issue.id,
+            key: issue.key,
+            self: issue.self,
+            fields: {
+                summary: issue.fields.summary,
+                status: issue.fields.status,
+                priority: issue.fields.priority,
+                updated: isoDaysAgo(integer(random, 0, 30)),
+                assignee: issue.fields.assignee
+            },
+            jiraSiteName
+        });
+    }
+
+    const data = {
+        pullRequests,
+        jiraIssuesMap,
+        jiraIssuesDetails,
+        pullRequestsByDestination,
+        jiraSiteName,
+        sprints,
+        sprintIssues,
+        orphanedIssues
+    };
+    return {
+        lastRefreshTime: new Date().toISOString(),
+        ...data,
+        dataHash: calculateHash(data)
+    };
+}
+
+// Same hash as buildProjectData() in index.mjs, so the smart reload behaves as in production
+function calculateHash(data) {
+    const hash = crypto.createHash('md5');
+    hash.update(JSON.stringify({
+        pullRequests: data.pullRequests,
+        jiraIssuesMap: data.jiraIssuesMap,
+        jiraIssuesDetails: data.jiraIssuesDetails,
+        sprints: data.sprints,
+        sprintIssues: data.sprintIssues,
+        orphanedIssues: data.orphanedIssues
+    }));
+    return hash.digest('hex');
+}
+
+/**
+ * Builds the /api/sync-statuses/:project response: about a fifth of the pull
+ * requests have conflicts, a few could not be computed.
+ */
+export function generateSyncStatuses(projectData) {
+    const random = createRandom(`sync-${projectData.pullRequests.length}`);
+    const statuses = {};
+    for (const pullRequest of projectData.pullRequests) {
+        const spec = `${pullRequest.destination.commit?.hash}..${pullRequest.source.commit?.hash}`;
+        if (spec.includes('undefined')) continue;
+        const roll = random();
+        statuses[`${pullRequest.source.repository.name}/${spec}`] =
+            roll < 0.04 ? { error: true } : { conflicts: roll < 0.24 };
+    }
+    return {
+        lastRefreshTime: new Date().toISOString(),
+        rateLimited: false,
+        rateLimitedUntil: null,
+        statuses
+    };
+}

--- a/fixtures/index.mjs
+++ b/fixtures/index.mjs
@@ -1,0 +1,64 @@
+/**
+ * Fixture mode: the server answers from generated data instead of Atlassian.
+ *
+ *   node index.mjs --fixtures                 (or PR_TREE_FIXTURES=1)
+ *   node index.mjs --fixtures --fixture-scale=3   (or PR_TREE_FIXTURE_SCALE=3)
+ *   node index.mjs --fixtures --fixture-chain-depth=8   (or PR_TREE_FIXTURE_CHAIN_DEPTH=8)
+ *
+ * No config.js is needed: the projects come from projects.js and the
+ * credentials are placeholders. The scale factor multiplies the number of
+ * pull requests, sprint issues and orphaned issues of every project; the
+ * chain depth is the length of the deepest stack of pull requests (24 in the
+ * real SECOLLAB project).
+ */
+
+import { createRequire } from 'module';
+import { generateProjectData, generateSyncStatuses, workspace, jiraSiteName, deepChain } from './generate.mjs';
+
+export function parseFixtureOptions(argv = process.argv, env = process.env) {
+    const enabled = argv.includes('--fixtures') || ['1', 'true', 'yes'].includes(String(env.PR_TREE_FIXTURES).toLowerCase());
+    const numberOption = (flag, envName, fallback) => {
+        const arg = argv.find(candidate => candidate.startsWith(`${flag}=`));
+        const value = Number(arg ? arg.split('=')[1] : env[envName]);
+        return Number.isFinite(value) && value > 0 ? value : fallback;
+    };
+    return {
+        enabled,
+        scale: numberOption('--fixture-scale', 'PR_TREE_FIXTURE_SCALE', 1),
+        chainDepth: Math.round(numberOption('--fixture-chain-depth', 'PR_TREE_FIXTURE_CHAIN_DEPTH', deepChain.depth))
+    };
+}
+
+/** A config.js replacement for fixture mode: real project definitions, placeholder credentials. */
+export function fixtureConfig() {
+    const require = createRequire(import.meta.url);
+    return {
+        bitbucket: { username: 'fixtures', password: 'fixtures', workspace },
+        jira: { siteName: jiraSiteName, username: 'fixtures', apiKey: 'fixtures' },
+        projects: require('../projects.js')
+    };
+}
+
+export function createFixtureSource(config, { scale = 1, chainDepth = deepChain.depth } = {}) {
+    const projectData = new Map();
+
+    function getProjectData(projectName) {
+        const projectConfig = config.projects[projectName];
+        if (!projectConfig) {
+            throw new Error('Project not found');
+        }
+        if (!projectData.has(projectName)) {
+            projectData.set(projectName, generateProjectData(projectName, projectConfig, { scale, chainDepth }));
+        }
+        const data = projectData.get(projectName);
+        data.lastRefreshTime = new Date().toISOString();
+        return data;
+    }
+
+    return {
+        scale,
+        chainDepth,
+        buildProjectData: async (projectName) => getProjectData(projectName),
+        buildSyncStatuses: async (projectName) => generateSyncStatuses(getProjectData(projectName))
+    };
+}

--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,6 @@ import express from 'express';
 import fetch from 'node-fetch';
 import { diff3Merge } from 'node-diff3';
 import dotenv from 'dotenv';
-import config from './config.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
@@ -17,8 +16,14 @@ import {
     getCacheStats,
     raiseAllCacheTtls
 } from './cache.mjs';
+import { parseFixtureOptions, fixtureConfig, createFixtureSource } from './fixtures/index.mjs';
 
 dotenv.config();
+
+// Fixture mode (--fixtures): generated data instead of Atlassian, no config.js needed
+const fixtureOptions = parseFixtureOptions();
+const config = fixtureOptions.enabled ? fixtureConfig() : (await import('./config.js')).default;
+const fixtureSource = fixtureOptions.enabled ? createFixtureSource(config, { scale: fixtureOptions.scale, chainDepth: fixtureOptions.chainDepth }) : null;
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -97,6 +102,9 @@ function noteRateLimit(url) {
 
 // Every Atlassian request goes through this wrapper so a single 429 pauses them all.
 async function atlassianFetch(url, options) {
+    if (fixtureSource) {
+        throw new Error(`Fixture mode: no request is sent to Atlassian (${url})`);
+    }
     if (isRateLimited()) {
         throw new RateLimitError();
     }
@@ -445,6 +453,9 @@ async function buildProjectData(projectName) {
     if (!projectConfig) {
         throw new Error('Project not found');
     }
+    if (fixtureSource) {
+        return fixtureSource.buildProjectData(projectName);
+    }
 
     log(`Processing pull requests for project: ${projectName}`, accessLogStream);
 
@@ -563,6 +574,9 @@ app.get('/api/sync-statuses/:project', async (req, res) => {
 
     try {
         const syncStatuses = await getCachedSyncStatuses(projectName, async () => {
+            if (fixtureSource) {
+                return { data: await fixtureSource.buildSyncStatuses(projectName), ttl: 300 };
+            }
             const projectData = await getCachedProjectData(projectName, () => buildProjectData(projectName));
 
             const statuses = {};
@@ -778,4 +792,7 @@ async function computeConflicts(repoName, spec) {
 
 app.listen(port, () => {
     log(`Server is running at http://localhost:${port}`, accessLogStream);
+    if (fixtureSource) {
+        log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
+    }
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {
+    "start": "node index.mjs",
+    "start:fixtures": "node index.mjs --fixtures",
     "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "version",
-  "version": "2.1.0",
-  "releaseDate": "2026-08-12",
+  "version": "2.2.0",
+  "releaseDate": "2026-09-05",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "releaseDate": "2026-09-05",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -1,9 +1,20 @@
-import { updateAllCounters } from './counter-utils.js';
+import { updateCounterDisplay } from './counter-utils.js';
 
-let currentApiResult = null;
+/**
+ * Filtering of the rendered pull-request tree.
+ *
+ * The data needed by the filters is indexed once per data load
+ * (buildFilterIndex), and every filter pass is a single walk of the rendered
+ * tree: each pull request is visited exactly once, its visibility and
+ * attention are decided from the index, and the counters of its ancestors are
+ * summed on the way back up. Nothing here searches arrays or the DOM per
+ * pull request, so a pass costs the same on a flat list and on a deep stack.
+ */
+
+let filterIndex = null;
 
 export function initializeFilter(apiResult) {
-    currentApiResult = apiResult;
+    filterIndex = buildFilterIndex(apiResult);
 }
 
 /**
@@ -43,11 +54,80 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
     return { assignee, reviewer, any: assignee || reviewer };
 }
 
-function getLinkedIssues(pullRequestData) {
-    const keys = currentApiResult.jiraIssuesMap[pullRequestData.id] || [];
-    return keys
-        .map(key => currentApiResult.jiraIssuesDetails.find(issue => issue.key === key))
-        .filter(issue => issue);
+/**
+ * Indexes the API result for the filters: one entry per pull request with its
+ * linked issues and the sets the filters compare against. Pure.
+ * @returns {{ pullRequestsById: Map<number, object> }}
+ */
+export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
+    const issuesByKey = new Map(jiraIssuesDetails.map(issue => [issue.key, issue]));
+
+    const sprintsByIssueKey = new Map();
+    for (const [sprintId, issueKeys] of Object.entries(sprintIssues)) {
+        for (const issueKey of issueKeys) {
+            if (!sprintsByIssueKey.has(issueKey)) {
+                sprintsByIssueKey.set(issueKey, new Set());
+            }
+            sprintsByIssueKey.get(issueKey).add(String(sprintId));
+        }
+    }
+
+    const pullRequestsById = new Map();
+    for (const pullRequest of pullRequests) {
+        const issueKeys = jiraIssuesMap[pullRequest.id] || [];
+        const linkedIssues = issueKeys.map(key => issuesByKey.get(key)).filter(issue => issue);
+        const entry = {
+            pullRequest,
+            linkedIssues,
+            assignees: new Set(linkedIssues
+                .filter(issue => issue.fields.assignee && issue.fields.assignee.displayName)
+                .map(issue => issue.fields.assignee.displayName)),
+            reviewers: new Set(pullRequest.participants
+                .filter(participant => participant.user.uuid !== pullRequest.author.uuid)
+                .map(participant => participant.user.display_name)),
+            sprints: new Set(issueKeys.flatMap(key => [...(sprintsByIssueKey.get(key) || [])])),
+            fixVersions: new Set(linkedIssues
+                .flatMap(issue => issue.fields.fixVersions || [])
+                .map(version => String(version.id)))
+        };
+        pullRequestsById.set(pullRequest.id, entry);
+    }
+
+    return { pullRequestsById };
+}
+
+/**
+ * Applies the filters to one indexed pull request. Pure.
+ * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
+ * @param {object} filters - { assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} rendered - what the tree shows for this pull request:
+ *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
+ * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
+ */
+export function evaluatePullRequest(entry, { assignees, reviewers, sprints, fixVersions, sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+    const attention = computeAttention(entry.pullRequest, {
+        statusInProgress,
+        statusInReview,
+        linkedIssues: entry.linkedIssues,
+        assignees,
+        reviewers
+    });
+
+    // Empty selection = show all; otherwise match ANY selected value
+    const assigneeMatch = assignees.length === 0 || assignees.some(name => entry.assignees.has(name));
+    const reviewerMatch = reviewers.length === 0 || reviewers.some(name => entry.reviewers.has(name));
+    const sprintMatch = sprints.length === 0 || sprints.some(sprintId => entry.sprints.has(String(sprintId)));
+    const fixVersionMatch = fixVersions.length === 0 || fixVersions.some(versionId => entry.fixVersions.has(String(versionId)));
+    const syncMatch = sync === 'Show all' ||
+        (sync === 'requested' && hasSyncLabel) ||
+        (sync === 'OK' && !hasSyncLabel);
+    // Ready for reviewer: in review, and a selected reviewer has not approved yet
+    const readyMatch = !ready || attention.reviewer;
+
+    return {
+        visible: assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch,
+        attention
+    };
 }
 
 /**
@@ -55,132 +135,101 @@ function getLinkedIssues(pullRequestData) {
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(assignees, reviewers, sprints, fixVersions, sync, ready) {
-    // Start filtering from the root branches
-    let rootBranches = document.getElementsByClassName("root-branch");
-    Array.from(rootBranches).forEach(rootBranch => {
-        filterBranch(rootBranch, assignees, reviewers, sprints, fixVersions, sync, ready);
-    });
+    const filters = { assignees, reviewers, sprints, fixVersions, sync, ready };
+    const pass = {
+        filters,
+        index: filterIndex || buildFilterIndex({}),
+        // The SYNC filter relies on the rendered badges: collect them once
+        pullRequestsWithSyncLabel: new Set(
+            Array.from(document.querySelectorAll('.pull-request .conflicts-count'))
+                .map(badge => badge.closest('.pull-request'))
+                .filter(pullRequest => pullRequest)
+                .map(pullRequest => pullRequest.dataset.id)
+        ),
+        shownAttention: 0
+    };
 
-    // Update all counters after filtering
-    // Pass first selected values for backwards compatibility with counter-utils
-    const assignee = assignees.length > 0 ? assignees[0] : "Show all";
-    const reviewer = reviewers.length > 0 ? reviewers[0] : "Show all";
-    const sprint = sprints.length > 0 ? sprints[0] : "Show all";
-    updateAllCounters(assignee, reviewer, sprint, sync);
+    for (const repository of document.querySelectorAll('.repository')) {
+        let repositoryTotal = 0;
+        let repositoryVisible = 0;
+        for (const rootBranch of repository.querySelectorAll('.root-branch')) {
+            const content = rootBranch.querySelector('.root-branch-content');
+            const counts = content ? filterChildren(content, pass) : { total: 0, visible: 0 };
+            repositoryTotal += counts.total;
+            repositoryVisible += counts.visible;
 
-    return countShownAttention();
-}
-
-function countShownAttention() {
-    return Array.from(document.querySelectorAll('.pull-request.needs-attention'))
-        .filter(pr => pr.style.display !== 'none' && !pr.classList.contains('filtered'))
-        .length;
-}
-
-function filterBranch(branch, assignees, reviewers, sprints, fixVersions, sync, ready) {
-    let pullRequests = branch.querySelectorAll(".pull-request");
-    let visiblePullRequests = 0;
-
-    // Filter pull requests from bottom to top
-    visiblePullRequests += filterPullRequests(pullRequests, assignees, reviewers, sprints, fixVersions, sync, ready);
-
-    // Hide branch if no visible pull requests
-    branch.style.display = visiblePullRequests > 0 ? "" : "none";
-
-    return visiblePullRequests;
-}
-
-function filterPullRequests(pullRequests, assignees, reviewers, sprints, fixVersions, sync, ready) {
-    let visiblePullRequests = 0;
-    for (let i = 0; i < pullRequests.length; i++) {
-        let pr = pullRequests[i];
-        let prId = pr.dataset.id;
-        let pullRequestData = currentApiResult.pullRequests.find(p => p.id === parseInt(prId));
-
-        let visibleChildren = 0;
-
-        // Check if this pull request has children
-        let childrenContainer = pr.nextElementSibling;
-        if (childrenContainer && childrenContainer.classList.contains('children')) {
-            // If it has children, check if any of them are visible
-            let childrenPullRequests = childrenContainer.querySelectorAll(".pull-request");
-            visibleChildren += filterPullRequests(childrenPullRequests, assignees, reviewers, sprints, fixVersions, sync, ready);
-            visiblePullRequests += visibleChildren;
+            // Hide branch if no visible pull requests
+            setDisplay(rootBranch, counts.visible > 0 ? '' : 'none');
+            const counter = rootBranch.querySelector('.branch-pr-counter');
+            if (counter) updateCounterDisplay(counter, counts.visible, counts.total);
         }
+        const counter = repository.querySelector('.repo-pr-counter');
+        if (counter) updateCounterDisplay(counter, repositoryVisible, repositoryTotal);
+    }
 
+    return pass.shownAttention;
+}
+
+// Filters the pull requests that are direct children of a container (a root
+// branch content or a .children element), recursing into their own children.
+// Returns the counts of the whole subtree.
+function filterChildren(container, pass) {
+    let total = 0;
+    let visible = 0;
+    for (let child = container.firstElementChild; child; child = child.nextElementSibling) {
+        if (!child.classList.contains('pull-request')) {
+            continue;
+        }
+        const counts = filterPullRequest(child, pass);
+        total += counts.total;
+        visible += counts.visible;
+    }
+    return { total, visible };
+}
+
+function filterPullRequest(pullRequestElement, pass) {
+    // Children first, so the visibility of a filtered-out parent can depend on them
+    const childrenContainer = pullRequestElement.nextElementSibling;
+    const hasChildren = childrenContainer && childrenContainer.classList.contains('children');
+    const children = hasChildren ? filterChildren(childrenContainer, pass) : { total: 0, visible: 0 };
+
+    const entry = pass.index.pullRequestsById.get(Number(pullRequestElement.dataset.id));
+    let isVisible = false;
+    if (entry) {
         // Attention is computed from data before visibility, so the ready filter never
         // depends on what a previous pass rendered
-        const attention = computeAttention(pullRequestData, {
-            statusInProgress: pr.classList.contains('status-in-progress'),
-            statusInReview: pr.classList.contains('status-in-review'),
-            linkedIssues: getLinkedIssues(pullRequestData),
-            assignees,
-            reviewers
+        const { visible, attention } = evaluatePullRequest(entry, pass.filters, {
+            statusInProgress: pullRequestElement.classList.contains('status-in-progress'),
+            statusInReview: pullRequestElement.classList.contains('status-in-review'),
+            hasSyncLabel: pass.pullRequestsWithSyncLabel.has(pullRequestElement.dataset.id)
         });
-        pr.classList.toggle('needs-attention', attention.any);
-
-        // Check if this pull request should be visible
-        let isVisible = isPullRequestVisible(pr, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready, attention);
-
-        // Update visibility state
-        pr.classList.toggle("filtered", !isVisible);
-        pr.style.display = (!isVisible && visibleChildren === 0) ? "none" : "";
-
-        if (isVisible) {
-            visiblePullRequests++;
+        isVisible = visible;
+        pullRequestElement.classList.toggle('needs-attention', attention.any);
+        if (visible && attention.any) {
+            pass.shownAttention++;
         }
     }
 
-    return visiblePullRequests;
+    // Update visibility state: a filtered-out pull request stays displayed
+    // while one of its descendants is visible
+    pullRequestElement.classList.toggle('filtered', !isVisible);
+    setDisplay(pullRequestElement, (!isVisible && children.visible === 0) ? 'none' : '');
+
+    // The child counter is refreshed only while it is shown (root pull
+    // requests permanently, others while collapsed), like before
+    if (hasChildren) {
+        const childCounter = pullRequestElement.querySelector('.child-counter');
+        if (childCounter && childCounter.classList.contains('visible')) {
+            updateCounterDisplay(childCounter, children.visible, children.total);
+        }
+    }
+
+    return { total: children.total + 1, visible: children.visible + (isVisible ? 1 : 0) };
 }
 
-function isPullRequestVisible(prElement, pullRequestData, assignees, reviewers, sprints, fixVersions, sync, ready, attention) {
-    // Assignee filter - check Jira issue assignees
-    // Empty array = show all (no filtering)
-    // Non-empty = match ANY selected value
-    const assigneeMatch = assignees.length === 0 || (() => {
-        const jiraIssueKeys = currentApiResult.jiraIssuesMap[pullRequestData.id] || [];
-        return jiraIssueKeys.some(issueKey => {
-            const issue = currentApiResult.jiraIssuesDetails.find(i => i.key === issueKey);
-            return issue && issue.fields.assignee && assignees.includes(issue.fields.assignee.displayName);
-        });
-    })();
-
-    // Reviewer filter - match ANY selected reviewer
-    const reviewerMatch = reviewers.length === 0 || pullRequestData.participants.some(p =>
-        p.user.uuid !== pullRequestData.author.uuid && reviewers.includes(p.user.display_name)
-    );
-
-    // Sprint filter - match if ANY linked issue is in ANY selected sprint
-    const sprintMatch = sprints.length === 0 || (
-        currentApiResult.jiraIssuesMap[pullRequestData.id] &&
-        currentApiResult.jiraIssuesMap[pullRequestData.id].some(issueKey =>
-            sprints.some(sprintId =>
-                currentApiResult.sprintIssues[sprintId] && currentApiResult.sprintIssues[sprintId].includes(issueKey)
-            )
-        )
-    );
-
-    // Fix Version filter - match if ANY linked issue has ANY selected fix version
-    const fixVersionMatch = fixVersions.length === 0 || (
-        currentApiResult.jiraIssuesMap[pullRequestData.id] &&
-        currentApiResult.jiraIssuesMap[pullRequestData.id].some(issueKey => {
-            const issueDetails = currentApiResult.jiraIssuesDetails.find(issue => issue.key === issueKey);
-            return issueDetails && issueDetails.fields.fixVersions &&
-                issueDetails.fields.fixVersions.some(version => fixVersions.includes(String(version.id)));
-        })
-    );
-
-    // Sync filter
-    const syncCounter = prElement.querySelector('.conflicts-counter');
-    const syncCountElement = syncCounter ? syncCounter.querySelector('.conflicts-count') : null;
-    const hasSyncLabel = syncCountElement !== null;
-    const syncMatch = sync === "Show all" ||
-        (sync === "requested" && hasSyncLabel) ||
-        (sync === "OK" && !hasSyncLabel);
-
-    // Ready for reviewer filter: in review, and a selected reviewer has not approved yet
-    const readyMatch = !ready || attention.reviewer;
-
-    return assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch;
+// Only touches the style when it changes, to keep style invalidation minimal
+function setDisplay(element, value) {
+    if (element.style.display !== value) {
+        element.style.display = value;
+    }
 }

--- a/public/counter-utils.js
+++ b/public/counter-utils.js
@@ -1,101 +1,24 @@
 /**
- * Updates all pull request counters in the UI to show filtered/total counts
- * @param {string} assignee - Selected assignee filter
- * @param {string} reviewer - Selected reviewer filter
- * @param {string} sprint - Selected sprint filter
- */
-export function updateAllCounters(assignee, reviewer, sprint) {
-    // Update repository counters
-    const repositories = document.querySelectorAll('.repository');
-    repositories.forEach(repo => updateRepositoryCounter(repo, assignee, reviewer, sprint));
-
-    // Update branch counters
-    const branches = document.querySelectorAll('.root-branch');
-    branches.forEach(branch => updateBranchCounter(branch, assignee, reviewer, sprint));
-
-    // Update pull request child counters
-    const pullRequests = document.querySelectorAll('.pull-request');
-    pullRequests.forEach(pr => updatePullRequestCounter(pr, assignee, reviewer, sprint));
-}
-
-/**
- * Updates the counter for a repository
- * @param {Element} repository - Repository DOM element
- * @param {string} assignee - Selected assignee filter
- * @param {string} reviewer - Selected reviewer filter
- * @param {string} sprint - Selected sprint filter
- */
-function updateRepositoryCounter(repository, assignee, reviewer, sprint) {
-    const counter = repository.querySelector('.repo-pr-counter');
-    if (!counter) return;
-
-    const pullRequests = repository.querySelectorAll('.pull-request');
-    const totalCount = pullRequests.length;
-    const visibleCount = Array.from(pullRequests).filter(pr =>
-        pr.style.display !== 'none' && !pr.classList.contains('filtered')
-    ).length;
-
-    updateCounterDisplay(counter, visibleCount, totalCount);
-}
-
-/**
- * Updates the counter for a branch
- * @param {Element} branch - Branch DOM element
- * @param {string} assignee - Selected assignee filter
- * @param {string} reviewer - Selected reviewer filter
- * @param {string} sprint - Selected sprint filter
- */
-function updateBranchCounter(branch, assignee, reviewer, sprint) {
-    const counter = branch.querySelector('.branch-pr-counter');
-    if (!counter) return;
-
-    const pullRequests = branch.querySelectorAll('.pull-request');
-    const totalCount = pullRequests.length;
-    const visibleCount = Array.from(pullRequests).filter(pr =>
-        pr.style.display !== 'none' && !pr.classList.contains('filtered')
-    ).length;
-
-    updateCounterDisplay(counter, visibleCount, totalCount);
-}
-
-/**
- * Updates the counter for a pull request's children
- * @param {Element} pullRequest - Pull request DOM element
- * @param {string} assignee - Selected assignee filter
- * @param {string} reviewer - Selected reviewer filter
- * @param {string} sprint - Selected sprint filter
- */
-function updatePullRequestCounter(pullRequest, assignee, reviewer, sprint) {
-    const counter = pullRequest.querySelector('.child-counter');
-    if (!counter || !counter.classList.contains('visible')) return;
-
-    const children = pullRequest.nextElementSibling;
-    if (!children || !children.classList.contains('children')) return;
-
-    const childPullRequests = children.querySelectorAll('.pull-request');
-    const totalCount = childPullRequests.length;
-    const visibleCount = Array.from(childPullRequests).filter(pr =>
-        pr.style.display !== 'none' && !pr.classList.contains('filtered')
-    ).length;
-
-    updateCounterDisplay(counter, visibleCount, totalCount);
-}
-
-/**
- * Updates the display of a counter element
+ * Updates the display of a filtered/total counter (repository, root branch or
+ * pull-request child counter). The counts themselves are computed by the
+ * filter pass in app-filter.js, in the same walk that decides visibility.
  * @param {Element} counterElement - Counter DOM element
- * @param {number} visibleCount - Number of visible/filtered items
- * @param {number} totalCount - Total number of items
+ * @param {number} visibleCount - Number of pull requests left visible by the filters
+ * @param {number} totalCount - Total number of pull requests
  */
-function updateCounterDisplay(counterElement, visibleCount, totalCount) {
+export function updateCounterDisplay(counterElement, visibleCount, totalCount) {
     const isFiltered = visibleCount !== totalCount;
     const displayText = isFiltered ? `${visibleCount}/${totalCount}` : `${totalCount}`;
-    counterElement.textContent = displayText;
+    if (counterElement.textContent !== displayText) {
+        counterElement.textContent = displayText;
+    }
 
     // Update the title attribute for tooltip
     const itemText = totalCount === 1 ? 'pull request' : 'pull requests';
     const titleText = isFiltered
         ? `${visibleCount} filtered ${itemText} out of ${totalCount} total`
         : `${totalCount} ${itemText}`;
-    counterElement.setAttribute('title', titleText);
+    if (counterElement.getAttribute('title') !== titleText) {
+        counterElement.setAttribute('title', titleText);
+    }
 }

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -77,3 +77,83 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ ...defaults, sync: 'requested' }), 1);
     assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
 });
+
+// ------------------------------------------------------------------ index and evaluation
+
+import { buildFilterIndex, evaluatePullRequest } from '../public/app-filter.js';
+
+const sampleApiResult = {
+    pullRequests: [
+        { id: 10, author, participants: [{ user: author, approved: false }, { user: jane, approved: false }, { user: bob, approved: true }] },
+        { id: 11, author, participants: [{ user: author, approved: false }] }
+    ],
+    jiraIssuesMap: { 10: ['PROJ-1', 'PROJ-2', 'PROJ-404'], 11: [] },
+    jiraIssuesDetails: [
+        { key: 'PROJ-1', fields: { assignee: { displayName: 'Jane' }, fixVersions: [{ id: 100, name: '1.0' }] } },
+        { key: 'PROJ-2', fields: { assignee: null, fixVersions: [] } }
+    ],
+    sprintIssues: { 5240: ['PROJ-2', 'PROJ-9'], 5241: ['PROJ-9'] }
+};
+
+const rendered = { statusInProgress: false, statusInReview: true, hasSyncLabel: false };
+const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+
+test('buildFilterIndex links issues, assignees, reviewers, sprints and fix versions per pull request', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    assert.deepEqual(entry.linkedIssues.map(issue => issue.key), ['PROJ-1', 'PROJ-2']); // PROJ-404 is unknown
+    assert.deepEqual([...entry.assignees], ['Jane']);
+    assert.deepEqual([...entry.reviewers], ['Jane', 'Bob']); // the author is not a reviewer
+    assert.deepEqual([...entry.sprints], ['5240']);
+    assert.deepEqual([...entry.fixVersions], ['100']);
+    const bare = pullRequestsById.get(11);
+    assert.equal(bare.linkedIssues.length, 0);
+    assert.equal(bare.reviewers.size, 0);
+});
+
+test('buildFilterIndex tolerates an empty result', () => {
+    assert.equal(buildFilterIndex({}).pullRequestsById.size, 0);
+});
+
+test('evaluatePullRequest shows everything without filters', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    assert.equal(evaluatePullRequest(pullRequestsById.get(10), noFilter, rendered).visible, true);
+    assert.equal(evaluatePullRequest(pullRequestsById.get(11), noFilter, rendered).visible, true);
+});
+
+test('evaluatePullRequest matches any selected value of each filter, and every filter must match', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    const evaluate = filters => evaluatePullRequest(entry, { ...noFilter, ...filters }, rendered).visible;
+    assert.equal(evaluate({ assignees: ['Bob', 'Jane'] }), true);
+    assert.equal(evaluate({ assignees: ['Bob'] }), false);
+    assert.equal(evaluate({ reviewers: ['Bob'] }), true);
+    assert.equal(evaluate({ reviewers: ['Author'] }), false);
+    assert.equal(evaluate({ sprints: ['5240'] }), true);
+    assert.equal(evaluate({ sprints: [5240] }), true); // ids may come as numbers
+    assert.equal(evaluate({ sprints: ['5241'] }), false);
+    assert.equal(evaluate({ fixVersions: ['100'] }), true);
+    assert.equal(evaluate({ fixVersions: ['200'] }), false);
+    assert.equal(evaluate({ assignees: ['Jane'], reviewers: ['Bob'], sprints: ['5240'], fixVersions: ['100'] }), true);
+    assert.equal(evaluate({ assignees: ['Jane'], sprints: ['5241'] }), false);
+});
+
+test('evaluatePullRequest SYNC filter follows the rendered badge', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    assert.equal(evaluatePullRequest(entry, { ...noFilter, sync: 'requested' }, { ...rendered, hasSyncLabel: true }).visible, true);
+    assert.equal(evaluatePullRequest(entry, { ...noFilter, sync: 'requested' }, { ...rendered, hasSyncLabel: false }).visible, false);
+    assert.equal(evaluatePullRequest(entry, { ...noFilter, sync: 'OK' }, { ...rendered, hasSyncLabel: false }).visible, true);
+    assert.equal(evaluatePullRequest(entry, { ...noFilter, sync: 'OK' }, { ...rendered, hasSyncLabel: true }).visible, false);
+});
+
+test('evaluatePullRequest ready filter keeps pull requests with reviewer attention only', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    const jane = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Jane'], ready: true }, rendered);
+    assert.equal(jane.visible, true);
+    assert.equal(jane.attention.reviewer, true);
+    const bobApproved = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Bob'], ready: true }, rendered);
+    assert.equal(bobApproved.visible, false);
+    assert.equal(bobApproved.attention.any, false);
+});

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -1,0 +1,152 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'module';
+import { generateProjectData, generateSyncStatuses, repositoryVolumes } from '../fixtures/generate.mjs';
+import { parseFixtureOptions, fixtureConfig, createFixtureSource } from '../fixtures/index.mjs';
+
+const projects = createRequire(import.meta.url)('../projects.js');
+
+function countByRepository(data) {
+    const counts = {};
+    for (const pullRequest of data.pullRequests) {
+        const name = pullRequest.source.repository.name;
+        counts[name] = (counts[name] || 0) + 1;
+    }
+    return counts;
+}
+
+test('SECOLLAB has the real-world volumes: 112 pull requests over 4 repositories, 7 sprints, 13 orphaned issues', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    assert.equal(data.pullRequests.length, 112);
+    assert.deepEqual(countByRepository(data), { 'products.secollab': 100, 'products.secollab.client': 2, 'products.web.oslc': 10 });
+    assert.equal(data.sprints.length, 7);
+    assert.equal(data.sprintIssues['5240'].length, 100);
+    assert.equal(data.sprintIssues['5307'].length, 0);
+    assert.equal(data.orphanedIssues.length, 13);
+    assert.ok(data.jiraIssuesDetails.length >= 100);
+});
+
+test('OSLC has the real-world volumes: 24 pull requests over 3 repositories, no orphaned issue', () => {
+    const data = generateProjectData('OSLC', projects.OSLC);
+    assert.equal(data.pullRequests.length, 24);
+    assert.deepEqual(countByRepository(data), { 'products.web.oslc': 10, 'products.web.common': 5, 'products.oslc': 9 });
+    assert.equal(data.orphanedIssues.length, 0);
+});
+
+test('generation is deterministic: same dataHash on every call', () => {
+    const first = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const second = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    assert.equal(first.dataHash, second.dataHash);
+});
+
+test('a repository shared by two projects yields the same pull requests in both', () => {
+    const secollab = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const oslc = generateProjectData('OSLC', projects.OSLC);
+    const ids = data => data.pullRequests.filter(pr => pr.source.repository.name === 'products.web.oslc').map(pr => pr.id);
+    assert.deepEqual(ids(secollab), ids(oslc));
+});
+
+test('every pull request is in the response shape the frontend reads', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    for (const pr of data.pullRequests) {
+        assert.equal(typeof pr.id, 'number');
+        assert.ok(pr.source.branch.name && pr.destination.branch.name);
+        assert.ok(pr.source.commit.hash && pr.destination.commit.hash);
+        assert.ok(pr.source.repository.links.html.href.startsWith('https://bitbucket.org/'));
+        assert.ok(pr.author.uuid && pr.author.account_id && pr.author.links.avatar.href);
+        assert.ok(pr.participants.length >= 1);
+        assert.equal(typeof pr.rendered.title.html, 'string');
+        assert.equal(typeof pr.rendered.description.html, 'string');
+        assert.ok(Array.isArray(data.jiraIssuesMap[pr.id]));
+    }
+    for (const issue of data.jiraIssuesDetails) {
+        assert.match(issue.key, /^(SECOLLAB|PRDOSLC|WEBCMN)-\d+$/);
+        assert.ok(Array.isArray(issue.fields.fixVersions));
+    }
+    const keys = data.jiraIssuesDetails.map(issue => issue.key);
+    assert.equal(new Set(keys).size, keys.length, 'issue keys are unique');
+});
+
+function deepestStack(data) {
+    const byDestination = data.pullRequestsByDestination;
+    const depth = pr => {
+        const children = byDestination[pr.source.branch.name];
+        return children ? 1 + Math.max(...children.map(depth)) : 1;
+    };
+    const roots = data.pullRequests.filter(pr => !data.pullRequests.some(other => other.source.branch.name === pr.destination.branch.name));
+    return Math.max(...roots.map(depth));
+}
+
+test('SECOLLAB carries the real 24-deep stack of pull requests under feat/ai_investigations', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    assert.equal(deepestStack(data), 24);
+    assert.equal(data.pullRequestsByDestination['feat/ai_investigations'].length, 1);
+    const chainRepo = data.pullRequests.filter(pr => pr.source.branch.name === 'ai-mcp-tool-layer');
+    assert.equal(chainRepo[0].source.repository.name, 'products.secollab');
+});
+
+test('the chain depth option shortens the deepest stack', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB, { chainDepth: 8 });
+    assert.equal(deepestStack(data), 8);
+    assert.equal(data.pullRequests.length, 112);
+});
+
+test('SECollab branches follow the INITIALS_YYMMDD_KEY_Slug convention most of the time', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const secollab = data.pullRequests.filter(pr => pr.source.repository.name === 'products.secollab');
+    const conventional = secollab.filter(pr => /^[A-Z]{2,4}_\d{6}_[A-Z]+-\d+_/.test(pr.source.branch.name));
+    assert.ok(conventional.length > secollab.length / 2, `${conventional.length} of ${secollab.length}`);
+});
+
+test('the scale factor multiplies the volumes', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB, { scale: 3 });
+    assert.equal(data.pullRequests.length, Object.values(repositoryVolumes).slice(0, 3).reduce((a, b) => a + b, 0) * 3 + 30);
+    assert.equal(data.sprintIssues['5240'].length, 300);
+    assert.equal(data.orphanedIssues.length, 39);
+});
+
+test('sync statuses cover every pull request with a conflicts or error flag', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const sync = generateSyncStatuses(data);
+    assert.equal(Object.keys(sync.statuses).length, data.pullRequests.length);
+    assert.equal(sync.rateLimited, false);
+    for (const status of Object.values(sync.statuses)) {
+        assert.ok(status.error === true || typeof status.conflicts === 'boolean');
+    }
+});
+
+test('fixture options come from the command line or the environment', () => {
+    assert.deepEqual(parseFixtureOptions(['node', 'index.mjs'], {}), { enabled: false, scale: 1, chainDepth: 24 });
+    assert.deepEqual(parseFixtureOptions(['node', 'index.mjs', '--fixtures'], {}), { enabled: true, scale: 1, chainDepth: 24 });
+    assert.deepEqual(parseFixtureOptions(['node', 'index.mjs', '--fixtures', '--fixture-scale=2.5', '--fixture-chain-depth=8'], {}), { enabled: true, scale: 2.5, chainDepth: 8 });
+    assert.deepEqual(parseFixtureOptions([], { PR_TREE_FIXTURES: '1', PR_TREE_FIXTURE_SCALE: '4', PR_TREE_FIXTURE_CHAIN_DEPTH: '12' }), { enabled: true, scale: 4, chainDepth: 12 });
+    assert.deepEqual(parseFixtureOptions(['--fixtures', '--fixture-scale=abc'], {}), { enabled: true, scale: 1, chainDepth: 24 });
+});
+
+test('the fixture source serves both configured projects and refreshes lastRefreshTime', async () => {
+    const source = createFixtureSource(fixtureConfig());
+    const first = await source.buildProjectData('SECOLLAB');
+    const second = await source.buildProjectData('SECOLLAB');
+    assert.equal(first.dataHash, second.dataHash);
+    assert.ok(second.lastRefreshTime >= first.lastRefreshTime);
+    assert.equal((await source.buildProjectData('OSLC')).pullRequests.length, 24);
+    await assert.rejects(source.buildProjectData('NOPE'), /Project not found/);
+    assert.equal(Object.keys((await source.buildSyncStatuses('OSLC')).statuses).length, 24);
+});
+
+import { buildFilterIndex, evaluatePullRequest } from '../public/app-filter.js';
+
+test('the filter index built on the SECOLLAB fixture links every pull request', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const { pullRequestsById } = buildFilterIndex(data);
+    assert.equal(pullRequestsById.size, data.pullRequests.length);
+    const withIssues = [...pullRequestsById.values()].filter(entry => entry.linkedIssues.length > 0);
+    assert.ok(withIssues.length > data.pullRequests.length * 0.8);
+    const inSprint = [...pullRequestsById.values()].filter(entry => entry.sprints.size > 0);
+    assert.ok(inSprint.length > 10, `${inSprint.length} pull requests in a sprint`);
+    const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+    const rendered = { statusInProgress: false, statusInReview: false, hasSyncLabel: false };
+    for (const entry of pullRequestsById.values()) {
+        assert.equal(evaluatePullRequest(entry, noFilter, rendered).visible, true);
+    }
+});


### PR DESCRIPTION
Filtering on SECOLLAB was slow because of the tree shape, not the volume. `filterBranch` selected every descendant pull request of a root branch and then recursed into each `.children` container selecting every descendant again, so a pull request at depth *d* was visited 2^d times. SECOLLAB carries a 24-deep stack of 26 pull requests under `feat/ai_investigations`: about 16.8 million visits, each with an `Array.find` over the pull requests, per filter change.

## Changes

- **Single-pass filtering** (`public/app-filter.js`): a filter index is built once per data load (`buildFilterIndex`, pure) with the linked issues and the assignee, reviewer, sprint and fix-version sets of each pull request; `evaluatePullRequest` (pure) decides visibility and attention; `filterBranches` walks direct children only, so each pull request is visited once, sums the counters on the way back up and writes to the DOM only when a value changes. `counter-utils.js` keeps the display helper only. Filter semantics are unchanged.
- **Fixture mode** (`fixtures/`, `npm run start:fixtures` or `node index.mjs --fixtures`): both projects are served from a deterministic generator modelled on the real SECOLLAB and OSLC projects (same repositories, Jira projects, volumes, branch naming convention, sprints, fix versions, participants, orphaned issues and the 24-deep stack; people are fictional). No `config.js` and no network needed; the SYNC load answers from the fixtures too and `atlassianFetch` refuses to send anything. `--fixture-scale=N` and `--fixture-chain-depth=N` (or `PR_TREE_FIXTURE_*` variables) tune it.
- **Tests**: `npm test` now has 31 tests, covering the generator (volumes, determinism, shared repository, deep stack, options, response shape) and the pure filter logic.
- Docs and version 2.3.0.

## Measurements

Filter change (one multi-select checkbox), JavaScript time in the browser, SECOLLAB fixture with 112 pull requests:

| Deepest stack | Before | After |
|---|---|---|
| 16 | 80 ms | 0.5 ms |
| 20 | 1181 ms | 0.5 ms |
| 24 (real SECOLLAB) | ~19 s (extrapolated, doubles per level) | 0.5 ms (7 ms with style and layout) |

The SYNC filter takes about 1 ms after loading the statuses.

## Verification

- Compared the new pass against an independent reimplementation of the old rules on every pull request (`filtered` class, `display`, repository counter) for six filter combinations: assignee, assignee + sprint, sprint + fix version, reviewer, reviewer + ready, cleared. Zero mismatches.
- Checked in the browser: tab title attention count, active-filter badge, child/branch/repository counters, filtered ancestors kept visible above visible descendants, SYNC load and filter from fixtures, both projects.
- Real-data structure came from the running local server (`/api/pull-requests/SECOLLAB`): 100/2/0/10 pull requests per repository, 62 root pull requests, longest chain 24, 4 KB average rendered description.

## Noted, not changed

`pullRequestsByDestination` is keyed by branch name across repositories, so two repositories sharing a branch name (`master` in three of them) share the entry. Bitbucket pull-request ids are also per repository, so a collision across repositories is possible in `jiraIssuesMap` and in the filter index. Neither is new; recorded in CLAUDE.md.

Closes #25
Stacked on #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)