### PR TITLE
feat: epic filter, resolved through sub-tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,14 @@ pr-tree/
 - Periodic refresh logic (2-minute intervals, tab visibility detection)
 - Loading state management
 - Event handlers for user interactions
+- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select from the index and returns the selection restricted to the offered keys
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against and the epic keys (`epics`), plus `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`); it also returns `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
 - `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
-- `parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters` (pure)
+- `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
 - `updateCounterDisplay(element, visible, total)`: the `n/total` text and tooltip of a counter; the counts come from the filter pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Multi-project support with dropdown selection
 - Pull request visualization ordered by most recently updated
 - Jira issue integration with status tracking
-- Advanced filtering (author, reviewer, sprint, sync status)
+- Advanced filtering (text, sprint, fix version, assignee, reviewer, sync status)
 - Real-time conflict detection
 - Commit ahead/behind tracking
 - Smart reload (auto-updates every 2 minutes when data changes)
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.3.0** (as of 2026-09-05)
+Current version: **2.4.0** (as of 2026-09-09)
 
 ## Technology Stack
 
@@ -125,10 +125,10 @@ pr-tree/
 - Event handlers for user interactions
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against; built once per data load by `initializeFilter()`
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
-- `filterBranches(...)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
-- `computeAttention`, `countActiveFilters` (pure)
+- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
 - `updateCounterDisplay(element, visible, total)`: the `n/total` text and tooltip of a counter; the counts come from the filter pass
@@ -141,7 +141,7 @@ pr-tree/
 
 **public/app-shell.js**
 - Banner and sidebar chrome, independent of pull-request data
-- Sidebar toggle (button, `F` key), stored in `localStorage` under `prTree.sidebarHidden` for the wide layout; below 900px the sidebar is a drawer that always starts closed
+- Sidebar toggle (button, `F` key), stored in `localStorage` under `prTree.sidebarHidden` for the wide layout; below 900px the sidebar is a drawer that always starts closed; `/` shows the sidebar and focuses the search box; Escape is left to a text box that has content (it clears itself)
 - Theme toggle, stored under `prTree.theme`; the OS setting is followed until a choice is stored; an inline script in `index.html` applies both before the first paint
 - Help modal, active-filter badge, tree toolbar (collapse all / expand all), document title (`(attention) PROJECT · Bitbucket Pull-Requests Tree`)
 - No DOM access at import time, so its pure helpers are unit-tested
@@ -282,6 +282,7 @@ log(message, logStream);  // Logs to both console and file
 State is managed through module-level variables in app.js:
 ```javascript
 let currentProject = null;
+let currentText = '';          // text filter
 let currentSprints = [];        // sprint ids
 let currentFixVersions = [];    // fix version ids
 let currentAssignees = [];
@@ -294,10 +295,10 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&author=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
+?project=PROJ&q=banner&author=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
 ```
 
-Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches()` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL.
+Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
 
 ### Filtering Architecture
 Single pass in app-filter.js:
@@ -479,9 +480,10 @@ Three streams available:
 7. **Ready for reviewer**: computed by `computeAttention()` from the data, never from rendered styles
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
+10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&author=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Multi-project support with dropdown selection
 - Pull request visualization ordered by most recently updated
 - Jira issue integration with status tracking
-- Advanced filtering (text, sprint, fix version, assignee, reviewer, sync status)
+- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)
 - Real-time conflict detection
 - Commit ahead/behind tracking
 - Smart reload (auto-updates every 2 minutes when data changes)
@@ -74,6 +74,7 @@ pr-tree/
 - API endpoint definitions (`/api/projects`, `/api/pull-requests/:project`, `/api/pull-request-conflicts/:repoName/:spec`)
 - Bitbucket API integration (fetch PRs, commit diffs)
 - Jira API integration (fetch issues, sprints, orphaned issues)
+- `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
 - Response hashing for change detection
 - Comprehensive logging system (access.log, error.log, performance.log)
 - Static file serving for public directory
@@ -125,9 +126,10 @@ pr-tree/
 - Event handlers for user interactions
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against and the epic keys (`epics`), plus `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
@@ -136,6 +138,7 @@ pr-tree/
 **fixtures/generate.mjs** and **fixtures/index.mjs**
 - `generateProjectData(projectName, projectConfig, { scale, chainDepth })` returns exactly the `/api/pull-requests/:project` response shape; `generateSyncStatuses(projectData)` the `/api/sync-statuses/:project` one
 - Volumes and structure follow the real projects (see the constants at the top of generate.mjs), including the 24-deep stack of `products.secollab` under `feat/ai_investigations` that made the old filtering explode
+- Epics per Jira project (`epicSummaries`, keys in numbering block 8): 40% of the standard issues have an epic parent, parents of sub-tasks are standard issues, parent-only entries carry summary, type, fix versions and parent like the server's
 - Seeded PRNG: the same repository always yields the same pull requests, so `dataHash` is stable and the smart reload stays quiet
 - `parseFixtureOptions()` reads `--fixtures`, `--fixture-scale=N`, `--fixture-chain-depth=N` or the `PR_TREE_FIXTURES*` environment variables; `fixtureConfig()` replaces config.js; `createFixtureSource()` is what index.mjs calls instead of Atlassian
 
@@ -285,6 +288,7 @@ let currentProject = null;
 let currentText = '';          // text filter
 let currentSprints = [];        // sprint ids
 let currentFixVersions = [];    // fix version ids
+let currentEpics = [];         // epic keys
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -295,7 +299,7 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&sync=requested&ready=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
@@ -481,9 +485,10 @@ Three streams available:
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
+11. **Jira hierarchy**: only `issueLevel`/`epicOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/PRD.md
+++ b/PRD.md
@@ -144,6 +144,7 @@ Development teams using Bitbucket and Jira face several workflow inefficiencies:
 - F3.5: Provide direct links to Jira issues
 - F3.6: Detect orphaned issues (In Review status without PRs)
 - F3.7: Support Jira workflow integration with "In Review" and "In Progress" statuses
+- F3.8: Fetch the parent of linked issues, and the summary, type and parent of parent issues, so that sub-tasks reach their story and epic
 
 **Workflow Context:**
 The application integrates with a Jira workflow where:
@@ -178,6 +179,7 @@ The application integrates with a Jira workflow where:
 - F4.8: Maintain filter state in URL parameters
 - F4.9: Hierarchical filtering (preserve parent-child relationships)
 - F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
+- F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
@@ -477,6 +479,7 @@ The application integrates with a Jira workflow where:
 |  Search        |                                                 |
 |  Sprint        | Repository 1                          [X / Y]   |
 |  Fix version   |   Branch A                            [X / Y]   |
+|  Epic          |                                                 |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
 |  Reviewer      |       JIRA-123 [In Progress]                    |
 |  Ready         |     PR #2                                       |

--- a/PRD.md
+++ b/PRD.md
@@ -177,6 +177,7 @@ The application integrates with a Jira workflow where:
 - F4.7: Support simultaneous multiple filters
 - F4.8: Maintain filter state in URL parameters
 - F4.9: Hierarchical filtering (preserve parent-child relationships)
+- F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
@@ -473,6 +474,7 @@ The application integrates with a Jira workflow where:
 | Banner: ☰ | App name | Project ▾ | Last refresh | ☾ | ? | GitHub | v |
 +----------------+-------------------------------------------------+
 | Filters  Clear | [Collapse all] [Expand all]                     |
+|  Search        |                                                 |
 |  Sprint        | Repository 1                          [X / Y]   |
 |  Fix version   |   Branch A                            [X / Y]   |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * Application layout
     * A top banner shows the app name, the project selector, the refresh status, the theme toggle, the help and GitHub links and the version
     * Filters live in a left sidebar that stays in place while the pull-request tree scrolls
-    * The sidebar can be hidden with the banner button or the `F` key; the choice is remembered by the browser
+    * The sidebar can be hidden with the banner button or the `F` key; the choice is remembered by the browser; `/` focuses the search box
     * On windows narrower than 900px the sidebar becomes a drawer over the tree
     * The badge on the sidebar button shows how many filters are active; "Clear filters" resets them all
     * Repository and branch headers stick to the top of the tree while scrolling
@@ -18,6 +18,9 @@
 * Provides initial warnings
     * If the pull request was approved by everyone
     * If the pull request is open but related issues are closed or in review
+* Provides a text filter
+    * Keeps the pull requests whose title, source branch name or linked issue keys contain every word typed (case-insensitive)
+    * `/` focuses the search box, Escape clears it
 * Provides an assignee filter
     * Filters pull requests based on the assignee of associated Jira issues
     * Highlights in red those where an effort is expected
@@ -31,7 +34,7 @@
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, sprint, fixVersion, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, assignee, reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -72,6 +75,9 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.4.0
+    * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
+        * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 * Provides a text filter
     * Keeps the pull requests whose title, source branch name or linked issue keys contain every word typed (case-insensitive)
     * `/` focuses the search box, Escape clears it
+* Provides an epic filter
+    * Keeps the pull requests whose linked issues belong to the selected epics; a pull request linked to a sub-task follows the epic of its parent story
 * Provides an assignee filter
     * Filters pull requests based on the assignee of associated Jira issues
     * Highlights in red those where an effort is expected
@@ -34,7 +36,7 @@
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, text, sprint, fixVersion, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, epic, assignee, reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -78,6 +80,9 @@
 * Version 2.4.0
     * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
         * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean
+    * Epic filter: pull requests of the selected epics, resolved through the parent story when the pull request is linked to a sub-task
+        * The server now fetches the summary, type and parent of parent issues (previously their fix versions only)
+        * Fixture data carries epics
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/docs/superpowers/plans/2026-09-09-text-epic-story-filters.md
+++ b/docs/superpowers/plans/2026-09-09-text-epic-story-filters.md
@@ -1656,11 +1656,13 @@ PR body: the resolution rules (epic itself, epic parent, epic of the parent stor
 
 With the user's `config.js` in place: `PORT=3002 node index.mjs`, then `curl -s http://localhost:3002/api/pull-requests/SECOLLAB > /private/tmp/claude-501/-Users-frej-Sites-pr-tree/fa03c818-2340-4f3b-8fb1-aecd87e2c6a0/scratchpad/secollab-after.json`; stop the server. Parent-only issues (`!fields.status`) now carry `summary`, `issuetype` and, for stories under an epic, `parent`; `buildFilterIndex` on that file yields more entries with a non-empty `epics` set than the 40 counted on 2026-09-09 (up to 56). One request per project only: the real server on port 3000 already polls Atlassian every two minutes.
 
+**Review follow-up (sixth commit, after the code-quality review):** `MultiSelect.escapeHtml()` now escapes quotes too (the option tooltip carries free-text summaries). The option helpers moved to `public/app-filter.js` as an exported, tested `issueOptions(issues)` (with private `compareIssueKeys` / `splitIssueKey`), and `populateEpicFilter` became a generic `populateIssueFilter(elementId, issues, selectedKeys)` in `app.js` that returns the selection restricted to the offered keys: `currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);`. The epic block of `restoreFiltersFromUrl` (a `setSelectedValues` before the options exist) was dropped. Fixtures: the first epic of each project has a fix version; the epic draw is skipped for projects without epics. Task 3 below is written against that code.
+
 ---
 
 ### Task 3: Story filter
 
-A multi-select of the stories delivered by the pull requests: the linked issue itself, or the parent of a linked sub-task. Same wiring as the epic filter.
+A multi-select of the stories delivered by the pull requests: the linked issue itself, or the parent of a linked sub-task. Same wiring as the epic filter, through the generic `populateIssueFilter` and `issueOptions` helpers.
 
 **Files:**
 - Modify: `public/app-filter.js`
@@ -1839,37 +1841,15 @@ c. Add `'storySelect'` to `multiSelectIds` (after `'epicSelect'`) and `'story'` 
 
 d. In `updateUrlWithFilters()`, add `currentStories.forEach(v => url.searchParams.append('story', v));` after the `epic` append.
 
-e. In `restoreFiltersFromUrl()`, add `currentStories = urlParams.getAll('story');` after the `epic` line, and after the `epicMultiSelect` restore block:
-
-```js
-    const storyMultiSelect = getMultiSelect('storySelect');
-    if (storyMultiSelect) {
-        storyMultiSelect.setSelectedValues(currentStories);
-    }
-```
+e. In `restoreFiltersFromUrl()`, add `currentStories = urlParams.getAll('story');` after the `epic` line (nothing else: the selection is applied by `populateIssueFilter` once the options exist).
 
 f. Nothing to change in `handleProjectChange()`.
 
 g. In `readFilterControls()`, add `const storyMultiSelect = getMultiSelect('storySelect');` and `currentStories = storyMultiSelect ? storyMultiSelect.getSelectedValues() : [];` after the epic lines.
 
-h. In `renderEverything()`, add `populateStoryFilter(filterIndex.stories);` right after `populateEpicFilter(filterIndex.epics);`.
+h. In `renderEverything()`, add `currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);` right after the `currentEpics = populateIssueFilter(...)` line.
 
-i. Add after `populateEpicFilter`:
-
-```js
-function populateStoryFilter(stories) {
-    const storyMultiSelect = getMultiSelect('storySelect');
-    if (!storyMultiSelect) return;
-
-    const options = issueOptions(stories);
-    storyMultiSelect.setOptions(options);
-
-    // Keep only the stories that exist in the options (the URL may carry unknown keys)
-    const known = new Set(options.map(option => option.value));
-    currentStories = currentStories.filter(key => known.has(key));
-    storyMultiSelect.setSelectedValues(currentStories);
-}
-```
+i. Nothing to add: `populateIssueFilter` (Task 2) is generic, and `issueOptions` in `app-filter.js` sorts the stories like the epics.
 
 j. Nothing to change in `initializeMultiSelects()`.
 
@@ -1915,7 +1895,7 @@ a. `README.md`:
 b. `CLAUDE.md`:
 
 - Replace `- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)` with `- Advanced filtering (text, sprint, fix version, epic, story, assignee, reviewer, sync status)`.
-- In the `**public/app-filter.js**` block: in the `buildFilterIndex` bullet, replace `the epic keys (`epics`), plus `index.epics`, the epics to list in the filter` with `the epic and story keys (`epics`, `stories`), plus `index.epics` and `index.stories`, the values to list in the two filters`; replace `- `issueLevel`, `epicOf` (pure)` with `- `issueLevel`, `epicOf`, `storyOf` (pure)`.
+- In the `**public/app-filter.js**` block: in the `buildFilterIndex` bullet, mention the story keys (`stories`) next to the epic keys and `index.stories` next to `index.epics`; in the bullet that starts with `- `issueLevel`, `epicOf``, insert `, `storyOf`` after ``epicOf``. In the `**public/app.js**` block, the `populateIssueFilter` bullet gains `(epics and stories)`.
 - In "Frontend State Management", add `let currentStories = [];       // story keys` after `currentEpics`, and `&story=PROJ-200` after `&epic=PROJ-100` in the URL example.
 - In "Common Pitfalls" item 11, replace `only `issueLevel`/`epicOf`` with `only `issueLevel`/`epicOf`/`storyOf``.
 - In "Testing Approach", add `storyOf` to the pure functions.

--- a/fixtures/generate.mjs
+++ b/fixtures/generate.mjs
@@ -3,7 +3,8 @@
  *
  * Volumes, repository names, Jira project keys, branch naming, stacked
  * pull-request chains, sprints and fix versions are modelled on the real
- * SECOLLAB and OSLC projects (September 2026 access logs). People are
+ * SECOLLAB and OSLC projects (September 2026 access logs). Standard issues
+ * belong to epics and sub-tasks to stories, as in Jira Cloud. People are
  * fictional. The same repository always yields the same pull requests, so
  * a repository shared by two projects (products.web.oslc) is consistent.
  *
@@ -297,6 +298,52 @@ function createIssueNumbering(block) {
     };
 }
 
+// Epics per Jira project; about 40% of the standard issues belong to one.
+// Their keys use block 8 of the numbering, which no other generation uses.
+const epicSummaries = {
+    SECOLLAB: [
+        'SECollab AI: assistive capability layer', 'Review workflow overhaul', 'DOORS synchronisation 2.0',
+        'End-to-end tests since 2.7.0', 'Accessibility compliance'
+    ],
+    PRDOSLC: ['OSLC Connect for Windchill 1.5', 'Configuration management support', 'TRS provider'],
+    WEBCMN: ['Design tokens migration', 'Session handling']
+};
+
+function createEpic(project, number, summary) {
+    const key = `${project}-${number}`;
+    return {
+        id: String(10000 + number),
+        key,
+        self: `https://${jiraSiteName}.atlassian.net/rest/api/3/issue/${key}`,
+        fields: {
+            summary,
+            status: { name: 'In Progress', statusCategory: { key: 'indeterminate' } },
+            priority: { name: 'Medium', iconUrl: priorityIconUrl('#e97f33'), id: '3' },
+            fixVersions: [],
+            issuetype: { name: 'Epic', subtask: false, hierarchyLevel: 1 }
+        }
+    };
+}
+
+const epicIssues = Object.fromEntries(Object.entries(epicSummaries).map(([project, summaries]) =>
+    [project, summaries.map((summary, index) => createEpic(project, (issueNumberBase[project] || 100) + 8000 + index + 1, summary))]
+));
+
+// The parent field as Jira returns it: the key and a few inline fields
+function inlineParent(issue) {
+    return {
+        id: issue.id,
+        key: issue.key,
+        self: issue.self,
+        fields: {
+            summary: issue.fields.summary,
+            status: issue.fields.status,
+            priority: issue.fields.priority,
+            issuetype: issue.fields.issuetype
+        }
+    };
+}
+
 function createIssue(random, nextIssueNumber, project, { status, assignee, parent, type } = {}) {
     const key = `${project}-${nextIssueNumber(project)}`;
     const issueType = type || pickWeighted(random, issueTypes);
@@ -305,6 +352,9 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
     // Sub-tasks mostly inherit their fix version from the parent (the server does that too)
     const fixVersions = issueType === 'Sub-task' || random() < 0.25 ? [] : [pick(random, versions)];
     const assigneePerson = assignee === null ? null : (assignee || (random() < 0.85 ? pick(random, team) : null));
+    // Sub-tasks get the parent they were given; standard issues belong to an epic 40% of the time
+    const epics = epicIssues[project] || [];
+    const parentIssue = parent || (issueType !== 'Sub-task' && random() < 0.4 && epics.length > 0 ? pick(random, epics) : null);
     return {
         id: String(10000 + Number(key.split('-')[1])),
         key,
@@ -315,8 +365,8 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
             priority: { name: priorityName, iconUrl: priorityIconUrl(priorityColour), id: String(priorities.findIndex(p => p[0] === priorityName) + 1) },
             fixVersions,
             assignee: assigneePerson ? assigneePerson.jira : null,
-            issuetype: { name: issueType, subtask: issueType === 'Sub-task' },
-            ...(parent ? { parent: { key: parent.key, fields: { summary: parent.fields.summary } } } : {})
+            issuetype: { name: issueType, subtask: issueType === 'Sub-task', hierarchyLevel: issueType === 'Sub-task' ? -1 : 0 },
+            ...(parentIssue ? { parent: inlineParent(parentIssue) } : {})
         }
     };
 }
@@ -434,7 +484,8 @@ export function generateRepository(repoName, { scale = 1, chainDepth = deepChain
             let parent = null;
             if (type === 'Sub-task') {
                 // Half of the parents are only known through the sub-task (fetched separately by the server)
-                parent = random() < 0.5 && issues.length > 0 ? pick(random, issues) : createIssue(random, nextIssueNumber, project, { type: 'Story', status: 'In Progress' });
+                const standardIssues = issues.filter(candidate => !candidate.fields.issuetype.subtask);
+                parent = random() < 0.5 && standardIssues.length > 0 ? pick(random, standardIssues) : createIssue(random, nextIssueNumber, project, { type: 'Story', status: 'In Progress' });
                 if (!issues.includes(parent)) parentIssues.push(parent);
             }
             const issue = createIssue(random, nextIssueNumber, project, { status: j === 0 ? status : (random() < 0.8 ? status : undefined), parent, type });
@@ -544,6 +595,9 @@ export function generateProjectData(projectName, projectConfig, { scale = 1, cha
     const nextIssueNumber = createIssueNumbering(9);
     const pullRequests = [];
     const knownIssues = new Map();
+    for (const epic of Object.values(epicIssues).flat()) {
+        knownIssues.set(epic.key, epic);
+    }
     for (const repoName of projectConfig.repositories) {
         const data = repositoryData(repoName, { scale, chainDepth });
         pullRequests.push(...data.pullRequests);
@@ -569,13 +623,24 @@ export function generateProjectData(projectName, projectConfig, { scale = 1, cha
             jiraIssuesDetails.push(structuredClone(issue));
         }
     }
-    // Parents of sub-tasks are fetched by the server with their fix versions only
+    // Parents (stories of sub-tasks, epics of standard issues) are fetched by the
+    // server with their summary, type, fix versions and parent
     for (const issue of [...jiraIssuesDetails]) {
         const parentKey = issue.fields.parent?.key;
         if (parentKey && !seen.has(parentKey) && knownIssues.has(parentKey)) {
             seen.add(parentKey);
             const parent = knownIssues.get(parentKey);
-            jiraIssuesDetails.push({ id: parent.id, key: parent.key, self: parent.self, fields: { fixVersions: parent.fields.fixVersions } });
+            jiraIssuesDetails.push({
+                id: parent.id,
+                key: parent.key,
+                self: parent.self,
+                fields: {
+                    summary: parent.fields.summary,
+                    issuetype: parent.fields.issuetype,
+                    fixVersions: parent.fields.fixVersions,
+                    ...(parent.fields.parent ? { parent: parent.fields.parent } : {})
+                }
+            });
         }
     }
     // Sub-tasks inherit the fix versions of their parent

--- a/fixtures/generate.mjs
+++ b/fixtures/generate.mjs
@@ -309,7 +309,7 @@ const epicSummaries = {
     WEBCMN: ['Design tokens migration', 'Session handling']
 };
 
-function createEpic(project, number, summary) {
+function createEpic(project, number, summary, fixVersions) {
     const key = `${project}-${number}`;
     return {
         id: String(10000 + number),
@@ -319,14 +319,20 @@ function createEpic(project, number, summary) {
             summary,
             status: { name: 'In Progress', statusCategory: { key: 'indeterminate' } },
             priority: { name: 'Medium', iconUrl: priorityIconUrl('#e97f33'), id: '3' },
-            fixVersions: [],
+            fixVersions,
             issuetype: { name: 'Epic', subtask: false, hierarchyLevel: 1 }
         }
     };
 }
 
+// The first epic of a project has a fix version, so issues inherit one from their epic
 const epicIssues = Object.fromEntries(Object.entries(epicSummaries).map(([project, summaries]) =>
-    [project, summaries.map((summary, index) => createEpic(project, (issueNumberBase[project] || 100) + 8000 + index + 1, summary))]
+    [project, summaries.map((summary, index) => createEpic(
+        project,
+        (issueNumberBase[project] || 100) + 8000 + index + 1,
+        summary,
+        index === 0 ? (fixVersionsByProject[project] || []).slice(0, 1) : []
+    ))]
 ));
 
 // The parent field as Jira returns it: the key and a few inline fields
@@ -354,7 +360,7 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
     const assigneePerson = assignee === null ? null : (assignee || (random() < 0.85 ? pick(random, team) : null));
     // Sub-tasks get the parent they were given; standard issues belong to an epic 40% of the time
     const epics = epicIssues[project] || [];
-    const parentIssue = parent || (issueType !== 'Sub-task' && random() < 0.4 && epics.length > 0 ? pick(random, epics) : null);
+    const parentIssue = parent || (epics.length > 0 && issueType !== 'Sub-task' && random() < 0.4 ? pick(random, epics) : null);
     return {
         id: String(10000 + Number(key.split('-')[1])),
         key,

--- a/index.mjs
+++ b/index.mjs
@@ -300,7 +300,9 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Issues without fix versions inherit their parent's, one level: sub-tasks from their story, and stories from their epic when the epic was fetched too
+    // Issues without fix versions inherit their parent's (sub-tasks from their story, stories from
+    // their epic when it was fetched too). One pass in array order, so a version can travel
+    // epic -> story -> sub-task when the story comes first
     for (const issue of jiraIssuesDetails) {
         if (issue.fields.parent &&
             (!issue.fields.fixVersions || issue.fields.fixVersions.length === 0)) {

--- a/index.mjs
+++ b/index.mjs
@@ -300,7 +300,7 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Inherit fix versions from parent for subtasks without fix versions
+    // Issues without fix versions inherit their parent's, one level: sub-tasks from their story, and stories from their epic when the epic was fetched too
     for (const issue of jiraIssuesDetails) {
         if (issue.fields.parent &&
             (!issue.fields.fixVersions || issue.fields.fixVersions.length === 0)) {

--- a/index.mjs
+++ b/index.mjs
@@ -275,10 +275,11 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Fetch missing parent issues to get their fix versions
+    // Fetch missing parent issues: their fix versions (inherited by sub-tasks)
+    // and their summary, type and parent (epic and story filters)
     if (missingParentKeys.length > 0) {
         const parentJql = `key IN (${missingParentKeys.join(',')})`;
-        const parentUrl = `${jiraBaseUrl}?jql=${encodeURIComponent(parentJql)}&fields=key,fixVersions`;
+        const parentUrl = `${jiraBaseUrl}?jql=${encodeURIComponent(parentJql)}&fields=key,summary,issuetype,fixVersions,parent`;
         try {
             const startTime = Date.now();
             const response = await atlassianFetch(parentUrl, {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "version",
-  "version": "2.3.0",
-  "releaseDate": "2026-09-05",
+  "version": "2.4.0",
+  "releaseDate": "2026-09-09",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -99,6 +99,8 @@ export function epicOf(issue, issuesByKey) {
     return null;
 }
 
+// ---------------------------------------------------- issue filter options
+
 /**
  * Options of an issue multi-select: "KEY Summary", valued by key, sorted by
  * Jira project then issue number descending (newest first). Pure.

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -23,13 +23,14 @@ export function initializeFilter(apiResult) {
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }) {
     return [
         parseTextQuery(text).length > 0,
         assignees.length > 0,
         reviewers.length > 0,
         sprints.length > 0,
         fixVersions.length > 0,
+        epics.length > 0,
         ready === true,
         sync !== 'Show all'
     ].filter(Boolean).length;
@@ -48,6 +49,51 @@ export function parseTextQuery(text) {
 /** True when every term is a substring of the searchable text. Pure. */
 export function matchesText(searchText, terms) {
     return terms.every(term => searchText.includes(term));
+}
+
+// ---------------------------------------------------------- Jira hierarchy
+// Jira Cloud: epic (hierarchyLevel 1) > standard issue (0) > sub-task (-1).
+// Every issue carries fields.issuetype and, when it has one, fields.parent with
+// the parent's key and inline fields (summary, status, priority, issuetype).
+// This is the only place that interprets these fields.
+
+/**
+ * Level of an issue in the Jira hierarchy: 'epic', 'standard' or 'subtask'.
+ * Issues without a type (parents fetched with fix versions only by an older
+ * server) count as standard. Pure.
+ */
+export function issueLevel(issue) {
+    const type = issue.fields && issue.fields.issuetype;
+    if (!type) return 'standard';
+    if (type.hierarchyLevel > 0 || type.name === 'Epic') return 'epic';
+    if (type.subtask === true || type.hierarchyLevel < 0) return 'subtask';
+    return 'standard';
+}
+
+// Key and summary of an issue or of an inline parent, as listed in the filters
+function issueReference(issue) {
+    return { key: issue.key, summary: (issue.fields && issue.fields.summary) || '' };
+}
+
+/**
+ * The epic above an issue: the issue itself when it is an epic, its parent when
+ * the parent is an epic, or the epic of its parent story when the issue is a
+ * sub-task (the story is looked up in issuesByKey, where the server puts the
+ * parents it fetched). Pure.
+ * @returns {{ key: string, summary: string } | null}
+ */
+export function epicOf(issue, issuesByKey) {
+    const level = issueLevel(issue);
+    if (level === 'epic') return issueReference(issue);
+    const parent = issue.fields && issue.fields.parent;
+    if (!parent) return null;
+    if (issueLevel(parent) === 'epic') return issueReference(parent);
+    if (level === 'subtask') {
+        const story = issuesByKey.get(parent.key);
+        const grandParent = story && story.fields && story.fields.parent;
+        if (grandParent && issueLevel(grandParent) === 'epic') return issueReference(grandParent);
+    }
+    return null;
 }
 
 // --------------------------------------------------------------- attention
@@ -80,7 +126,7 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
  * Indexes the API result for the filters: one entry per pull request with its
  * linked issues, the text the text filter searches and the sets the other
  * filters compare against. Pure.
- * @returns {{ pullRequestsById: Map<number, object> }}
+ * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }> }}
  */
 export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
     const issuesByKey = new Map(jiraIssuesDetails.map(issue => [issue.key, issue]));
@@ -96,9 +142,14 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
     }
 
     const pullRequestsById = new Map();
+    const epics = new Map();
     for (const pullRequest of pullRequests) {
         const issueKeys = jiraIssuesMap[pullRequest.id] || [];
         const linkedIssues = issueKeys.map(key => issuesByKey.get(key)).filter(issue => issue);
+        const pullRequestEpics = linkedIssues.map(issue => epicOf(issue, issuesByKey)).filter(epic => epic);
+        for (const epic of pullRequestEpics) {
+            epics.set(epic.key, epic);
+        }
         const entry = {
             pullRequest,
             linkedIssues,
@@ -114,12 +165,13 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
             sprints: new Set(issueKeys.flatMap(key => [...(sprintsByIssueKey.get(key) || [])])),
             fixVersions: new Set(linkedIssues
                 .flatMap(issue => issue.fields.fixVersions || [])
-                .map(version => String(version.id)))
+                .map(version => String(version.id))),
+            epics: new Set(pullRequestEpics.map(epic => epic.key))
         };
         pullRequestsById.set(pullRequest.id, entry);
     }
 
-    return { pullRequestsById };
+    return { pullRequestsById, epics };
 }
 
 // -------------------------------------------------------------- evaluation
@@ -127,12 +179,12 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -147,6 +199,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const reviewerMatch = reviewers.length === 0 || reviewers.some(name => entry.reviewers.has(name));
     const sprintMatch = sprints.length === 0 || sprints.some(sprintId => entry.sprints.has(String(sprintId)));
     const fixVersionMatch = fixVersions.length === 0 || fixVersions.some(versionId => entry.fixVersions.has(String(versionId)));
+    const epicMatch = epics.length === 0 || epics.some(key => entry.epics.has(key));
     const syncMatch = sync === 'Show all' ||
         (sync === 'requested' && hasSyncLabel) ||
         (sync === 'OK' && !hasSyncLabel);
@@ -154,7 +207,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const readyMatch = !ready || attention.reviewer;
 
     return {
-        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch,
+        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && syncMatch && readyMatch,
         attention
     };
 }
@@ -163,7 +216,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(filters) {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -13,16 +13,19 @@ import { updateCounterDisplay } from './counter-utils.js';
 
 let filterIndex = null;
 
+/** Builds the filter index for a data load and returns it. */
 export function initializeFilter(apiResult) {
     filterIndex = buildFilterIndex(apiResult);
+    return filterIndex;
 }
 
 /**
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ assignees, reviewers, sprints, fixVersions, sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, sync, ready }) {
     return [
+        parseTextQuery(text).length > 0,
         assignees.length > 0,
         reviewers.length > 0,
         sprints.length > 0,
@@ -31,6 +34,23 @@ export function countActiveFilters({ assignees, reviewers, sprints, fixVersions,
         sync !== 'Show all'
     ].filter(Boolean).length;
 }
+
+// ------------------------------------------------------------- text filter
+
+/**
+ * Splits a text query into lower-cased terms. Pure.
+ * @returns {string[]} no term for a blank query
+ */
+export function parseTextQuery(text) {
+    return String(text || '').toLowerCase().split(/\s+/).filter(term => term !== '');
+}
+
+/** True when every term is a substring of the searchable text. Pure. */
+export function matchesText(searchText, terms) {
+    return terms.every(term => searchText.includes(term));
+}
+
+// --------------------------------------------------------------- attention
 
 /**
  * Decides whether a pull request needs the attention of the people selected
@@ -54,9 +74,12 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
     return { assignee, reviewer, any: assignee || reviewer };
 }
 
+// ------------------------------------------------------------------- index
+
 /**
  * Indexes the API result for the filters: one entry per pull request with its
- * linked issues and the sets the filters compare against. Pure.
+ * linked issues, the text the text filter searches and the sets the other
+ * filters compare against. Pure.
  * @returns {{ pullRequestsById: Map<number, object> }}
  */
 export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
@@ -79,6 +102,9 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
         const entry = {
             pullRequest,
             linkedIssues,
+            // What the text filter searches: title, source branch and issue keys
+            searchText: [pullRequest.title, pullRequest.source?.branch?.name, ...issueKeys]
+                .filter(Boolean).join(' ').toLowerCase(),
             assignees: new Set(linkedIssues
                 .filter(issue => issue.fields.assignee && issue.fields.assignee.displayName)
                 .map(issue => issue.fields.assignee.displayName)),
@@ -96,15 +122,17 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
     return { pullRequestsById };
 }
 
+// -------------------------------------------------------------- evaluation
+
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { assignees, reviewers, sprints, fixVersions, sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -113,6 +141,7 @@ export function evaluatePullRequest(entry, { assignees, reviewers, sprints, fixV
         reviewers
     });
 
+    const textMatch = matchesText(entry.searchText, parseTextQuery(text));
     // Empty selection = show all; otherwise match ANY selected value
     const assigneeMatch = assignees.length === 0 || assignees.some(name => entry.assignees.has(name));
     const reviewerMatch = reviewers.length === 0 || reviewers.some(name => entry.reviewers.has(name));
@@ -125,17 +154,19 @@ export function evaluatePullRequest(entry, { assignees, reviewers, sprints, fixV
     const readyMatch = !ready || attention.reviewer;
 
     return {
-        visible: assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch,
+        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch,
         attention
     };
 }
 
+// ---------------------------------------------------------------- tree pass
+
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
  * @returns {number} how many pull requests are left shown and need attention
  */
-export function filterBranches(assignees, reviewers, sprints, fixVersions, sync, ready) {
-    const filters = { assignees, reviewers, sprints, fixVersions, sync, ready };
+export function filterBranches(filters) {
     const pass = {
         filters,
         index: filterIndex || buildFilterIndex({}),

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -80,6 +80,9 @@ function issueReference(issue) {
  * the parent is an epic, or the epic of its parent story when the issue is a
  * sub-task (the story is looked up in issuesByKey, where the server puts the
  * parents it fetched). Pure.
+ * @param {object} issue - a linked issue or an inline parent
+ * @param {Map<string, object>} issuesByKey - the issues of jiraIssuesDetails by
+ *   key (required: the sub-task branch reads it)
  * @returns {{ key: string, summary: string } | null}
  */
 export function epicOf(issue, issuesByKey) {
@@ -94,6 +97,30 @@ export function epicOf(issue, issuesByKey) {
         if (grandParent && issueLevel(grandParent) === 'epic') return issueReference(grandParent);
     }
     return null;
+}
+
+/**
+ * Options of an issue multi-select: "KEY Summary", valued by key, sorted by
+ * Jira project then issue number descending (newest first). Pure.
+ * @param {Iterable<{ key: string, summary: string }>} issues - records, e.g. index.epics.values()
+ * @returns {{ value: string, label: string }[]}
+ */
+export function issueOptions(issues) {
+    return [...issues]
+        .sort((a, b) => compareIssueKeys(a.key, b.key))
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+}
+
+// Jira project alphabetically, then issue number descending
+function compareIssueKeys(a, b) {
+    const [projectA, numberA] = splitIssueKey(a);
+    const [projectB, numberB] = splitIssueKey(b);
+    return projectA.localeCompare(projectB) || numberB - numberA;
+}
+
+function splitIssueKey(key) {
+    const dash = key.lastIndexOf('-');
+    return [key.slice(0, dash), Number(key.slice(dash + 1))];
 }
 
 // --------------------------------------------------------------- attention

--- a/public/app-shell.js
+++ b/public/app-shell.js
@@ -76,6 +76,13 @@ export function closeSidebarDrawer() {
     }
 }
 
+/** Shows the sidebar if it is hidden: remembered in the wide layout, the drawer just opens. */
+export function showSidebar() {
+    if (isSidebarHidden()) {
+        setSidebarHidden(false);
+    }
+}
+
 function applyLayoutMode() {
     if (wideLayout.matches) {
         setSidebarHidden(readStorage(SIDEBAR_STORAGE_KEY) === 'true', { persist: false });
@@ -175,6 +182,28 @@ function isTypingTarget(target) {
         (target.matches('input, select, textarea') || target.isContentEditable);
 }
 
+// A text box with content keeps Escape for itself: it clears the box
+function isFilledTextBox(target) {
+    return target instanceof HTMLInputElement &&
+        (target.type === 'search' || target.type === 'text') &&
+        target.value !== '';
+}
+
+function isHelpOpen() {
+    const modal = document.getElementById('helpModal');
+    return Boolean(modal) && !modal.hidden;
+}
+
+function focusTextFilter() {
+    const input = document.getElementById('textFilter');
+    if (!input) {
+        return;
+    }
+    showSidebar();
+    input.focus();
+    input.select();
+}
+
 // Registered in the capture phase: an open multi-select is still open here and
 // handles Escape itself, so the shell stays out of its way.
 function handleKeydown(event) {
@@ -183,8 +212,10 @@ function handleKeydown(event) {
     }
 
     if (event.key === 'Escape') {
-        const modal = document.getElementById('helpModal');
-        if (modal && !modal.hidden) {
+        if (isFilledTextBox(event.target)) {
+            return;
+        }
+        if (isHelpOpen()) {
             closeHelp();
         } else {
             closeSidebarDrawer();
@@ -192,11 +223,15 @@ function handleKeydown(event) {
         return;
     }
 
-    if ((event.key === 'f' || event.key === 'F') &&
-        !event.ctrlKey && !event.metaKey && !event.altKey &&
-        !isTypingTarget(event.target)) {
+    if (event.ctrlKey || event.metaKey || event.altKey || isTypingTarget(event.target) || isHelpOpen()) {
+        return;
+    }
+    if (event.key === 'f' || event.key === 'F') {
         event.preventDefault();
         toggleSidebar();
+    } else if (event.key === '/') {
+        event.preventDefault();
+        focusTextFilter();
     }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -7,6 +7,7 @@ let currentProject = null;
 let currentText = '';
 let currentSprints = [];
 let currentFixVersions = [];
+let currentEpics = [];
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -20,9 +21,9 @@ let syncStatusLoading = false;
 let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
-const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'];
+const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'assigneeSelect', 'reviewerSelect'];
 // URL parameters written by the filters
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'assignee', 'reviewer', 'sync', 'ready'];
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'assignee', 'reviewer', 'sync', 'ready'];
 
 function currentFilters() {
     return {
@@ -31,6 +32,7 @@ function currentFilters() {
         reviewers: currentReviewers,
         sprints: currentSprints,
         fixVersions: currentFixVersions,
+        epics: currentEpics,
         sync: currentSync,
         ready: currentReadyForReviewer
     };
@@ -89,6 +91,7 @@ function updateUrlWithFilters({ replace = false } = {}) {
     currentReviewers.forEach(v => url.searchParams.append('reviewer', v));
     currentSprints.forEach(v => url.searchParams.append('sprint', v));
     currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
+    currentEpics.forEach(v => url.searchParams.append('epic', v));
     if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
     if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
 
@@ -114,6 +117,7 @@ function restoreFiltersFromUrl() {
     currentReviewers = urlParams.getAll('reviewer');
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
+    currentEpics = urlParams.getAll('epic');
     currentText = urlParams.get('q') || '';
 
     if (!currentSyncStatuses) {
@@ -138,6 +142,10 @@ function restoreFiltersFromUrl() {
     }
     if (fixVersionMultiSelect) {
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
+    }
+    const epicMultiSelect = getMultiSelect('epicSelect');
+    if (epicMultiSelect) {
+        epicMultiSelect.setSelectedValues(currentEpics);
     }
 
     // Update sync select and ready checkbox
@@ -282,12 +290,14 @@ function readFilterControls() {
     const reviewerMultiSelect = getMultiSelect('reviewerSelect');
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
+    const epicMultiSelect = getMultiSelect('epicSelect');
 
     currentText = textFilter ? textFilter.value : '';
     currentAssignees = assigneeMultiSelect ? assigneeMultiSelect.getSelectedValues() : [];
     currentReviewers = reviewerMultiSelect ? reviewerMultiSelect.getSelectedValues() : [];
     currentSprints = sprintMultiSelect ? sprintMultiSelect.getSelectedValues() : [];
     currentFixVersions = fixVersionMultiSelect ? fixVersionMultiSelect.getSelectedValues() : [];
+    currentEpics = epicMultiSelect ? epicMultiSelect.getSelectedValues() : [];
 
     // Get sync and ready values from regular form elements
     const syncSelect = document.getElementById("syncSelect");
@@ -476,7 +486,7 @@ function renderEverything(apiResult) {
     const toggleStates = captureToggleStates();
 
     currentApiResult = apiResult;
-    initializeFilter(currentApiResult);
+    const filterIndex = initializeFilter(currentApiResult);
     const container = document.getElementById('pull-requests');
 
     // Create main content
@@ -503,6 +513,7 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
+    populateEpicFilter(filterIndex.epics);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();
@@ -775,6 +786,38 @@ function populateFixVersionFilter(jiraIssuesDetails) {
         currentFixVersions = currentFixVersions.filter(id => validFixVersionIds.includes(id));
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
     }
+}
+
+// Options of an issue filter: "KEY Summary", newest issue first within each Jira project
+function issueOptions(issues) {
+    return [...issues.values()]
+        .sort((a, b) => compareIssueKeys(a.key, b.key))
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+}
+
+// Jira project alphabetically, then issue number descending
+function compareIssueKeys(a, b) {
+    const [projectA, numberA] = splitIssueKey(a);
+    const [projectB, numberB] = splitIssueKey(b);
+    return projectA.localeCompare(projectB) || numberB - numberA;
+}
+
+function splitIssueKey(key) {
+    const dash = key.lastIndexOf('-');
+    return [key.slice(0, dash), Number(key.slice(dash + 1))];
+}
+
+function populateEpicFilter(epics) {
+    const epicMultiSelect = getMultiSelect('epicSelect');
+    if (!epicMultiSelect) return;
+
+    const options = issueOptions(epics);
+    epicMultiSelect.setOptions(options);
+
+    // Keep only the epics that exist in the options (the URL may carry unknown keys)
+    const known = new Set(options.map(option => option.value));
+    currentEpics = currentEpics.filter(key => known.has(key));
+    epicMultiSelect.setSelectedValues(currentEpics);
 }
 
 // Fetches the SYNC status of every pull request of the current project in a

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-import { initializeFilter, filterBranches, countActiveFilters } from './app-filter.js';
+import { initializeFilter, filterBranches, countActiveFilters, issueOptions } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
 import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
@@ -142,10 +142,6 @@ function restoreFiltersFromUrl() {
     }
     if (fixVersionMultiSelect) {
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
-    }
-    const epicMultiSelect = getMultiSelect('epicSelect');
-    if (epicMultiSelect) {
-        epicMultiSelect.setSelectedValues(currentEpics);
     }
 
     // Update sync select and ready checkbox
@@ -513,7 +509,7 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
-    populateEpicFilter(filterIndex.epics);
+    currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();
@@ -788,36 +784,14 @@ function populateFixVersionFilter(jiraIssuesDetails) {
     }
 }
 
-// Options of an issue filter: "KEY Summary", newest issue first within each Jira project
-function issueOptions(issues) {
-    return [...issues.values()]
-        .sort((a, b) => compareIssueKeys(a.key, b.key))
-        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
-}
-
-// Jira project alphabetically, then issue number descending
-function compareIssueKeys(a, b) {
-    const [projectA, numberA] = splitIssueKey(a);
-    const [projectB, numberB] = splitIssueKey(b);
-    return projectA.localeCompare(projectB) || numberB - numberA;
-}
-
-function splitIssueKey(key) {
-    const dash = key.lastIndexOf('-');
-    return [key.slice(0, dash), Number(key.slice(dash + 1))];
-}
-
-function populateEpicFilter(epics) {
-    const epicMultiSelect = getMultiSelect('epicSelect');
-    if (!epicMultiSelect) return;
-
-    const options = issueOptions(epics);
-    epicMultiSelect.setOptions(options);
-
-    // Keep only the epics that exist in the options (the URL may carry unknown keys)
-    const known = new Set(options.map(option => option.value));
-    currentEpics = currentEpics.filter(key => known.has(key));
-    epicMultiSelect.setSelectedValues(currentEpics);
+// Fills an issue multi-select (epics, stories) and returns the selection
+// restricted to the keys it offers (the URL may carry keys of another project)
+function populateIssueFilter(elementId, issues, selectedKeys) {
+    const multiSelect = getMultiSelect(elementId);
+    if (!multiSelect) return selectedKeys;
+    multiSelect.setOptions(issueOptions(issues.values()));
+    multiSelect.setSelectedValues(selectedKeys);
+    return multiSelect.getSelectedValues();
 }
 
 // Fetches the SYNC status of every pull request of the current project in a

--- a/public/app.js
+++ b/public/app.js
@@ -150,9 +150,13 @@ function restoreFiltersFromUrl() {
         readyCheck.disabled = currentReviewers.length === 0;
     }
 
-    // The URL holds the trimmed query: leave a box the user is typing in alone
+    // The URL holds the trimmed query: a box the user is typing in is authoritative
     const textFilter = document.getElementById('textFilter');
-    if (textFilter && document.activeElement !== textFilter) textFilter.value = currentText;
+    if (textFilter && document.activeElement === textFilter) {
+        currentText = textFilter.value;
+    } else if (textFilter) {
+        textFilter.value = currentText;
+    }
     updateTextFilterClearButton();
 }
 
@@ -270,7 +274,8 @@ function showErrorState() {
     showStateMessage('fas fa-exclamation-triangle', `Could not load ${currentProject}. The next automatic check will retry.`, 'error');
 }
 
-// Copies the filter controls into the state variables and refreshes the controls that depend on them (ready checkbox, clear button)
+// Copies the filter controls into the state variables and refreshes the
+// controls that depend on them (ready checkbox, clear button)
 function readFilterControls() {
     const textFilter = document.getElementById('textFilter');
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,7 @@ import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates
 import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
 
 let currentProject = null;
+let currentText = '';
 let currentSprints = [];
 let currentFixVersions = [];
 let currentAssignees = [];
@@ -20,6 +21,7 @@ let syncLoadFailed = false;
 
 function currentFilters() {
     return {
+        text: currentText,
         assignees: currentAssignees,
         reviewers: currentReviewers,
         sprints: currentSprints,
@@ -34,7 +36,7 @@ function currentFilters() {
 // and the attention count in the tab title.
 function applyFilters() {
     const filters = currentFilters();
-    const attentionCount = filterBranches(filters.assignees, filters.reviewers, filters.sprints, filters.fixVersions, filters.sync, filters.ready);
+    const attentionCount = filterBranches(filters);
     updateActiveFilterBadge(countActiveFilters(filters));
     updateDocumentTitle({ project: currentProject, attentionCount });
 }
@@ -42,6 +44,8 @@ function applyFilters() {
 // Resets every filter control to its default and applies the result once.
 // The project and the loaded SYNC statuses are kept.
 function clearAllFilters() {
+    const textFilter = document.getElementById('textFilter');
+    if (textFilter) textFilter.value = '';
     ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'].forEach(id => {
         const multiSelect = getMultiSelect(id);
         if (multiSelect) multiSelect.clearAll(false);
@@ -53,7 +57,9 @@ function clearAllFilters() {
     handleFilterChange();
 }
 
-function updateUrlWithFilters() {
+// Writes the filters to the URL. `replace` swaps the current history entry
+// instead of pushing one (used while typing in the search box).
+function updateUrlWithFilters({ replace = false } = {}) {
     const url = new URL(window.location);
 
     // Clear existing multi-select params first
@@ -67,6 +73,14 @@ function updateUrlWithFilters() {
         url.searchParams.set('project', currentProject);
     } else {
         url.searchParams.delete('project');
+    }
+
+    // Set the text filter
+    const text = currentText.trim();
+    if (text !== '') {
+        url.searchParams.set('q', text);
+    } else {
+        url.searchParams.delete('q');
     }
 
     // Set multi-select params (use repeated params format)
@@ -89,7 +103,11 @@ function updateUrlWithFilters() {
     }
 
     // Update URL without reloading the page
-    window.history.pushState({}, '', url);
+    if (replace) {
+        window.history.replaceState({}, '', url);
+    } else {
+        window.history.pushState({}, '', url);
+    }
 }
 
 // Update filter restoration from URL
@@ -101,6 +119,7 @@ function restoreFiltersFromUrl() {
     currentReviewers = urlParams.getAll('reviewer');
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
+    currentText = urlParams.get('q') || '';
 
     if (!currentSyncStatuses) {
         currentSync = "Show all"; // Not restored from URL because SYNC status is only loaded on demand
@@ -135,6 +154,10 @@ function restoreFiltersFromUrl() {
         readyCheck.checked = currentReadyForReviewer;
         readyCheck.disabled = currentReviewers.length === 0;
     }
+
+    const textFilter = document.getElementById('textFilter');
+    if (textFilter) textFilter.value = currentText;
+    updateTextFilterClearButton();
 }
 
 function initializeSyncControls() {
@@ -194,6 +217,7 @@ async function handleProjectChange(event, isInitialLoad = false) {
         // Only clear filters from URL when manually switching projects, not during initial page load
         if (!isInitialLoad) {
             const url = new URL(window.location);
+            url.searchParams.delete('q');
             url.searchParams.delete('assignee');
             url.searchParams.delete('reviewer');
             url.searchParams.delete('sprint');
@@ -203,6 +227,7 @@ async function handleProjectChange(event, isInitialLoad = false) {
             window.history.pushState({}, '', url);
 
             // Clear multi-select state and UI
+            currentText = '';
             currentAssignees = [];
             currentReviewers = [];
             currentSprints = [];
@@ -221,6 +246,10 @@ async function handleProjectChange(event, isInitialLoad = false) {
             if (reviewerMultiSelect) reviewerMultiSelect.clearAll(false);
             if (sprintMultiSelect) sprintMultiSelect.clearAll(false);
             if (fixVersionMultiSelect) fixVersionMultiSelect.clearAll(false);
+
+            const textFilter = document.getElementById('textFilter');
+            if (textFilter) textFilter.value = '';
+            updateTextFilterClearButton();
 
             // Reset sync statuses and ready checkbox (SYNC data belongs to the previous project)
             currentSyncStatuses = null;
@@ -279,13 +308,15 @@ function showErrorState() {
     showStateMessage('fas fa-exclamation-triangle', `Could not load ${currentProject}. The next automatic check will retry.`, 'error');
 }
 
-function handleFilterChange() {
-    // Get values from multi-select components
+// Copies the filter controls into the state variables
+function readFilterControls() {
+    const textFilter = document.getElementById('textFilter');
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
     const reviewerMultiSelect = getMultiSelect('reviewerSelect');
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
 
+    currentText = textFilter ? textFilter.value : '';
     currentAssignees = assigneeMultiSelect ? assigneeMultiSelect.getSelectedValues() : [];
     currentReviewers = reviewerMultiSelect ? reviewerMultiSelect.getSelectedValues() : [];
     currentSprints = sprintMultiSelect ? sprintMultiSelect.getSelectedValues() : [];
@@ -307,11 +338,52 @@ function handleFilterChange() {
         }
     }
 
+    updateTextFilterClearButton();
+}
+
+function handleFilterChange() {
+    readFilterControls();
     applyFilters();
     updateUrlWithFilters();
 }
 
+// Typing in the search box: same path, but the URL entry is replaced so the
+// history does not gain an entry per keystroke
+function handleTextFilterInput() {
+    readFilterControls();
+    applyFilters();
+    updateUrlWithFilters({ replace: true });
+}
 
+function updateTextFilterClearButton() {
+    const clearButton = document.getElementById('textFilterClear');
+    if (clearButton) clearButton.hidden = currentText === '';
+}
+
+function initializeTextFilter() {
+    const textFilter = document.getElementById('textFilter');
+    const clearButton = document.getElementById('textFilterClear');
+    if (!textFilter) return;
+    textFilter.addEventListener('input', handleTextFilterInput);
+    textFilter.addEventListener('keydown', event => {
+        if (event.key !== 'Escape') return;
+        if (textFilter.value !== '') {
+            // Clear on Escape; the app shell leaves Escape to a filled text box
+            event.preventDefault();
+            textFilter.value = '';
+            handleTextFilterInput();
+        } else {
+            textFilter.blur();
+        }
+    });
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            textFilter.value = '';
+            handleTextFilterInput();
+            textFilter.focus();
+        });
+    }
+}
 
 function populateFilters(pullRequests) {
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
@@ -1144,6 +1216,7 @@ function initializeMultiSelects() {
 document.addEventListener('DOMContentLoaded', function() {
     initializeAppShell({ onClearFilters: clearAllFilters });
     initializeMultiSelects();
+    initializeTextFilter();
     showEmptyState();
     loadProjects();
     fetchAndDisplayVersion();

--- a/public/app.js
+++ b/public/app.js
@@ -19,6 +19,11 @@ let currentSyncStatuses = null;
 let syncStatusLoading = false;
 let syncLoadFailed = false;
 
+// Multi-select filters, in sidebar order
+const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'];
+// URL parameters written by the filters
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'assignee', 'reviewer', 'sync', 'ready'];
+
 function currentFilters() {
     return {
         text: currentText,
@@ -41,12 +46,12 @@ function applyFilters() {
     updateDocumentTitle({ project: currentProject, attentionCount });
 }
 
-// Resets every filter control to its default and applies the result once.
-// The project and the loaded SYNC statuses are kept.
-function clearAllFilters() {
+// Puts every filter control back to its default without applying anything:
+// the search box, the multi-selects, the ready checkbox and the SYNC select
+function resetFilterControls() {
     const textFilter = document.getElementById('textFilter');
     if (textFilter) textFilter.value = '';
-    ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'].forEach(id => {
+    multiSelectIds.forEach(id => {
         const multiSelect = getMultiSelect(id);
         if (multiSelect) multiSelect.clearAll(false);
     });
@@ -54,6 +59,12 @@ function clearAllFilters() {
     if (readyCheck) readyCheck.checked = false;
     const syncSelect = document.getElementById('syncSelect');
     if (syncSelect) syncSelect.value = 'Show all';
+}
+
+// Resets every filter and applies the result once.
+// The project and the loaded SYNC statuses are kept.
+function clearAllFilters() {
+    resetFilterControls();
     handleFilterChange();
 }
 
@@ -62,11 +73,7 @@ function clearAllFilters() {
 function updateUrlWithFilters({ replace = false } = {}) {
     const url = new URL(window.location);
 
-    // Clear existing multi-select params first
-    url.searchParams.delete('assignee');
-    url.searchParams.delete('reviewer');
-    url.searchParams.delete('sprint');
-    url.searchParams.delete('fixVersion');
+    filterUrlParams.forEach(param => url.searchParams.delete(param));
 
     // Set project
     if (currentProject) {
@@ -75,38 +82,26 @@ function updateUrlWithFilters({ replace = false } = {}) {
         url.searchParams.delete('project');
     }
 
-    // Set the text filter
+    // Set the active filters (multi-selects use the repeated params format)
     const text = currentText.trim();
-    if (text !== '') {
-        url.searchParams.set('q', text);
-    } else {
-        url.searchParams.delete('q');
-    }
-
-    // Set multi-select params (use repeated params format)
+    if (text !== '') url.searchParams.set('q', text);
     currentAssignees.forEach(v => url.searchParams.append('assignee', v));
     currentReviewers.forEach(v => url.searchParams.append('reviewer', v));
     currentSprints.forEach(v => url.searchParams.append('sprint', v));
     currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
+    if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
+    if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
 
-    // Set other params
-    if (currentSync !== "Show all") {
-        url.searchParams.set('sync', currentSync);
-    } else {
-        url.searchParams.delete('sync');
-    }
-
-    if (currentReadyForReviewer) {
-        url.searchParams.set('ready', 'true');
-    } else {
-        url.searchParams.delete('ready');
-    }
-
-    // Update URL without reloading the page
-    if (replace) {
-        window.history.replaceState({}, '', url);
-    } else {
-        window.history.pushState({}, '', url);
+    // Update URL without reloading the page. Safari throws past 100 updates
+    // per 30 seconds: the URL then catches up on the next change
+    try {
+        if (replace) {
+            window.history.replaceState({}, '', url);
+        } else {
+            window.history.pushState({}, '', url);
+        }
+    } catch (error) {
+        // The filters are already applied; only the address bar lags
     }
 }
 
@@ -155,8 +150,9 @@ function restoreFiltersFromUrl() {
         readyCheck.disabled = currentReviewers.length === 0;
     }
 
+    // The URL holds the trimmed query: leave a box the user is typing in alone
     const textFilter = document.getElementById('textFilter');
-    if (textFilter) textFilter.value = currentText;
+    if (textFilter && document.activeElement !== textFilter) textFilter.value = currentText;
     updateTextFilterClearButton();
 }
 
@@ -217,49 +213,15 @@ async function handleProjectChange(event, isInitialLoad = false) {
         // Only clear filters from URL when manually switching projects, not during initial page load
         if (!isInitialLoad) {
             const url = new URL(window.location);
-            url.searchParams.delete('q');
-            url.searchParams.delete('assignee');
-            url.searchParams.delete('reviewer');
-            url.searchParams.delete('sprint');
-            url.searchParams.delete('fixVersion');
-            url.searchParams.delete('sync');
-            url.searchParams.delete('ready');
+            filterUrlParams.forEach(param => url.searchParams.delete(param));
             window.history.pushState({}, '', url);
 
-            // Clear multi-select state and UI
-            currentText = '';
-            currentAssignees = [];
-            currentReviewers = [];
-            currentSprints = [];
-            currentFixVersions = [];
-            currentSync = "Show all";
-            currentReadyForReviewer = false;
-
-            // Clear multi-select components
-            const assigneeMultiSelect = getMultiSelect('assigneeSelect');
-            const reviewerMultiSelect = getMultiSelect('reviewerSelect');
-            const sprintMultiSelect = getMultiSelect('sprintSelect');
-            const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
-
-            // Pass false to prevent triggering handleFilterChange callbacks
-            if (assigneeMultiSelect) assigneeMultiSelect.clearAll(false);
-            if (reviewerMultiSelect) reviewerMultiSelect.clearAll(false);
-            if (sprintMultiSelect) sprintMultiSelect.clearAll(false);
-            if (fixVersionMultiSelect) fixVersionMultiSelect.clearAll(false);
-
-            const textFilter = document.getElementById('textFilter');
-            if (textFilter) textFilter.value = '';
-            updateTextFilterClearButton();
-
-            // Reset sync statuses and ready checkbox (SYNC data belongs to the previous project)
+            // SYNC data belongs to the previous project; then reset the controls and read them into the state
             currentSyncStatuses = null;
             syncLoadFailed = false;
             updateSyncControls();
-            const readyCheck = document.getElementById('readyForReviewerCheck');
-            if (readyCheck) {
-                readyCheck.checked = false;
-                readyCheck.disabled = true;
-            }
+            resetFilterControls();
+            readFilterControls();
         }
 
         showLoadingState();
@@ -308,7 +270,7 @@ function showErrorState() {
     showStateMessage('fas fa-exclamation-triangle', `Could not load ${currentProject}. The next automatic check will retry.`, 'error');
 }
 
-// Copies the filter controls into the state variables
+// Copies the filter controls into the state variables and refreshes the controls that depend on them (ready checkbox, clear button)
 function readFilterControls() {
     const textFilter = document.getElementById('textFilter');
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
@@ -1206,10 +1168,7 @@ function initializePopovers() {
 
 // Initialize multi-select components
 function initializeMultiSelects() {
-    createMultiSelect('sprintSelect', { onChange: handleFilterChange });
-    createMultiSelect('fixVersionSelect', { onChange: handleFilterChange });
-    createMultiSelect('assigneeSelect', { onChange: handleFilterChange });
-    createMultiSelect('reviewerSelect', { onChange: handleFilterChange });
+    multiSelectIds.forEach(id => createMultiSelect(id, { onChange: handleFilterChange }));
 }
 
 // Update the DOMContentLoaded event listener

--- a/public/index.html
+++ b/public/index.html
@@ -66,10 +66,10 @@
     <button type="button" id="clearFiltersButton" class="link-button" hidden>Clear filters</button>
   </div>
 
-  <div class="text-filter">
+  <div class="text-filter" role="search">
     <i class="fas fa-search text-filter-icon" aria-hidden="true"></i>
     <input type="search" id="textFilter" class="text-filter-input" placeholder="Title, branch or issue key"
-           aria-label="Search pull requests" autocomplete="off" spellcheck="false">
+           aria-label="Search pull requests" title="Search pull requests (/)" autocomplete="off" spellcheck="false">
     <button type="button" id="textFilterClear" class="text-filter-clear" aria-label="Clear search" hidden>
       <i class="fas fa-times"></i>
     </button>

--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,15 @@
     <button type="button" id="clearFiltersButton" class="link-button" hidden>Clear filters</button>
   </div>
 
+  <div class="text-filter">
+    <i class="fas fa-search text-filter-icon" aria-hidden="true"></i>
+    <input type="search" id="textFilter" class="text-filter-input" placeholder="Title, branch or issue key"
+           aria-label="Search pull requests" autocomplete="off" spellcheck="false">
+    <button type="button" id="textFilterClear" class="text-filter-clear" aria-label="Clear search" hidden>
+      <i class="fas fa-times"></i>
+    </button>
+  </div>
+
   <div class="filter-item">
     <span class="filter-label">Sprint</span>
     <div class="multi-select" id="sprintSelect" data-filter="sprint">

--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,29 @@
   </div>
 
   <div class="filter-item">
+    <span class="filter-label">Epic
+      <i class="fas fa-info-circle info-icon"
+         title="Epic of the linked issues; for a sub-task, the epic of its parent story"></i>
+    </span>
+    <div class="multi-select" id="epicSelect" data-filter="epic">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item">
     <span class="filter-label">Assignee</span>
     <div class="multi-select" id="assigneeSelect" data-filter="assignee">
       <div class="multi-select-trigger" tabindex="0">

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -164,7 +164,7 @@ export class MultiSelect {
             return `
                 <label class="multi-select-option">
                     <input type="checkbox" value="${this.escapeHtml(opt.value)}" ${isChecked ? 'checked' : ''}>
-                    <span class="multi-select-option-label">${this.escapeHtml(opt.label)}</span>
+                    <span class="multi-select-option-label" title="${this.escapeHtml(opt.label)}">${this.escapeHtml(opt.label)}</span>
                 </label>
             `;
         }).join('');

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -244,9 +244,9 @@ export class MultiSelect {
     }
 
     escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
+        return String(text).replace(/[&<>"']/g, character => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        })[character]);
     }
 }
 

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -5,6 +5,9 @@
 
 const instances = new Map();
 
+// Text and attribute values are both double-quoted here; quotes are escaped too
+const htmlEscapes = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+
 export class MultiSelect {
     constructor(elementId, options = {}) {
         this.elementId = elementId;
@@ -244,9 +247,7 @@ export class MultiSelect {
     }
 
     escapeHtml(text) {
-        return String(text).replace(/[&<>"']/g, character => ({
-            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-        })[character]);
+        return String(text ?? '').replace(/[&<>"']/g, character => htmlEscapes[character]);
     }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -330,6 +330,78 @@ html.sidebar-hidden .sidebar {
     gap: 8px;
 }
 
+.text-filter {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.text-filter-icon {
+    position: absolute;
+    left: 11px;
+    color: var(--text-muted);
+    font-size: 13px;
+    pointer-events: none;
+}
+
+.text-filter-input {
+    width: 100%;
+    padding: 8px 32px 8px 32px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--surface-color);
+    color: var(--text-color);
+    font-family: inherit;
+    font-size: 14px;
+    line-height: inherit;
+    appearance: none;
+    -webkit-appearance: none;
+    transition: border-color 0.2s ease;
+}
+
+/* The native cancel button is replaced by .text-filter-clear */
+.text-filter-input::-webkit-search-cancel-button,
+.text-filter-input::-webkit-search-decoration {
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.text-filter-input::placeholder {
+    color: var(--text-muted);
+}
+
+.text-filter-input:hover {
+    border-color: var(--primary-color);
+}
+
+.text-filter-input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.text-filter-clear {
+    position: absolute;
+    right: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.text-filter-clear:hover {
+    background-color: var(--surface-muted);
+    color: var(--text-color);
+}
+
 .sidebar-backdrop {
     display: none;
 }

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -184,12 +184,18 @@ test('matchesText requires every term as a substring', () => {
     assert.equal(matchesText(searchText, ['proj-12', 'restore']), true);
     assert.equal(matchesText(searchText, ['banner', 'footer']), false);
     assert.equal(matchesText(searchText, ['ann']), true); // substring, not whole word
+    assert.equal(matchesText('', ['x']), false);
 });
 
 test('buildFilterIndex searches the title, the source branch and the issue keys only', () => {
     const { pullRequestsById } = buildFilterIndex(sampleApiResult);
     assert.equal(pullRequestsById.get(10).searchText, 'fix(proj-1): restore the banner jd_260901_proj-1_banner proj-1 proj-2 proj-404');
     assert.equal(pullRequestsById.get(11).searchText, 'chore: bump dependencies chore/bump-deps');
+    const bare = buildFilterIndex({
+        pullRequests: [{ id: 12, title: 'Hotfix', author, participants: [] }],
+        jiraIssuesMap: {}, jiraIssuesDetails: [], sprintIssues: {}
+    });
+    assert.equal(bare.pullRequestsById.get(12).searchText, 'hotfix'); // no source branch
 });
 
 test('evaluatePullRequest text filter is case-insensitive and needs every word', () => {
@@ -197,7 +203,7 @@ test('evaluatePullRequest text filter is case-insensitive and needs every word',
     const evaluate = text => evaluatePullRequest(pullRequestsById.get(10), { ...noFilter, text }, rendered).visible;
     assert.equal(evaluate(''), true);
     assert.equal(evaluate('BANNER'), true);
-    assert.equal(evaluate('proj-404'), true); // an issue key of the title, even without details
+    assert.equal(evaluate('proj-404'), true); // a key of jiraIssuesMap without details (the keys are searched even when the title changes)
     assert.equal(evaluate('jd_260901'), true); // the source branch
     assert.equal(evaluate('restore banner'), true);
     assert.equal(evaluate('banner footer'), false);

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -213,7 +213,7 @@ test('evaluatePullRequest text filter is case-insensitive and needs every word',
 
 // ------------------------------------------------------------------ epic filter
 
-import { issueLevel, epicOf } from '../public/app-filter.js';
+import { issueLevel, epicOf, issueOptions } from '../public/app-filter.js';
 
 const epicType = { name: 'Epic', subtask: false, hierarchyLevel: 1 };
 const storyType = { name: 'Story', subtask: false, hierarchyLevel: 0 };
@@ -225,7 +225,9 @@ const inlineEpicAi = { id: '1', key: 'PROJ-100', fields: { summary: 'Assistive A
 const inlineStoryChat = { id: '2', key: 'PROJ-200', fields: { summary: 'Chat panel', status: {}, priority: {}, issuetype: storyType } };
 
 const epicAi = { key: 'PROJ-100', fields: { summary: 'Assistive AI', issuetype: epicType } };
+const epicUx = { key: 'PROJ-101', fields: { summary: 'UX', issuetype: epicType } };
 const storyInEpic = { key: 'PROJ-200', fields: { summary: 'Chat panel', issuetype: storyType, parent: inlineEpicAi } };
+const storyInUx = { key: 'PROJ-203', fields: { summary: 'Toolbar', issuetype: storyType, parent: { id: '3', key: 'PROJ-101', fields: { summary: 'UX', status: {}, priority: {}, issuetype: epicType } } } };
 const bugWithoutEpic = { key: 'PROJ-201', fields: { summary: 'Crash on save', issuetype: bugType } };
 const subtaskOfStory = { key: 'PROJ-300', fields: { summary: 'Chat panel: API', issuetype: subtaskType, parent: inlineStoryChat } };
 const subtaskOfUnknown = { key: 'PROJ-301', fields: { summary: 'Orphan work', issuetype: subtaskType, parent: { key: 'PROJ-999', fields: { summary: 'Unknown story', issuetype: storyType } } } };
@@ -249,6 +251,8 @@ test('epicOf resolves the epic itself, a direct epic parent and the epic of a su
     assert.equal(epicOf(bugWithoutEpic, issuesByKey), null);
     assert.equal(epicOf(subtaskOfUnknown, issuesByKey), null); // the parent is not in the details
     assert.equal(epicOf(parentOnlyStory, issuesByKey), null);
+    // A sub-task whose direct parent is an epic needs no lookup
+    assert.deepEqual(epicOf({ key: 'PROJ-304', fields: { summary: 'Odd', issuetype: subtaskType, parent: inlineEpicAi } }, new Map()), { key: 'PROJ-100', summary: 'Assistive AI' });
 });
 
 test('epicOf needs the parent of the parent story, which the server now fetches for parent-only stories', () => {
@@ -263,10 +267,11 @@ const hierarchyApiResult = {
         { id: 20, title: 'PROJ-200 chat panel', source: { branch: { name: 'feature/PROJ-200' } }, author, participants: [] },
         { id: 21, title: 'PROJ-300 chat panel api', source: { branch: { name: 'feature/PROJ-300' } }, author, participants: [] },
         { id: 22, title: 'PROJ-201 crash on save', source: { branch: { name: 'bugfix/PROJ-201' } }, author, participants: [] },
-        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] }
+        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] },
+        { id: 24, title: 'PROJ-200 PROJ-203 both', source: { branch: { name: 'feature/both' } }, author, participants: [] }
     ],
-    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'] },
-    jiraIssuesDetails: [epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory],
+    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'], 24: ['PROJ-200', 'PROJ-203'] },
+    jiraIssuesDetails: [epicAi, epicUx, storyInEpic, storyInUx, bugWithoutEpic, subtaskOfStory],
     sprintIssues: {}
 };
 
@@ -276,7 +281,8 @@ test('buildFilterIndex collects the epics of every pull request and the list of 
     assert.deepEqual([...pullRequestsById.get(21).epics], ['PROJ-100']); // through the parent story
     assert.deepEqual([...pullRequestsById.get(22).epics], []);
     assert.deepEqual([...pullRequestsById.get(23).epics], ['PROJ-100']); // linked to the epic itself
-    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }]);
+    assert.deepEqual([...pullRequestsById.get(24).epics], ['PROJ-100', 'PROJ-101']); // two issues under two epics
+    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }, { key: 'PROJ-101', summary: 'UX' }]);
     assert.equal(buildFilterIndex({}).epics.size, 0);
 });
 
@@ -289,4 +295,16 @@ test('evaluatePullRequest epic filter matches any selected epic', () => {
     assert.equal(evaluate(22, []), true);
     assert.equal(evaluate(20, ['PROJ-999', 'PROJ-100']), true);
     assert.equal(evaluate(20, ['PROJ-999']), false);
+});
+
+test('issueOptions labels "KEY Summary" and sorts by project then newest issue first', () => {
+    const options = issueOptions([
+        { key: 'PROJ-9', summary: 'Nine' }, { key: 'ALPHA-100', summary: 'Hundred' },
+        { key: 'PROJ-10', summary: 'Ten' }, { key: 'ALPHA-2', summary: 'Two' }
+    ]);
+    assert.deepEqual(options, [
+        { value: 'ALPHA-100', label: 'ALPHA-100 Hundred' }, { value: 'ALPHA-2', label: 'ALPHA-2 Two' },
+        { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
+    ]);
+    assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -76,6 +76,8 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ ...defaults, reviewers: ['Jane', 'Bob'], ready: true }), 2);
     assert.equal(countActiveFilters({ ...defaults, sync: 'requested' }), 1);
     assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
+    assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
+    assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -84,8 +86,14 @@ import { buildFilterIndex, evaluatePullRequest } from '../public/app-filter.js';
 
 const sampleApiResult = {
     pullRequests: [
-        { id: 10, author, participants: [{ user: author, approved: false }, { user: jane, approved: false }, { user: bob, approved: true }] },
-        { id: 11, author, participants: [{ user: author, approved: false }] }
+        {
+            id: 10, title: 'fix(PROJ-1): restore the banner', source: { branch: { name: 'JD_260901_PROJ-1_Banner' } },
+            author, participants: [{ user: author, approved: false }, { user: jane, approved: false }, { user: bob, approved: true }]
+        },
+        {
+            id: 11, title: 'chore: bump dependencies', source: { branch: { name: 'chore/bump-deps' } },
+            author, participants: [{ user: author, approved: false }]
+        }
     ],
     jiraIssuesMap: { 10: ['PROJ-1', 'PROJ-2', 'PROJ-404'], 11: [] },
     jiraIssuesDetails: [
@@ -156,4 +164,42 @@ test('evaluatePullRequest ready filter keeps pull requests with reviewer attenti
     const bobApproved = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Bob'], ready: true }, rendered);
     assert.equal(bobApproved.visible, false);
     assert.equal(bobApproved.attention.any, false);
+});
+
+// ------------------------------------------------------------------ text filter
+
+import { parseTextQuery, matchesText } from '../public/app-filter.js';
+
+test('parseTextQuery lower-cases, trims and splits on whitespace', () => {
+    assert.deepEqual(parseTextQuery('  Fix  PROJ-12\tbanner '), ['fix', 'proj-12', 'banner']);
+    assert.deepEqual(parseTextQuery(''), []);
+    assert.deepEqual(parseTextQuery('   '), []);
+    assert.deepEqual(parseTextQuery(undefined), []);
+});
+
+test('matchesText requires every term as a substring', () => {
+    const searchText = 'fix(proj-12): restore banner feature/proj-12-banner proj-12';
+    assert.equal(matchesText(searchText, []), true);
+    assert.equal(matchesText(searchText, ['banner']), true);
+    assert.equal(matchesText(searchText, ['proj-12', 'restore']), true);
+    assert.equal(matchesText(searchText, ['banner', 'footer']), false);
+    assert.equal(matchesText(searchText, ['ann']), true); // substring, not whole word
+});
+
+test('buildFilterIndex searches the title, the source branch and the issue keys only', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    assert.equal(pullRequestsById.get(10).searchText, 'fix(proj-1): restore the banner jd_260901_proj-1_banner proj-1 proj-2 proj-404');
+    assert.equal(pullRequestsById.get(11).searchText, 'chore: bump dependencies chore/bump-deps');
+});
+
+test('evaluatePullRequest text filter is case-insensitive and needs every word', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const evaluate = text => evaluatePullRequest(pullRequestsById.get(10), { ...noFilter, text }, rendered).visible;
+    assert.equal(evaluate(''), true);
+    assert.equal(evaluate('BANNER'), true);
+    assert.equal(evaluate('proj-404'), true); // an issue key of the title, even without details
+    assert.equal(evaluate('jd_260901'), true); // the source branch
+    assert.equal(evaluate('restore banner'), true);
+    assert.equal(evaluate('banner footer'), false);
+    assert.equal(evaluate('Author'), false); // people are not searched
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -78,6 +78,7 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
     assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
     assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
+    assert.equal(countActiveFilters({ ...defaults, epics: ['PROJ-100', 'PROJ-101'] }), 1);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -208,4 +209,84 @@ test('evaluatePullRequest text filter is case-insensitive and needs every word',
     assert.equal(evaluate('restore banner'), true);
     assert.equal(evaluate('banner footer'), false);
     assert.equal(evaluate('Author'), false); // people are not searched
+});
+
+// ------------------------------------------------------------------ epic filter
+
+import { issueLevel, epicOf } from '../public/app-filter.js';
+
+const epicType = { name: 'Epic', subtask: false, hierarchyLevel: 1 };
+const storyType = { name: 'Story', subtask: false, hierarchyLevel: 0 };
+const bugType = { name: 'Bug', subtask: false, hierarchyLevel: 0 };
+const subtaskType = { name: 'Sub-task', subtask: true, hierarchyLevel: -1 };
+
+// Jira returns the parent with a few inline fields (summary, status, priority, issuetype)
+const inlineEpicAi = { id: '1', key: 'PROJ-100', fields: { summary: 'Assistive AI', status: {}, priority: {}, issuetype: epicType } };
+const inlineStoryChat = { id: '2', key: 'PROJ-200', fields: { summary: 'Chat panel', status: {}, priority: {}, issuetype: storyType } };
+
+const epicAi = { key: 'PROJ-100', fields: { summary: 'Assistive AI', issuetype: epicType } };
+const storyInEpic = { key: 'PROJ-200', fields: { summary: 'Chat panel', issuetype: storyType, parent: inlineEpicAi } };
+const bugWithoutEpic = { key: 'PROJ-201', fields: { summary: 'Crash on save', issuetype: bugType } };
+const subtaskOfStory = { key: 'PROJ-300', fields: { summary: 'Chat panel: API', issuetype: subtaskType, parent: inlineStoryChat } };
+const subtaskOfUnknown = { key: 'PROJ-301', fields: { summary: 'Orphan work', issuetype: subtaskType, parent: { key: 'PROJ-999', fields: { summary: 'Unknown story', issuetype: storyType } } } };
+const parentOnlyStory = { key: 'PROJ-202', fields: { fixVersions: [] } }; // fetched with fix versions only (older server)
+
+test('issueLevel classifies epics, standard issues and sub-tasks, and defaults to standard', () => {
+    assert.equal(issueLevel(epicAi), 'epic');
+    assert.equal(issueLevel({ key: 'X-1', fields: { issuetype: { name: 'Epic' } } }), 'epic'); // no hierarchyLevel
+    assert.equal(issueLevel(storyInEpic), 'standard');
+    assert.equal(issueLevel(bugWithoutEpic), 'standard');
+    assert.equal(issueLevel(subtaskOfStory), 'subtask');
+    assert.equal(issueLevel({ key: 'X-2', fields: { issuetype: { name: 'Sub-task', subtask: true } } }), 'subtask');
+    assert.equal(issueLevel(parentOnlyStory), 'standard');
+});
+
+test('epicOf resolves the epic itself, a direct epic parent and the epic of a sub-task parent', () => {
+    const issuesByKey = new Map([epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory, subtaskOfUnknown].map(issue => [issue.key, issue]));
+    assert.deepEqual(epicOf(epicAi, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.deepEqual(epicOf(storyInEpic, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.deepEqual(epicOf(subtaskOfStory, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.equal(epicOf(bugWithoutEpic, issuesByKey), null);
+    assert.equal(epicOf(subtaskOfUnknown, issuesByKey), null); // the parent is not in the details
+    assert.equal(epicOf(parentOnlyStory, issuesByKey), null);
+});
+
+test('epicOf needs the parent of the parent story, which the server now fetches for parent-only stories', () => {
+    const parentOnlyWithEpic = { key: 'PROJ-202', fields: { summary: 'Search page', issuetype: storyType, fixVersions: [], parent: inlineEpicAi } };
+    const subtask = { key: 'PROJ-302', fields: { summary: 'Search page: index', issuetype: subtaskType, parent: { key: 'PROJ-202', fields: { summary: 'Search page', issuetype: storyType } } } };
+    assert.deepEqual(epicOf(subtask, new Map([[parentOnlyWithEpic.key, parentOnlyWithEpic]])), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.equal(epicOf(subtask, new Map([[parentOnlyStory.key, parentOnlyStory]])), null); // older server: no parent on the story
+});
+
+const hierarchyApiResult = {
+    pullRequests: [
+        { id: 20, title: 'PROJ-200 chat panel', source: { branch: { name: 'feature/PROJ-200' } }, author, participants: [] },
+        { id: 21, title: 'PROJ-300 chat panel api', source: { branch: { name: 'feature/PROJ-300' } }, author, participants: [] },
+        { id: 22, title: 'PROJ-201 crash on save', source: { branch: { name: 'bugfix/PROJ-201' } }, author, participants: [] },
+        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] }
+    ],
+    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'] },
+    jiraIssuesDetails: [epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory],
+    sprintIssues: {}
+};
+
+test('buildFilterIndex collects the epics of every pull request and the list of epics', () => {
+    const { pullRequestsById, epics } = buildFilterIndex(hierarchyApiResult);
+    assert.deepEqual([...pullRequestsById.get(20).epics], ['PROJ-100']);
+    assert.deepEqual([...pullRequestsById.get(21).epics], ['PROJ-100']); // through the parent story
+    assert.deepEqual([...pullRequestsById.get(22).epics], []);
+    assert.deepEqual([...pullRequestsById.get(23).epics], ['PROJ-100']); // linked to the epic itself
+    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }]);
+    assert.equal(buildFilterIndex({}).epics.size, 0);
+});
+
+test('evaluatePullRequest epic filter matches any selected epic', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, epics) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, epics }, rendered).visible;
+    assert.equal(evaluate(20, ['PROJ-100']), true);
+    assert.equal(evaluate(21, ['PROJ-100']), true);
+    assert.equal(evaluate(22, ['PROJ-100']), false);
+    assert.equal(evaluate(22, []), true);
+    assert.equal(evaluate(20, ['PROJ-999', 'PROJ-100']), true);
+    assert.equal(evaluate(20, ['PROJ-999']), false);
 });

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -150,3 +150,27 @@ test('the filter index built on the SECOLLAB fixture links every pull request', 
         assert.equal(evaluatePullRequest(entry, noFilter, rendered).visible, true);
     }
 });
+
+test('the SECOLLAB fixture carries epics and parent-only issues with their hierarchy', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const underAnEpic = data.jiraIssuesDetails.filter(issue => issue.fields.parent?.fields?.issuetype?.name === 'Epic');
+    assert.ok(underAnEpic.length > 20, `${underAnEpic.length} issues under an epic`);
+    for (const issue of data.jiraIssuesDetails) {
+        if (issue.fields.issuetype) assert.equal(typeof issue.fields.issuetype.hierarchyLevel, 'number');
+    }
+    // Parent-only entries (no status: fetched as parents) carry summary, type, fix versions and parent
+    const parentOnly = data.jiraIssuesDetails.filter(issue => !issue.fields.status);
+    assert.ok(parentOnly.length > 0);
+    for (const issue of parentOnly) {
+        assert.equal(typeof issue.fields.summary, 'string');
+        assert.ok(issue.fields.issuetype.name);
+        assert.ok(Array.isArray(issue.fields.fixVersions));
+    }
+    assert.ok(parentOnly.some(issue => issue.fields.issuetype.name === 'Epic'), 'epics are fetched as parents');
+    assert.ok(parentOnly.some(issue => issue.fields.parent), 'a parent-only story carries its epic');
+    const { pullRequestsById, epics } = buildFilterIndex(data);
+    assert.ok(epics.size >= 3, `${epics.size} epics`);
+    const linkedToSubtask = [...pullRequestsById.values()].filter(entry => entry.linkedIssues.some(issue => issue.fields.issuetype.subtask));
+    assert.ok(linkedToSubtask.length > 0);
+    assert.ok(linkedToSubtask.some(entry => entry.epics.size > 0), 'a pull request linked to a sub-task reaches its epic');
+});


### PR DESCRIPTION
An **Epic** multi-select in the sidebar, after Fix version, keeps the pull requests whose linked issues belong to the selected epics. The epic of a linked issue is: the issue itself when it is an epic, its parent when the parent is an epic, or, for a sub-task, the epic of its parent story. Options read `KEY Summary` (newest issue first within each Jira project), the URL parameter is `epic` (repeated), unknown keys are dropped on restore.

## Changes

- **Hierarchy logic** (`public/app-filter.js`): pure `issueLevel` (epic / standard / sub-task from `issuetype`) and `epicOf`, the only code that interprets `issuetype` and `parent`; `entry.epics` and `index.epics` in the filter index; the epic match; pure, tested `issueOptions` for the option labels and order.
- **Server** (`index.mjs`): the fetch of parent issues asks Jira for `key,summary,issuetype,fixVersions,parent` instead of `key,fixVersions`, so a sub-task reaches the epic of its parent story. Checked against the live SECOLLAB data: the 13 parent-only issues now carry summary and type, 3 carry their epic, and 43 pull requests reach an epic through 7 epics (40 through 5 before). Issues without an epic simply match no epic.
- **Fixtures** (`fixtures/generate.mjs`): epics per Jira project, `hierarchyLevel` on every issue type, Jira-shaped inline parents, 40% of standard issues under an epic, parent-only entries with their hierarchy; on the SECOLLAB fixture 13 of 112 pull requests reach an epic only through a sub-task, so the server change is exercised offline.
- **Sidebar and state** (`public/index.html`, `public/app.js`): the Epic multi-select with its info icon, `currentEpics`, one id in `multiSelectIds` and one parameter in `filterUrlParams`, a generic `populateIssueFilter(elementId, issues, selectedKeys)` that the story filter reuses.
- **Multi-select** (`public/multi-select.js`): option labels carry the full label as tooltip (they are ellipsised); `escapeHtml` now escapes quotes too, since summaries flow into an attribute.
- **Tests**: 42 (`npm test`): the four rows of the resolution table, the degraded case of an older server, two epics on one pull request, option ordering, the fixture hierarchy.
- **Docs**: README, CLAUDE.md, PRD (F3.8, F4.11); plan corrections for the story filter.

## Verified

- `npm test`: 42 pass, 0 fail, deterministic fixtures.
- In the browser on the fixture server: selecting an epic shows exactly the 8 pull requests an independent computation over the API data predicts (3 of them through sub-tasks), counters and badge follow, `?epic=` restores and drops unknown keys, "Clear filters" and the project switch reset, OSLC lists its own epics, a label with quotes, angle brackets and an ampersand renders intact in the option and its tooltip.

Stacked on #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuGDyDk4Av2U5A1oVXhAMF