### PR TITLE
feat: story filter (linked issue or parent of a sub-task)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,14 @@ pr-tree/
 - Periodic refresh logic (2-minute intervals, tab visibility detection)
 - Loading state management
 - Event handlers for user interactions
+- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select from the index and returns the selection restricted to the offered keys
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against and the epic keys (`epics`), plus `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`); it also returns `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
 - `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
-- `parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters` (pure)
+- `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
 - `updateCounterDisplay(element, visible, total)`: the `n/total` text and tooltip of a counter; the counts come from the filter pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Multi-project support with dropdown selection
 - Pull request visualization ordered by most recently updated
 - Jira issue integration with status tracking
-- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)
+- Advanced filtering (text, sprint, fix version, epic, story, assignee, reviewer, sync status)
 - Real-time conflict detection
 - Commit ahead/behind tracking
 - Smart reload (auto-updates every 2 minutes when data changes)
@@ -124,13 +124,13 @@ pr-tree/
 - Periodic refresh logic (2-minute intervals, tab visibility detection)
 - Loading state management
 - Event handlers for user interactions
-- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select from the index and returns the selection restricted to the offered keys
+- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select (epics and stories) from the index and returns the selection restricted to the offered keys
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`); it also returns `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`) and story keys (`stories`); it also returns `index.epics` and `index.stories`, the epics and stories to list in the filters; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
-- `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
+- `issueLevel`, `epicOf`, `storyOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
@@ -290,6 +290,7 @@ let currentText = '';          // text filter
 let currentSprints = [];        // sprint ids
 let currentFixVersions = [];    // fix version ids
 let currentEpics = [];         // epic keys
+let currentStories = [];       // story keys
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -300,7 +301,7 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&story=PROJ-200&sync=requested&ready=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
@@ -486,10 +487,10 @@ Three streams available:
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
-11. **Jira hierarchy**: only `issueLevel`/`epicOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
+11. **Jira hierarchy**: only `issueLevel`/`epicOf`/`storyOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Multi-project support with dropdown selection
 - Pull request visualization ordered by most recently updated
 - Jira issue integration with status tracking
-- Advanced filtering (text, sprint, fix version, assignee, reviewer, sync status)
+- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)
 - Real-time conflict detection
 - Commit ahead/behind tracking
 - Smart reload (auto-updates every 2 minutes when data changes)
@@ -74,6 +74,7 @@ pr-tree/
 - API endpoint definitions (`/api/projects`, `/api/pull-requests/:project`, `/api/pull-request-conflicts/:repoName/:spec`)
 - Bitbucket API integration (fetch PRs, commit diffs)
 - Jira API integration (fetch issues, sprints, orphaned issues)
+- `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
 - Response hashing for change detection
 - Comprehensive logging system (access.log, error.log, performance.log)
 - Static file serving for public directory
@@ -125,9 +126,10 @@ pr-tree/
 - Event handlers for user interactions
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against and the epic keys (`epics`), plus `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
@@ -136,6 +138,7 @@ pr-tree/
 **fixtures/generate.mjs** and **fixtures/index.mjs**
 - `generateProjectData(projectName, projectConfig, { scale, chainDepth })` returns exactly the `/api/pull-requests/:project` response shape; `generateSyncStatuses(projectData)` the `/api/sync-statuses/:project` one
 - Volumes and structure follow the real projects (see the constants at the top of generate.mjs), including the 24-deep stack of `products.secollab` under `feat/ai_investigations` that made the old filtering explode
+- Epics per Jira project (`epicSummaries`, keys in numbering block 8): 40% of the standard issues have an epic parent, parents of sub-tasks are standard issues, parent-only entries carry summary, type, fix versions and parent like the server's
 - Seeded PRNG: the same repository always yields the same pull requests, so `dataHash` is stable and the smart reload stays quiet
 - `parseFixtureOptions()` reads `--fixtures`, `--fixture-scale=N`, `--fixture-chain-depth=N` or the `PR_TREE_FIXTURES*` environment variables; `fixtureConfig()` replaces config.js; `createFixtureSource()` is what index.mjs calls instead of Atlassian
 
@@ -285,6 +288,7 @@ let currentProject = null;
 let currentText = '';          // text filter
 let currentSprints = [];        // sprint ids
 let currentFixVersions = [];    // fix version ids
+let currentEpics = [];         // epic keys
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -295,7 +299,7 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&sync=requested&ready=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
@@ -481,9 +485,10 @@ Three streams available:
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
+11. **Jira hierarchy**: only `issueLevel`/`epicOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/PRD.md
+++ b/PRD.md
@@ -180,6 +180,7 @@ The application integrates with a Jira workflow where:
 - F4.9: Hierarchical filtering (preserve parent-child relationships)
 - F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
 - F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
+- F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
@@ -480,6 +481,7 @@ The application integrates with a Jira workflow where:
 |  Sprint        | Repository 1                          [X / Y]   |
 |  Fix version   |   Branch A                            [X / Y]   |
 |  Epic          |                                                 |
+|  Story         |                                                 |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
 |  Reviewer      |       JIRA-123 [In Progress]                    |
 |  Ready         |     PR #2                                       |

--- a/PRD.md
+++ b/PRD.md
@@ -144,6 +144,7 @@ Development teams using Bitbucket and Jira face several workflow inefficiencies:
 - F3.5: Provide direct links to Jira issues
 - F3.6: Detect orphaned issues (In Review status without PRs)
 - F3.7: Support Jira workflow integration with "In Review" and "In Progress" statuses
+- F3.8: Fetch the parent of linked issues, and the summary, type and parent of parent issues, so that sub-tasks reach their story and epic
 
 **Workflow Context:**
 The application integrates with a Jira workflow where:
@@ -178,6 +179,7 @@ The application integrates with a Jira workflow where:
 - F4.8: Maintain filter state in URL parameters
 - F4.9: Hierarchical filtering (preserve parent-child relationships)
 - F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
+- F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
@@ -477,6 +479,7 @@ The application integrates with a Jira workflow where:
 |  Search        |                                                 |
 |  Sprint        | Repository 1                          [X / Y]   |
 |  Fix version   |   Branch A                            [X / Y]   |
+|  Epic          |                                                 |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
 |  Reviewer      |       JIRA-123 [In Progress]                    |
 |  Ready         |     PR #2                                       |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
     * `/` focuses the search box, Escape clears it
 * Provides an epic filter
     * Keeps the pull requests whose linked issues belong to the selected epics; a pull request linked to a sub-task follows the epic of its parent story
+* Provides a story filter
+    * Keeps the pull requests delivering the selected issues: the linked issue itself, or the parent of a linked sub-task
 * Provides an assignee filter
     * Filters pull requests based on the assignee of associated Jira issues
     * Highlights in red those where an effort is expected
@@ -36,7 +38,7 @@
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, text, sprint, fixVersion, epic, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -83,6 +85,7 @@
     * Epic filter: pull requests of the selected epics, resolved through the parent story when the pull request is linked to a sub-task
         * The server now fetches the summary, type and parent of parent issues (previously their fix versions only)
         * Fixture data carries epics
+    * Story filter: pull requests of the selected issues, the linked issue itself or the parent of a linked sub-task
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 * Provides a text filter
     * Keeps the pull requests whose title, source branch name or linked issue keys contain every word typed (case-insensitive)
     * `/` focuses the search box, Escape clears it
+* Provides an epic filter
+    * Keeps the pull requests whose linked issues belong to the selected epics; a pull request linked to a sub-task follows the epic of its parent story
 * Provides an assignee filter
     * Filters pull requests based on the assignee of associated Jira issues
     * Highlights in red those where an effort is expected
@@ -34,7 +36,7 @@
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, text, sprint, fixVersion, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, epic, assignee, reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -78,6 +80,9 @@
 * Version 2.4.0
     * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
         * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean
+    * Epic filter: pull requests of the selected epics, resolved through the parent story when the pull request is linked to a sub-task
+        * The server now fetches the summary, type and parent of parent issues (previously their fix versions only)
+        * Fixture data carries epics
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/docs/superpowers/plans/2026-09-09-text-epic-story-filters.md
+++ b/docs/superpowers/plans/2026-09-09-text-epic-story-filters.md
@@ -1656,11 +1656,13 @@ PR body: the resolution rules (epic itself, epic parent, epic of the parent stor
 
 With the user's `config.js` in place: `PORT=3002 node index.mjs`, then `curl -s http://localhost:3002/api/pull-requests/SECOLLAB > /private/tmp/claude-501/-Users-frej-Sites-pr-tree/fa03c818-2340-4f3b-8fb1-aecd87e2c6a0/scratchpad/secollab-after.json`; stop the server. Parent-only issues (`!fields.status`) now carry `summary`, `issuetype` and, for stories under an epic, `parent`; `buildFilterIndex` on that file yields more entries with a non-empty `epics` set than the 40 counted on 2026-09-09 (up to 56). One request per project only: the real server on port 3000 already polls Atlassian every two minutes.
 
+**Review follow-up (sixth commit, after the code-quality review):** `MultiSelect.escapeHtml()` now escapes quotes too (the option tooltip carries free-text summaries). The option helpers moved to `public/app-filter.js` as an exported, tested `issueOptions(issues)` (with private `compareIssueKeys` / `splitIssueKey`), and `populateEpicFilter` became a generic `populateIssueFilter(elementId, issues, selectedKeys)` in `app.js` that returns the selection restricted to the offered keys: `currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);`. The epic block of `restoreFiltersFromUrl` (a `setSelectedValues` before the options exist) was dropped. Fixtures: the first epic of each project has a fix version; the epic draw is skipped for projects without epics. Task 3 below is written against that code.
+
 ---
 
 ### Task 3: Story filter
 
-A multi-select of the stories delivered by the pull requests: the linked issue itself, or the parent of a linked sub-task. Same wiring as the epic filter.
+A multi-select of the stories delivered by the pull requests: the linked issue itself, or the parent of a linked sub-task. Same wiring as the epic filter, through the generic `populateIssueFilter` and `issueOptions` helpers.
 
 **Files:**
 - Modify: `public/app-filter.js`
@@ -1839,37 +1841,15 @@ c. Add `'storySelect'` to `multiSelectIds` (after `'epicSelect'`) and `'story'` 
 
 d. In `updateUrlWithFilters()`, add `currentStories.forEach(v => url.searchParams.append('story', v));` after the `epic` append.
 
-e. In `restoreFiltersFromUrl()`, add `currentStories = urlParams.getAll('story');` after the `epic` line, and after the `epicMultiSelect` restore block:
-
-```js
-    const storyMultiSelect = getMultiSelect('storySelect');
-    if (storyMultiSelect) {
-        storyMultiSelect.setSelectedValues(currentStories);
-    }
-```
+e. In `restoreFiltersFromUrl()`, add `currentStories = urlParams.getAll('story');` after the `epic` line (nothing else: the selection is applied by `populateIssueFilter` once the options exist).
 
 f. Nothing to change in `handleProjectChange()`.
 
 g. In `readFilterControls()`, add `const storyMultiSelect = getMultiSelect('storySelect');` and `currentStories = storyMultiSelect ? storyMultiSelect.getSelectedValues() : [];` after the epic lines.
 
-h. In `renderEverything()`, add `populateStoryFilter(filterIndex.stories);` right after `populateEpicFilter(filterIndex.epics);`.
+h. In `renderEverything()`, add `currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);` right after the `currentEpics = populateIssueFilter(...)` line.
 
-i. Add after `populateEpicFilter`:
-
-```js
-function populateStoryFilter(stories) {
-    const storyMultiSelect = getMultiSelect('storySelect');
-    if (!storyMultiSelect) return;
-
-    const options = issueOptions(stories);
-    storyMultiSelect.setOptions(options);
-
-    // Keep only the stories that exist in the options (the URL may carry unknown keys)
-    const known = new Set(options.map(option => option.value));
-    currentStories = currentStories.filter(key => known.has(key));
-    storyMultiSelect.setSelectedValues(currentStories);
-}
-```
+i. Nothing to add: `populateIssueFilter` (Task 2) is generic, and `issueOptions` in `app-filter.js` sorts the stories like the epics.
 
 j. Nothing to change in `initializeMultiSelects()`.
 
@@ -1915,7 +1895,7 @@ a. `README.md`:
 b. `CLAUDE.md`:
 
 - Replace `- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)` with `- Advanced filtering (text, sprint, fix version, epic, story, assignee, reviewer, sync status)`.
-- In the `**public/app-filter.js**` block: in the `buildFilterIndex` bullet, replace `the epic keys (`epics`), plus `index.epics`, the epics to list in the filter` with `the epic and story keys (`epics`, `stories`), plus `index.epics` and `index.stories`, the values to list in the two filters`; replace `- `issueLevel`, `epicOf` (pure)` with `- `issueLevel`, `epicOf`, `storyOf` (pure)`.
+- In the `**public/app-filter.js**` block: in the `buildFilterIndex` bullet, mention the story keys (`stories`) next to the epic keys and `index.stories` next to `index.epics`; in the bullet that starts with `- `issueLevel`, `epicOf``, insert `, `storyOf`` after ``epicOf``. In the `**public/app.js**` block, the `populateIssueFilter` bullet gains `(epics and stories)`.
 - In "Frontend State Management", add `let currentStories = [];       // story keys` after `currentEpics`, and `&story=PROJ-200` after `&epic=PROJ-100` in the URL example.
 - In "Common Pitfalls" item 11, replace `only `issueLevel`/`epicOf`` with `only `issueLevel`/`epicOf`/`storyOf``.
 - In "Testing Approach", add `storyOf` to the pure functions.

--- a/docs/superpowers/specs/2026-09-09-text-epic-story-filters-design.md
+++ b/docs/superpowers/specs/2026-09-09-text-epic-story-filters-design.md
@@ -192,6 +192,12 @@ looks one level up, and the data hash changes once after deployment.
 
 ## 9. Code structure
 
+Superseded in two places during implementation (see the review follow-ups in
+the plan): the option helpers live in `app-filter.js` as the pure, tested
+`issueOptions`, and one generic `populateIssueFilter(elementId, issues,
+selectedKeys)` in `app.js` replaces `populateEpicFilter` and
+`populateStoryFilter`.
+
 | File | PR 1 (text) | PR 2 (epic) | PR 3 (story) |
 |---|---|---|---|
 | `public/index.html` | search box under the sidebar header | Epic multi-select after Fix version | Story multi-select after Epic |

--- a/fixtures/generate.mjs
+++ b/fixtures/generate.mjs
@@ -3,7 +3,8 @@
  *
  * Volumes, repository names, Jira project keys, branch naming, stacked
  * pull-request chains, sprints and fix versions are modelled on the real
- * SECOLLAB and OSLC projects (September 2026 access logs). People are
+ * SECOLLAB and OSLC projects (September 2026 access logs). Standard issues
+ * belong to epics and sub-tasks to stories, as in Jira Cloud. People are
  * fictional. The same repository always yields the same pull requests, so
  * a repository shared by two projects (products.web.oslc) is consistent.
  *
@@ -297,6 +298,52 @@ function createIssueNumbering(block) {
     };
 }
 
+// Epics per Jira project; about 40% of the standard issues belong to one.
+// Their keys use block 8 of the numbering, which no other generation uses.
+const epicSummaries = {
+    SECOLLAB: [
+        'SECollab AI: assistive capability layer', 'Review workflow overhaul', 'DOORS synchronisation 2.0',
+        'End-to-end tests since 2.7.0', 'Accessibility compliance'
+    ],
+    PRDOSLC: ['OSLC Connect for Windchill 1.5', 'Configuration management support', 'TRS provider'],
+    WEBCMN: ['Design tokens migration', 'Session handling']
+};
+
+function createEpic(project, number, summary) {
+    const key = `${project}-${number}`;
+    return {
+        id: String(10000 + number),
+        key,
+        self: `https://${jiraSiteName}.atlassian.net/rest/api/3/issue/${key}`,
+        fields: {
+            summary,
+            status: { name: 'In Progress', statusCategory: { key: 'indeterminate' } },
+            priority: { name: 'Medium', iconUrl: priorityIconUrl('#e97f33'), id: '3' },
+            fixVersions: [],
+            issuetype: { name: 'Epic', subtask: false, hierarchyLevel: 1 }
+        }
+    };
+}
+
+const epicIssues = Object.fromEntries(Object.entries(epicSummaries).map(([project, summaries]) =>
+    [project, summaries.map((summary, index) => createEpic(project, (issueNumberBase[project] || 100) + 8000 + index + 1, summary))]
+));
+
+// The parent field as Jira returns it: the key and a few inline fields
+function inlineParent(issue) {
+    return {
+        id: issue.id,
+        key: issue.key,
+        self: issue.self,
+        fields: {
+            summary: issue.fields.summary,
+            status: issue.fields.status,
+            priority: issue.fields.priority,
+            issuetype: issue.fields.issuetype
+        }
+    };
+}
+
 function createIssue(random, nextIssueNumber, project, { status, assignee, parent, type } = {}) {
     const key = `${project}-${nextIssueNumber(project)}`;
     const issueType = type || pickWeighted(random, issueTypes);
@@ -305,6 +352,9 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
     // Sub-tasks mostly inherit their fix version from the parent (the server does that too)
     const fixVersions = issueType === 'Sub-task' || random() < 0.25 ? [] : [pick(random, versions)];
     const assigneePerson = assignee === null ? null : (assignee || (random() < 0.85 ? pick(random, team) : null));
+    // Sub-tasks get the parent they were given; standard issues belong to an epic 40% of the time
+    const epics = epicIssues[project] || [];
+    const parentIssue = parent || (issueType !== 'Sub-task' && random() < 0.4 && epics.length > 0 ? pick(random, epics) : null);
     return {
         id: String(10000 + Number(key.split('-')[1])),
         key,
@@ -315,8 +365,8 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
             priority: { name: priorityName, iconUrl: priorityIconUrl(priorityColour), id: String(priorities.findIndex(p => p[0] === priorityName) + 1) },
             fixVersions,
             assignee: assigneePerson ? assigneePerson.jira : null,
-            issuetype: { name: issueType, subtask: issueType === 'Sub-task' },
-            ...(parent ? { parent: { key: parent.key, fields: { summary: parent.fields.summary } } } : {})
+            issuetype: { name: issueType, subtask: issueType === 'Sub-task', hierarchyLevel: issueType === 'Sub-task' ? -1 : 0 },
+            ...(parentIssue ? { parent: inlineParent(parentIssue) } : {})
         }
     };
 }
@@ -434,7 +484,8 @@ export function generateRepository(repoName, { scale = 1, chainDepth = deepChain
             let parent = null;
             if (type === 'Sub-task') {
                 // Half of the parents are only known through the sub-task (fetched separately by the server)
-                parent = random() < 0.5 && issues.length > 0 ? pick(random, issues) : createIssue(random, nextIssueNumber, project, { type: 'Story', status: 'In Progress' });
+                const standardIssues = issues.filter(candidate => !candidate.fields.issuetype.subtask);
+                parent = random() < 0.5 && standardIssues.length > 0 ? pick(random, standardIssues) : createIssue(random, nextIssueNumber, project, { type: 'Story', status: 'In Progress' });
                 if (!issues.includes(parent)) parentIssues.push(parent);
             }
             const issue = createIssue(random, nextIssueNumber, project, { status: j === 0 ? status : (random() < 0.8 ? status : undefined), parent, type });
@@ -544,6 +595,9 @@ export function generateProjectData(projectName, projectConfig, { scale = 1, cha
     const nextIssueNumber = createIssueNumbering(9);
     const pullRequests = [];
     const knownIssues = new Map();
+    for (const epic of Object.values(epicIssues).flat()) {
+        knownIssues.set(epic.key, epic);
+    }
     for (const repoName of projectConfig.repositories) {
         const data = repositoryData(repoName, { scale, chainDepth });
         pullRequests.push(...data.pullRequests);
@@ -569,13 +623,24 @@ export function generateProjectData(projectName, projectConfig, { scale = 1, cha
             jiraIssuesDetails.push(structuredClone(issue));
         }
     }
-    // Parents of sub-tasks are fetched by the server with their fix versions only
+    // Parents (stories of sub-tasks, epics of standard issues) are fetched by the
+    // server with their summary, type, fix versions and parent
     for (const issue of [...jiraIssuesDetails]) {
         const parentKey = issue.fields.parent?.key;
         if (parentKey && !seen.has(parentKey) && knownIssues.has(parentKey)) {
             seen.add(parentKey);
             const parent = knownIssues.get(parentKey);
-            jiraIssuesDetails.push({ id: parent.id, key: parent.key, self: parent.self, fields: { fixVersions: parent.fields.fixVersions } });
+            jiraIssuesDetails.push({
+                id: parent.id,
+                key: parent.key,
+                self: parent.self,
+                fields: {
+                    summary: parent.fields.summary,
+                    issuetype: parent.fields.issuetype,
+                    fixVersions: parent.fields.fixVersions,
+                    ...(parent.fields.parent ? { parent: parent.fields.parent } : {})
+                }
+            });
         }
     }
     // Sub-tasks inherit the fix versions of their parent

--- a/fixtures/generate.mjs
+++ b/fixtures/generate.mjs
@@ -309,7 +309,7 @@ const epicSummaries = {
     WEBCMN: ['Design tokens migration', 'Session handling']
 };
 
-function createEpic(project, number, summary) {
+function createEpic(project, number, summary, fixVersions) {
     const key = `${project}-${number}`;
     return {
         id: String(10000 + number),
@@ -319,14 +319,20 @@ function createEpic(project, number, summary) {
             summary,
             status: { name: 'In Progress', statusCategory: { key: 'indeterminate' } },
             priority: { name: 'Medium', iconUrl: priorityIconUrl('#e97f33'), id: '3' },
-            fixVersions: [],
+            fixVersions,
             issuetype: { name: 'Epic', subtask: false, hierarchyLevel: 1 }
         }
     };
 }
 
+// The first epic of a project has a fix version, so issues inherit one from their epic
 const epicIssues = Object.fromEntries(Object.entries(epicSummaries).map(([project, summaries]) =>
-    [project, summaries.map((summary, index) => createEpic(project, (issueNumberBase[project] || 100) + 8000 + index + 1, summary))]
+    [project, summaries.map((summary, index) => createEpic(
+        project,
+        (issueNumberBase[project] || 100) + 8000 + index + 1,
+        summary,
+        index === 0 ? (fixVersionsByProject[project] || []).slice(0, 1) : []
+    ))]
 ));
 
 // The parent field as Jira returns it: the key and a few inline fields
@@ -354,7 +360,7 @@ function createIssue(random, nextIssueNumber, project, { status, assignee, paren
     const assigneePerson = assignee === null ? null : (assignee || (random() < 0.85 ? pick(random, team) : null));
     // Sub-tasks get the parent they were given; standard issues belong to an epic 40% of the time
     const epics = epicIssues[project] || [];
-    const parentIssue = parent || (issueType !== 'Sub-task' && random() < 0.4 && epics.length > 0 ? pick(random, epics) : null);
+    const parentIssue = parent || (epics.length > 0 && issueType !== 'Sub-task' && random() < 0.4 ? pick(random, epics) : null);
     return {
         id: String(10000 + Number(key.split('-')[1])),
         key,

--- a/index.mjs
+++ b/index.mjs
@@ -300,7 +300,9 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Issues without fix versions inherit their parent's, one level: sub-tasks from their story, and stories from their epic when the epic was fetched too
+    // Issues without fix versions inherit their parent's (sub-tasks from their story, stories from
+    // their epic when it was fetched too). One pass in array order, so a version can travel
+    // epic -> story -> sub-task when the story comes first
     for (const issue of jiraIssuesDetails) {
         if (issue.fields.parent &&
             (!issue.fields.fixVersions || issue.fields.fixVersions.length === 0)) {

--- a/index.mjs
+++ b/index.mjs
@@ -300,7 +300,7 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Inherit fix versions from parent for subtasks without fix versions
+    // Issues without fix versions inherit their parent's, one level: sub-tasks from their story, and stories from their epic when the epic was fetched too
     for (const issue of jiraIssuesDetails) {
         if (issue.fields.parent &&
             (!issue.fields.fixVersions || issue.fields.fixVersions.length === 0)) {

--- a/index.mjs
+++ b/index.mjs
@@ -275,10 +275,11 @@ async function fetchJiraIssuesDetails(jiraIssues, jiraProjects) {
         }
     }
 
-    // Fetch missing parent issues to get their fix versions
+    // Fetch missing parent issues: their fix versions (inherited by sub-tasks)
+    // and their summary, type and parent (epic and story filters)
     if (missingParentKeys.length > 0) {
         const parentJql = `key IN (${missingParentKeys.join(',')})`;
-        const parentUrl = `${jiraBaseUrl}?jql=${encodeURIComponent(parentJql)}&fields=key,fixVersions`;
+        const parentUrl = `${jiraBaseUrl}?jql=${encodeURIComponent(parentJql)}&fields=key,summary,issuetype,fixVersions,parent`;
         try {
             const startTime = Date.now();
             const response = await atlassianFetch(parentUrl, {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -99,6 +99,8 @@ export function epicOf(issue, issuesByKey) {
     return null;
 }
 
+// ---------------------------------------------------- issue filter options
+
 /**
  * Options of an issue multi-select: "KEY Summary", valued by key, sorted by
  * Jira project then issue number descending (newest first). Pure.

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -23,13 +23,14 @@ export function initializeFilter(apiResult) {
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }) {
     return [
         parseTextQuery(text).length > 0,
         assignees.length > 0,
         reviewers.length > 0,
         sprints.length > 0,
         fixVersions.length > 0,
+        epics.length > 0,
         ready === true,
         sync !== 'Show all'
     ].filter(Boolean).length;
@@ -48,6 +49,51 @@ export function parseTextQuery(text) {
 /** True when every term is a substring of the searchable text. Pure. */
 export function matchesText(searchText, terms) {
     return terms.every(term => searchText.includes(term));
+}
+
+// ---------------------------------------------------------- Jira hierarchy
+// Jira Cloud: epic (hierarchyLevel 1) > standard issue (0) > sub-task (-1).
+// Every issue carries fields.issuetype and, when it has one, fields.parent with
+// the parent's key and inline fields (summary, status, priority, issuetype).
+// This is the only place that interprets these fields.
+
+/**
+ * Level of an issue in the Jira hierarchy: 'epic', 'standard' or 'subtask'.
+ * Issues without a type (parents fetched with fix versions only by an older
+ * server) count as standard. Pure.
+ */
+export function issueLevel(issue) {
+    const type = issue.fields && issue.fields.issuetype;
+    if (!type) return 'standard';
+    if (type.hierarchyLevel > 0 || type.name === 'Epic') return 'epic';
+    if (type.subtask === true || type.hierarchyLevel < 0) return 'subtask';
+    return 'standard';
+}
+
+// Key and summary of an issue or of an inline parent, as listed in the filters
+function issueReference(issue) {
+    return { key: issue.key, summary: (issue.fields && issue.fields.summary) || '' };
+}
+
+/**
+ * The epic above an issue: the issue itself when it is an epic, its parent when
+ * the parent is an epic, or the epic of its parent story when the issue is a
+ * sub-task (the story is looked up in issuesByKey, where the server puts the
+ * parents it fetched). Pure.
+ * @returns {{ key: string, summary: string } | null}
+ */
+export function epicOf(issue, issuesByKey) {
+    const level = issueLevel(issue);
+    if (level === 'epic') return issueReference(issue);
+    const parent = issue.fields && issue.fields.parent;
+    if (!parent) return null;
+    if (issueLevel(parent) === 'epic') return issueReference(parent);
+    if (level === 'subtask') {
+        const story = issuesByKey.get(parent.key);
+        const grandParent = story && story.fields && story.fields.parent;
+        if (grandParent && issueLevel(grandParent) === 'epic') return issueReference(grandParent);
+    }
+    return null;
 }
 
 // --------------------------------------------------------------- attention
@@ -80,7 +126,7 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
  * Indexes the API result for the filters: one entry per pull request with its
  * linked issues, the text the text filter searches and the sets the other
  * filters compare against. Pure.
- * @returns {{ pullRequestsById: Map<number, object> }}
+ * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }> }}
  */
 export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
     const issuesByKey = new Map(jiraIssuesDetails.map(issue => [issue.key, issue]));
@@ -96,9 +142,14 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
     }
 
     const pullRequestsById = new Map();
+    const epics = new Map();
     for (const pullRequest of pullRequests) {
         const issueKeys = jiraIssuesMap[pullRequest.id] || [];
         const linkedIssues = issueKeys.map(key => issuesByKey.get(key)).filter(issue => issue);
+        const pullRequestEpics = linkedIssues.map(issue => epicOf(issue, issuesByKey)).filter(epic => epic);
+        for (const epic of pullRequestEpics) {
+            epics.set(epic.key, epic);
+        }
         const entry = {
             pullRequest,
             linkedIssues,
@@ -114,12 +165,13 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
             sprints: new Set(issueKeys.flatMap(key => [...(sprintsByIssueKey.get(key) || [])])),
             fixVersions: new Set(linkedIssues
                 .flatMap(issue => issue.fields.fixVersions || [])
-                .map(version => String(version.id)))
+                .map(version => String(version.id))),
+            epics: new Set(pullRequestEpics.map(epic => epic.key))
         };
         pullRequestsById.set(pullRequest.id, entry);
     }
 
-    return { pullRequestsById };
+    return { pullRequestsById, epics };
 }
 
 // -------------------------------------------------------------- evaluation
@@ -127,12 +179,12 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -147,6 +199,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const reviewerMatch = reviewers.length === 0 || reviewers.some(name => entry.reviewers.has(name));
     const sprintMatch = sprints.length === 0 || sprints.some(sprintId => entry.sprints.has(String(sprintId)));
     const fixVersionMatch = fixVersions.length === 0 || fixVersions.some(versionId => entry.fixVersions.has(String(versionId)));
+    const epicMatch = epics.length === 0 || epics.some(key => entry.epics.has(key));
     const syncMatch = sync === 'Show all' ||
         (sync === 'requested' && hasSyncLabel) ||
         (sync === 'OK' && !hasSyncLabel);
@@ -154,7 +207,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const readyMatch = !ready || attention.reviewer;
 
     return {
-        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && syncMatch && readyMatch,
+        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && syncMatch && readyMatch,
         attention
     };
 }
@@ -163,7 +216,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(filters) {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -80,6 +80,9 @@ function issueReference(issue) {
  * the parent is an epic, or the epic of its parent story when the issue is a
  * sub-task (the story is looked up in issuesByKey, where the server puts the
  * parents it fetched). Pure.
+ * @param {object} issue - a linked issue or an inline parent
+ * @param {Map<string, object>} issuesByKey - the issues of jiraIssuesDetails by
+ *   key (required: the sub-task branch reads it)
  * @returns {{ key: string, summary: string } | null}
  */
 export function epicOf(issue, issuesByKey) {
@@ -94,6 +97,30 @@ export function epicOf(issue, issuesByKey) {
         if (grandParent && issueLevel(grandParent) === 'epic') return issueReference(grandParent);
     }
     return null;
+}
+
+/**
+ * Options of an issue multi-select: "KEY Summary", valued by key, sorted by
+ * Jira project then issue number descending (newest first). Pure.
+ * @param {Iterable<{ key: string, summary: string }>} issues - records, e.g. index.epics.values()
+ * @returns {{ value: string, label: string }[]}
+ */
+export function issueOptions(issues) {
+    return [...issues]
+        .sort((a, b) => compareIssueKeys(a.key, b.key))
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+}
+
+// Jira project alphabetically, then issue number descending
+function compareIssueKeys(a, b) {
+    const [projectA, numberA] = splitIssueKey(a);
+    const [projectB, numberB] = splitIssueKey(b);
+    return projectA.localeCompare(projectB) || numberB - numberA;
+}
+
+function splitIssueKey(key) {
+    const dash = key.lastIndexOf('-');
+    return [key.slice(0, dash), Number(key.slice(dash + 1))];
 }
 
 // --------------------------------------------------------------- attention

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -23,7 +23,7 @@ export function initializeFilter(apiResult) {
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }) {
     return [
         parseTextQuery(text).length > 0,
         assignees.length > 0,
@@ -31,6 +31,7 @@ export function countActiveFilters({ text = '', assignees, reviewers, sprints, f
         sprints.length > 0,
         fixVersions.length > 0,
         epics.length > 0,
+        stories.length > 0,
         ready === true,
         sync !== 'Show all'
     ].filter(Boolean).length;
@@ -99,6 +100,19 @@ export function epicOf(issue, issuesByKey) {
     return null;
 }
 
+/**
+ * The story an issue belongs to: the issue itself when it is a standard issue,
+ * its parent when it is a sub-task (the inline parent carries the key and the
+ * summary), nothing for an epic. Pure.
+ * @returns {{ key: string, summary: string } | null}
+ */
+export function storyOf(issue) {
+    const level = issueLevel(issue);
+    if (level === 'standard') return issueReference(issue);
+    if (level === 'subtask' && issue.fields.parent) return issueReference(issue.fields.parent);
+    return null;
+}
+
 // ---------------------------------------------------- issue filter options
 
 /**
@@ -155,7 +169,7 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
  * Indexes the API result for the filters: one entry per pull request with its
  * linked issues, the text the text filter searches and the sets the other
  * filters compare against. Pure.
- * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }> }}
+ * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }>, stories: Map<string, { key, summary }> }}
  */
 export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
     const issuesByKey = new Map(jiraIssuesDetails.map(issue => [issue.key, issue]));
@@ -172,12 +186,17 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 
     const pullRequestsById = new Map();
     const epics = new Map();
+    const stories = new Map();
     for (const pullRequest of pullRequests) {
         const issueKeys = jiraIssuesMap[pullRequest.id] || [];
         const linkedIssues = issueKeys.map(key => issuesByKey.get(key)).filter(issue => issue);
         const pullRequestEpics = linkedIssues.map(issue => epicOf(issue, issuesByKey)).filter(epic => epic);
         for (const epic of pullRequestEpics) {
             epics.set(epic.key, epic);
+        }
+        const pullRequestStories = linkedIssues.map(issue => storyOf(issue)).filter(story => story);
+        for (const story of pullRequestStories) {
+            stories.set(story.key, story);
         }
         const entry = {
             pullRequest,
@@ -195,12 +214,13 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
             fixVersions: new Set(linkedIssues
                 .flatMap(issue => issue.fields.fixVersions || [])
                 .map(version => String(version.id))),
-            epics: new Set(pullRequestEpics.map(epic => epic.key))
+            epics: new Set(pullRequestEpics.map(epic => epic.key)),
+            stories: new Set(pullRequestStories.map(story => story.key))
         };
         pullRequestsById.set(pullRequest.id, entry);
     }
 
-    return { pullRequestsById, epics };
+    return { pullRequestsById, epics, stories };
 }
 
 // -------------------------------------------------------------- evaluation
@@ -208,12 +228,12 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -229,6 +249,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const sprintMatch = sprints.length === 0 || sprints.some(sprintId => entry.sprints.has(String(sprintId)));
     const fixVersionMatch = fixVersions.length === 0 || fixVersions.some(versionId => entry.fixVersions.has(String(versionId)));
     const epicMatch = epics.length === 0 || epics.some(key => entry.epics.has(key));
+    const storyMatch = stories.length === 0 || stories.some(key => entry.stories.has(key));
     const syncMatch = sync === 'Show all' ||
         (sync === 'requested' && hasSyncLabel) ||
         (sync === 'OK' && !hasSyncLabel);
@@ -236,7 +257,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const readyMatch = !ready || attention.reviewer;
 
     return {
-        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && syncMatch && readyMatch,
+        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && storyMatch && syncMatch && readyMatch,
         attention
     };
 }
@@ -245,7 +266,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(filters) {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -124,7 +124,7 @@ export function storyOf(issue) {
 export function issueOptions(issues) {
     return [...issues]
         .sort((a, b) => compareIssueKeys(a.key, b.key))
-        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}`.trim() }));
 }
 
 // Jira project alphabetically, then issue number descending

--- a/public/app.js
+++ b/public/app.js
@@ -7,6 +7,7 @@ let currentProject = null;
 let currentText = '';
 let currentSprints = [];
 let currentFixVersions = [];
+let currentEpics = [];
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -20,9 +21,9 @@ let syncStatusLoading = false;
 let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
-const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'assigneeSelect', 'reviewerSelect'];
+const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'assigneeSelect', 'reviewerSelect'];
 // URL parameters written by the filters
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'assignee', 'reviewer', 'sync', 'ready'];
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'assignee', 'reviewer', 'sync', 'ready'];
 
 function currentFilters() {
     return {
@@ -31,6 +32,7 @@ function currentFilters() {
         reviewers: currentReviewers,
         sprints: currentSprints,
         fixVersions: currentFixVersions,
+        epics: currentEpics,
         sync: currentSync,
         ready: currentReadyForReviewer
     };
@@ -89,6 +91,7 @@ function updateUrlWithFilters({ replace = false } = {}) {
     currentReviewers.forEach(v => url.searchParams.append('reviewer', v));
     currentSprints.forEach(v => url.searchParams.append('sprint', v));
     currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
+    currentEpics.forEach(v => url.searchParams.append('epic', v));
     if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
     if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
 
@@ -114,6 +117,7 @@ function restoreFiltersFromUrl() {
     currentReviewers = urlParams.getAll('reviewer');
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
+    currentEpics = urlParams.getAll('epic');
     currentText = urlParams.get('q') || '';
 
     if (!currentSyncStatuses) {
@@ -138,6 +142,10 @@ function restoreFiltersFromUrl() {
     }
     if (fixVersionMultiSelect) {
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
+    }
+    const epicMultiSelect = getMultiSelect('epicSelect');
+    if (epicMultiSelect) {
+        epicMultiSelect.setSelectedValues(currentEpics);
     }
 
     // Update sync select and ready checkbox
@@ -282,12 +290,14 @@ function readFilterControls() {
     const reviewerMultiSelect = getMultiSelect('reviewerSelect');
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
+    const epicMultiSelect = getMultiSelect('epicSelect');
 
     currentText = textFilter ? textFilter.value : '';
     currentAssignees = assigneeMultiSelect ? assigneeMultiSelect.getSelectedValues() : [];
     currentReviewers = reviewerMultiSelect ? reviewerMultiSelect.getSelectedValues() : [];
     currentSprints = sprintMultiSelect ? sprintMultiSelect.getSelectedValues() : [];
     currentFixVersions = fixVersionMultiSelect ? fixVersionMultiSelect.getSelectedValues() : [];
+    currentEpics = epicMultiSelect ? epicMultiSelect.getSelectedValues() : [];
 
     // Get sync and ready values from regular form elements
     const syncSelect = document.getElementById("syncSelect");
@@ -476,7 +486,7 @@ function renderEverything(apiResult) {
     const toggleStates = captureToggleStates();
 
     currentApiResult = apiResult;
-    initializeFilter(currentApiResult);
+    const filterIndex = initializeFilter(currentApiResult);
     const container = document.getElementById('pull-requests');
 
     // Create main content
@@ -503,6 +513,7 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
+    populateEpicFilter(filterIndex.epics);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();
@@ -775,6 +786,38 @@ function populateFixVersionFilter(jiraIssuesDetails) {
         currentFixVersions = currentFixVersions.filter(id => validFixVersionIds.includes(id));
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
     }
+}
+
+// Options of an issue filter: "KEY Summary", newest issue first within each Jira project
+function issueOptions(issues) {
+    return [...issues.values()]
+        .sort((a, b) => compareIssueKeys(a.key, b.key))
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+}
+
+// Jira project alphabetically, then issue number descending
+function compareIssueKeys(a, b) {
+    const [projectA, numberA] = splitIssueKey(a);
+    const [projectB, numberB] = splitIssueKey(b);
+    return projectA.localeCompare(projectB) || numberB - numberA;
+}
+
+function splitIssueKey(key) {
+    const dash = key.lastIndexOf('-');
+    return [key.slice(0, dash), Number(key.slice(dash + 1))];
+}
+
+function populateEpicFilter(epics) {
+    const epicMultiSelect = getMultiSelect('epicSelect');
+    if (!epicMultiSelect) return;
+
+    const options = issueOptions(epics);
+    epicMultiSelect.setOptions(options);
+
+    // Keep only the epics that exist in the options (the URL may carry unknown keys)
+    const known = new Set(options.map(option => option.value));
+    currentEpics = currentEpics.filter(key => known.has(key));
+    epicMultiSelect.setSelectedValues(currentEpics);
 }
 
 // Fetches the SYNC status of every pull request of the current project in a

--- a/public/app.js
+++ b/public/app.js
@@ -120,6 +120,7 @@ function restoreFiltersFromUrl() {
     currentReviewers = urlParams.getAll('reviewer');
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
+    // Epic and story selections are applied by populateIssueFilter once their options exist
     currentEpics = urlParams.getAll('epic');
     currentStories = urlParams.getAll('story');
     currentText = urlParams.get('q') || '';

--- a/public/app.js
+++ b/public/app.js
@@ -8,6 +8,7 @@ let currentText = '';
 let currentSprints = [];
 let currentFixVersions = [];
 let currentEpics = [];
+let currentStories = [];
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -21,9 +22,9 @@ let syncStatusLoading = false;
 let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
-const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'assigneeSelect', 'reviewerSelect'];
+const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'storySelect', 'assigneeSelect', 'reviewerSelect'];
 // URL parameters written by the filters
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'assignee', 'reviewer', 'sync', 'ready'];
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'ready'];
 
 function currentFilters() {
     return {
@@ -33,6 +34,7 @@ function currentFilters() {
         sprints: currentSprints,
         fixVersions: currentFixVersions,
         epics: currentEpics,
+        stories: currentStories,
         sync: currentSync,
         ready: currentReadyForReviewer
     };
@@ -92,6 +94,7 @@ function updateUrlWithFilters({ replace = false } = {}) {
     currentSprints.forEach(v => url.searchParams.append('sprint', v));
     currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
     currentEpics.forEach(v => url.searchParams.append('epic', v));
+    currentStories.forEach(v => url.searchParams.append('story', v));
     if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
     if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
 
@@ -118,6 +121,7 @@ function restoreFiltersFromUrl() {
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
     currentEpics = urlParams.getAll('epic');
+    currentStories = urlParams.getAll('story');
     currentText = urlParams.get('q') || '';
 
     if (!currentSyncStatuses) {
@@ -287,6 +291,7 @@ function readFilterControls() {
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
     const epicMultiSelect = getMultiSelect('epicSelect');
+    const storyMultiSelect = getMultiSelect('storySelect');
 
     currentText = textFilter ? textFilter.value : '';
     currentAssignees = assigneeMultiSelect ? assigneeMultiSelect.getSelectedValues() : [];
@@ -294,6 +299,7 @@ function readFilterControls() {
     currentSprints = sprintMultiSelect ? sprintMultiSelect.getSelectedValues() : [];
     currentFixVersions = fixVersionMultiSelect ? fixVersionMultiSelect.getSelectedValues() : [];
     currentEpics = epicMultiSelect ? epicMultiSelect.getSelectedValues() : [];
+    currentStories = storyMultiSelect ? storyMultiSelect.getSelectedValues() : [];
 
     // Get sync and ready values from regular form elements
     const syncSelect = document.getElementById("syncSelect");
@@ -510,6 +516,7 @@ function renderEverything(apiResult) {
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
     currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
+    currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();

--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-import { initializeFilter, filterBranches, countActiveFilters } from './app-filter.js';
+import { initializeFilter, filterBranches, countActiveFilters, issueOptions } from './app-filter.js';
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
 import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
@@ -142,10 +142,6 @@ function restoreFiltersFromUrl() {
     }
     if (fixVersionMultiSelect) {
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
-    }
-    const epicMultiSelect = getMultiSelect('epicSelect');
-    if (epicMultiSelect) {
-        epicMultiSelect.setSelectedValues(currentEpics);
     }
 
     // Update sync select and ready checkbox
@@ -513,7 +509,7 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
-    populateEpicFilter(filterIndex.epics);
+    currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();
@@ -788,36 +784,14 @@ function populateFixVersionFilter(jiraIssuesDetails) {
     }
 }
 
-// Options of an issue filter: "KEY Summary", newest issue first within each Jira project
-function issueOptions(issues) {
-    return [...issues.values()]
-        .sort((a, b) => compareIssueKeys(a.key, b.key))
-        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
-}
-
-// Jira project alphabetically, then issue number descending
-function compareIssueKeys(a, b) {
-    const [projectA, numberA] = splitIssueKey(a);
-    const [projectB, numberB] = splitIssueKey(b);
-    return projectA.localeCompare(projectB) || numberB - numberA;
-}
-
-function splitIssueKey(key) {
-    const dash = key.lastIndexOf('-');
-    return [key.slice(0, dash), Number(key.slice(dash + 1))];
-}
-
-function populateEpicFilter(epics) {
-    const epicMultiSelect = getMultiSelect('epicSelect');
-    if (!epicMultiSelect) return;
-
-    const options = issueOptions(epics);
-    epicMultiSelect.setOptions(options);
-
-    // Keep only the epics that exist in the options (the URL may carry unknown keys)
-    const known = new Set(options.map(option => option.value));
-    currentEpics = currentEpics.filter(key => known.has(key));
-    epicMultiSelect.setSelectedValues(currentEpics);
+// Fills an issue multi-select (epics, stories) and returns the selection
+// restricted to the keys it offers (the URL may carry keys of another project)
+function populateIssueFilter(elementId, issues, selectedKeys) {
+    const multiSelect = getMultiSelect(elementId);
+    if (!multiSelect) return selectedKeys;
+    multiSelect.setOptions(issueOptions(issues.values()));
+    multiSelect.setSelectedValues(selectedKeys);
+    return multiSelect.getSelectedValues();
 }
 
 // Fetches the SYNC status of every pull request of the current project in a

--- a/public/index.html
+++ b/public/index.html
@@ -139,6 +139,29 @@
   </div>
 
   <div class="filter-item">
+    <span class="filter-label">Story
+      <i class="fas fa-info-circle info-icon"
+         title="Issue delivered by the pull request: the linked issue, or the parent of a linked sub-task"></i>
+    </span>
+    <div class="multi-select" id="storySelect" data-filter="story">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item">
     <span class="filter-label">Assignee</span>
     <div class="multi-select" id="assigneeSelect" data-filter="assignee">
       <div class="multi-select-trigger" tabindex="0">

--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,29 @@
   </div>
 
   <div class="filter-item">
+    <span class="filter-label">Epic
+      <i class="fas fa-info-circle info-icon"
+         title="Epic of the linked issues; for a sub-task, the epic of its parent story"></i>
+    </span>
+    <div class="multi-select" id="epicSelect" data-filter="epic">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item">
     <span class="filter-label">Assignee</span>
     <div class="multi-select" id="assigneeSelect" data-filter="assignee">
       <div class="multi-select-trigger" tabindex="0">

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -164,7 +164,7 @@ export class MultiSelect {
             return `
                 <label class="multi-select-option">
                     <input type="checkbox" value="${this.escapeHtml(opt.value)}" ${isChecked ? 'checked' : ''}>
-                    <span class="multi-select-option-label">${this.escapeHtml(opt.label)}</span>
+                    <span class="multi-select-option-label" title="${this.escapeHtml(opt.label)}">${this.escapeHtml(opt.label)}</span>
                 </label>
             `;
         }).join('');

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -244,9 +244,9 @@ export class MultiSelect {
     }
 
     escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
+        return String(text).replace(/[&<>"']/g, character => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        })[character]);
     }
 }
 

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -5,6 +5,9 @@
 
 const instances = new Map();
 
+// Text and attribute values are both double-quoted here; quotes are escaped too
+const htmlEscapes = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+
 export class MultiSelect {
     constructor(elementId, options = {}) {
         this.elementId = elementId;
@@ -244,9 +247,7 @@ export class MultiSelect {
     }
 
     escapeHtml(text) {
-        return String(text).replace(/[&<>"']/g, character => ({
-            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-        })[character]);
+        return String(text ?? '').replace(/[&<>"']/g, character => htmlEscapes[character]);
     }
 }
 

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -213,7 +213,7 @@ test('evaluatePullRequest text filter is case-insensitive and needs every word',
 
 // ------------------------------------------------------------------ epic filter
 
-import { issueLevel, epicOf } from '../public/app-filter.js';
+import { issueLevel, epicOf, issueOptions } from '../public/app-filter.js';
 
 const epicType = { name: 'Epic', subtask: false, hierarchyLevel: 1 };
 const storyType = { name: 'Story', subtask: false, hierarchyLevel: 0 };
@@ -225,7 +225,9 @@ const inlineEpicAi = { id: '1', key: 'PROJ-100', fields: { summary: 'Assistive A
 const inlineStoryChat = { id: '2', key: 'PROJ-200', fields: { summary: 'Chat panel', status: {}, priority: {}, issuetype: storyType } };
 
 const epicAi = { key: 'PROJ-100', fields: { summary: 'Assistive AI', issuetype: epicType } };
+const epicUx = { key: 'PROJ-101', fields: { summary: 'UX', issuetype: epicType } };
 const storyInEpic = { key: 'PROJ-200', fields: { summary: 'Chat panel', issuetype: storyType, parent: inlineEpicAi } };
+const storyInUx = { key: 'PROJ-203', fields: { summary: 'Toolbar', issuetype: storyType, parent: { id: '3', key: 'PROJ-101', fields: { summary: 'UX', status: {}, priority: {}, issuetype: epicType } } } };
 const bugWithoutEpic = { key: 'PROJ-201', fields: { summary: 'Crash on save', issuetype: bugType } };
 const subtaskOfStory = { key: 'PROJ-300', fields: { summary: 'Chat panel: API', issuetype: subtaskType, parent: inlineStoryChat } };
 const subtaskOfUnknown = { key: 'PROJ-301', fields: { summary: 'Orphan work', issuetype: subtaskType, parent: { key: 'PROJ-999', fields: { summary: 'Unknown story', issuetype: storyType } } } };
@@ -249,6 +251,8 @@ test('epicOf resolves the epic itself, a direct epic parent and the epic of a su
     assert.equal(epicOf(bugWithoutEpic, issuesByKey), null);
     assert.equal(epicOf(subtaskOfUnknown, issuesByKey), null); // the parent is not in the details
     assert.equal(epicOf(parentOnlyStory, issuesByKey), null);
+    // A sub-task whose direct parent is an epic needs no lookup
+    assert.deepEqual(epicOf({ key: 'PROJ-304', fields: { summary: 'Odd', issuetype: subtaskType, parent: inlineEpicAi } }, new Map()), { key: 'PROJ-100', summary: 'Assistive AI' });
 });
 
 test('epicOf needs the parent of the parent story, which the server now fetches for parent-only stories', () => {
@@ -263,10 +267,11 @@ const hierarchyApiResult = {
         { id: 20, title: 'PROJ-200 chat panel', source: { branch: { name: 'feature/PROJ-200' } }, author, participants: [] },
         { id: 21, title: 'PROJ-300 chat panel api', source: { branch: { name: 'feature/PROJ-300' } }, author, participants: [] },
         { id: 22, title: 'PROJ-201 crash on save', source: { branch: { name: 'bugfix/PROJ-201' } }, author, participants: [] },
-        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] }
+        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] },
+        { id: 24, title: 'PROJ-200 PROJ-203 both', source: { branch: { name: 'feature/both' } }, author, participants: [] }
     ],
-    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'] },
-    jiraIssuesDetails: [epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory],
+    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'], 24: ['PROJ-200', 'PROJ-203'] },
+    jiraIssuesDetails: [epicAi, epicUx, storyInEpic, storyInUx, bugWithoutEpic, subtaskOfStory],
     sprintIssues: {}
 };
 
@@ -276,7 +281,8 @@ test('buildFilterIndex collects the epics of every pull request and the list of 
     assert.deepEqual([...pullRequestsById.get(21).epics], ['PROJ-100']); // through the parent story
     assert.deepEqual([...pullRequestsById.get(22).epics], []);
     assert.deepEqual([...pullRequestsById.get(23).epics], ['PROJ-100']); // linked to the epic itself
-    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }]);
+    assert.deepEqual([...pullRequestsById.get(24).epics], ['PROJ-100', 'PROJ-101']); // two issues under two epics
+    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }, { key: 'PROJ-101', summary: 'UX' }]);
     assert.equal(buildFilterIndex({}).epics.size, 0);
 });
 
@@ -289,4 +295,16 @@ test('evaluatePullRequest epic filter matches any selected epic', () => {
     assert.equal(evaluate(22, []), true);
     assert.equal(evaluate(20, ['PROJ-999', 'PROJ-100']), true);
     assert.equal(evaluate(20, ['PROJ-999']), false);
+});
+
+test('issueOptions labels "KEY Summary" and sorts by project then newest issue first', () => {
+    const options = issueOptions([
+        { key: 'PROJ-9', summary: 'Nine' }, { key: 'ALPHA-100', summary: 'Hundred' },
+        { key: 'PROJ-10', summary: 'Ten' }, { key: 'ALPHA-2', summary: 'Two' }
+    ]);
+    assert.deepEqual(options, [
+        { value: 'ALPHA-100', label: 'ALPHA-100 Hundred' }, { value: 'ALPHA-2', label: 'ALPHA-2 Two' },
+        { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
+    ]);
+    assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -308,6 +308,7 @@ test('issueOptions labels "KEY Summary" and sorts by project then newest issue f
         { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
     ]);
     assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
+    assert.deepEqual(issueOptions([{ key: 'X-2', summary: '' }]), [{ value: 'X-2', label: 'X-2' }]); // parent fetched without a summary by an older server
 });
 
 // ----------------------------------------------------------------- story filter
@@ -343,4 +344,19 @@ test('evaluatePullRequest story filter matches any selected story', () => {
     assert.equal(evaluate(22, ['PROJ-200', 'PROJ-201']), true);
     assert.equal(evaluate(23, ['PROJ-200']), false);
     assert.equal(evaluate(23, []), true);
+});
+
+test('epic and story filters combine as AND, and a story linked together with its own sub-task counts once', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, filters) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, ...filters }, rendered).visible;
+    assert.equal(evaluate(21, { epics: ['PROJ-100'], stories: ['PROJ-200'] }), true);
+    assert.equal(evaluate(21, { epics: ['PROJ-100'], stories: ['PROJ-201'] }), false);
+    assert.equal(evaluate(22, { epics: ['PROJ-100'], stories: ['PROJ-201'] }), false); // the story matches, the epic does not
+    const both = buildFilterIndex({
+        ...hierarchyApiResult,
+        pullRequests: [{ id: 30, title: 'PROJ-200 PROJ-300 both', source: { branch: { name: 'feature/both' } }, author, participants: [] }],
+        jiraIssuesMap: { 30: ['PROJ-200', 'PROJ-300'] }
+    });
+    assert.deepEqual([...both.pullRequestsById.get(30).stories], ['PROJ-200']);
+    assert.equal(countActiveFilters({ assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false, epics: ['PROJ-100'], stories: ['PROJ-200'] }), 2);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -79,6 +79,7 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
     assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
     assert.equal(countActiveFilters({ ...defaults, epics: ['PROJ-100', 'PROJ-101'] }), 1);
+    assert.equal(countActiveFilters({ ...defaults, stories: ['PROJ-200'] }), 1);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -307,4 +308,39 @@ test('issueOptions labels "KEY Summary" and sorts by project then newest issue f
         { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
     ]);
     assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
+});
+
+// ----------------------------------------------------------------- story filter
+
+import { storyOf } from '../public/app-filter.js';
+
+test('storyOf is the issue itself, the parent of a sub-task, and nothing for an epic', () => {
+    assert.deepEqual(storyOf(storyInEpic), { key: 'PROJ-200', summary: 'Chat panel' });
+    assert.deepEqual(storyOf(bugWithoutEpic), { key: 'PROJ-201', summary: 'Crash on save' });
+    assert.deepEqual(storyOf(subtaskOfStory), { key: 'PROJ-200', summary: 'Chat panel' });
+    assert.deepEqual(storyOf(subtaskOfUnknown), { key: 'PROJ-999', summary: 'Unknown story' }); // the inline parent is enough
+    assert.equal(storyOf(epicAi), null);
+    assert.equal(storyOf({ key: 'PROJ-303', fields: { issuetype: subtaskType } }), null); // sub-task without parent
+});
+
+test('buildFilterIndex collects the stories of every pull request and the list of stories', () => {
+    const { pullRequestsById, stories } = buildFilterIndex(hierarchyApiResult);
+    assert.deepEqual([...pullRequestsById.get(20).stories], ['PROJ-200']);
+    assert.deepEqual([...pullRequestsById.get(21).stories], ['PROJ-200']); // the parent of the sub-task
+    assert.deepEqual([...pullRequestsById.get(22).stories], ['PROJ-201']);
+    assert.deepEqual([...pullRequestsById.get(23).stories], []); // an epic is not a story
+    assert.deepEqual([...pullRequestsById.get(24).stories], ['PROJ-200', 'PROJ-203']); // two issues, two stories
+    assert.deepEqual([...stories.keys()], ['PROJ-200', 'PROJ-201', 'PROJ-203']);
+    assert.equal(buildFilterIndex({}).stories.size, 0);
+});
+
+test('evaluatePullRequest story filter matches any selected story', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, stories) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, stories }, rendered).visible;
+    assert.equal(evaluate(20, ['PROJ-200']), true);
+    assert.equal(evaluate(21, ['PROJ-200']), true);
+    assert.equal(evaluate(22, ['PROJ-200']), false);
+    assert.equal(evaluate(22, ['PROJ-200', 'PROJ-201']), true);
+    assert.equal(evaluate(23, ['PROJ-200']), false);
+    assert.equal(evaluate(23, []), true);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -78,6 +78,7 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
     assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
     assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
+    assert.equal(countActiveFilters({ ...defaults, epics: ['PROJ-100', 'PROJ-101'] }), 1);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -208,4 +209,84 @@ test('evaluatePullRequest text filter is case-insensitive and needs every word',
     assert.equal(evaluate('restore banner'), true);
     assert.equal(evaluate('banner footer'), false);
     assert.equal(evaluate('Author'), false); // people are not searched
+});
+
+// ------------------------------------------------------------------ epic filter
+
+import { issueLevel, epicOf } from '../public/app-filter.js';
+
+const epicType = { name: 'Epic', subtask: false, hierarchyLevel: 1 };
+const storyType = { name: 'Story', subtask: false, hierarchyLevel: 0 };
+const bugType = { name: 'Bug', subtask: false, hierarchyLevel: 0 };
+const subtaskType = { name: 'Sub-task', subtask: true, hierarchyLevel: -1 };
+
+// Jira returns the parent with a few inline fields (summary, status, priority, issuetype)
+const inlineEpicAi = { id: '1', key: 'PROJ-100', fields: { summary: 'Assistive AI', status: {}, priority: {}, issuetype: epicType } };
+const inlineStoryChat = { id: '2', key: 'PROJ-200', fields: { summary: 'Chat panel', status: {}, priority: {}, issuetype: storyType } };
+
+const epicAi = { key: 'PROJ-100', fields: { summary: 'Assistive AI', issuetype: epicType } };
+const storyInEpic = { key: 'PROJ-200', fields: { summary: 'Chat panel', issuetype: storyType, parent: inlineEpicAi } };
+const bugWithoutEpic = { key: 'PROJ-201', fields: { summary: 'Crash on save', issuetype: bugType } };
+const subtaskOfStory = { key: 'PROJ-300', fields: { summary: 'Chat panel: API', issuetype: subtaskType, parent: inlineStoryChat } };
+const subtaskOfUnknown = { key: 'PROJ-301', fields: { summary: 'Orphan work', issuetype: subtaskType, parent: { key: 'PROJ-999', fields: { summary: 'Unknown story', issuetype: storyType } } } };
+const parentOnlyStory = { key: 'PROJ-202', fields: { fixVersions: [] } }; // fetched with fix versions only (older server)
+
+test('issueLevel classifies epics, standard issues and sub-tasks, and defaults to standard', () => {
+    assert.equal(issueLevel(epicAi), 'epic');
+    assert.equal(issueLevel({ key: 'X-1', fields: { issuetype: { name: 'Epic' } } }), 'epic'); // no hierarchyLevel
+    assert.equal(issueLevel(storyInEpic), 'standard');
+    assert.equal(issueLevel(bugWithoutEpic), 'standard');
+    assert.equal(issueLevel(subtaskOfStory), 'subtask');
+    assert.equal(issueLevel({ key: 'X-2', fields: { issuetype: { name: 'Sub-task', subtask: true } } }), 'subtask');
+    assert.equal(issueLevel(parentOnlyStory), 'standard');
+});
+
+test('epicOf resolves the epic itself, a direct epic parent and the epic of a sub-task parent', () => {
+    const issuesByKey = new Map([epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory, subtaskOfUnknown].map(issue => [issue.key, issue]));
+    assert.deepEqual(epicOf(epicAi, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.deepEqual(epicOf(storyInEpic, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.deepEqual(epicOf(subtaskOfStory, issuesByKey), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.equal(epicOf(bugWithoutEpic, issuesByKey), null);
+    assert.equal(epicOf(subtaskOfUnknown, issuesByKey), null); // the parent is not in the details
+    assert.equal(epicOf(parentOnlyStory, issuesByKey), null);
+});
+
+test('epicOf needs the parent of the parent story, which the server now fetches for parent-only stories', () => {
+    const parentOnlyWithEpic = { key: 'PROJ-202', fields: { summary: 'Search page', issuetype: storyType, fixVersions: [], parent: inlineEpicAi } };
+    const subtask = { key: 'PROJ-302', fields: { summary: 'Search page: index', issuetype: subtaskType, parent: { key: 'PROJ-202', fields: { summary: 'Search page', issuetype: storyType } } } };
+    assert.deepEqual(epicOf(subtask, new Map([[parentOnlyWithEpic.key, parentOnlyWithEpic]])), { key: 'PROJ-100', summary: 'Assistive AI' });
+    assert.equal(epicOf(subtask, new Map([[parentOnlyStory.key, parentOnlyStory]])), null); // older server: no parent on the story
+});
+
+const hierarchyApiResult = {
+    pullRequests: [
+        { id: 20, title: 'PROJ-200 chat panel', source: { branch: { name: 'feature/PROJ-200' } }, author, participants: [] },
+        { id: 21, title: 'PROJ-300 chat panel api', source: { branch: { name: 'feature/PROJ-300' } }, author, participants: [] },
+        { id: 22, title: 'PROJ-201 crash on save', source: { branch: { name: 'bugfix/PROJ-201' } }, author, participants: [] },
+        { id: 23, title: 'PROJ-100 epic branch', source: { branch: { name: 'feature/PROJ-100' } }, author, participants: [] }
+    ],
+    jiraIssuesMap: { 20: ['PROJ-200'], 21: ['PROJ-300'], 22: ['PROJ-201'], 23: ['PROJ-100'] },
+    jiraIssuesDetails: [epicAi, storyInEpic, bugWithoutEpic, subtaskOfStory],
+    sprintIssues: {}
+};
+
+test('buildFilterIndex collects the epics of every pull request and the list of epics', () => {
+    const { pullRequestsById, epics } = buildFilterIndex(hierarchyApiResult);
+    assert.deepEqual([...pullRequestsById.get(20).epics], ['PROJ-100']);
+    assert.deepEqual([...pullRequestsById.get(21).epics], ['PROJ-100']); // through the parent story
+    assert.deepEqual([...pullRequestsById.get(22).epics], []);
+    assert.deepEqual([...pullRequestsById.get(23).epics], ['PROJ-100']); // linked to the epic itself
+    assert.deepEqual([...epics.values()], [{ key: 'PROJ-100', summary: 'Assistive AI' }]);
+    assert.equal(buildFilterIndex({}).epics.size, 0);
+});
+
+test('evaluatePullRequest epic filter matches any selected epic', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, epics) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, epics }, rendered).visible;
+    assert.equal(evaluate(20, ['PROJ-100']), true);
+    assert.equal(evaluate(21, ['PROJ-100']), true);
+    assert.equal(evaluate(22, ['PROJ-100']), false);
+    assert.equal(evaluate(22, []), true);
+    assert.equal(evaluate(20, ['PROJ-999', 'PROJ-100']), true);
+    assert.equal(evaluate(20, ['PROJ-999']), false);
 });

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -174,3 +174,14 @@ test('the SECOLLAB fixture carries epics and parent-only issues with their hiera
     assert.ok(linkedToSubtask.length > 0);
     assert.ok(linkedToSubtask.some(entry => entry.epics.size > 0), 'a pull request linked to a sub-task reaches its epic');
 });
+
+test('the filter index resolves a story for every pull request linked to an issue', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const { pullRequestsById, stories } = buildFilterIndex(data);
+    const linked = [...pullRequestsById.values()].filter(entry => entry.linkedIssues.length > 0);
+    assert.ok(linked.every(entry => entry.stories.size > 0));
+    assert.ok(stories.size > 50, `${stories.size} stories`);
+    const withSubtask = linked.find(entry => entry.linkedIssues.some(issue => issue.fields.issuetype.subtask));
+    const subtask = withSubtask.linkedIssues.find(issue => issue.fields.issuetype.subtask);
+    assert.ok(withSubtask.stories.has(subtask.fields.parent.key), 'the story of a sub-task is its parent');
+});

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -150,3 +150,27 @@ test('the filter index built on the SECOLLAB fixture links every pull request', 
         assert.equal(evaluatePullRequest(entry, noFilter, rendered).visible, true);
     }
 });
+
+test('the SECOLLAB fixture carries epics and parent-only issues with their hierarchy', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const underAnEpic = data.jiraIssuesDetails.filter(issue => issue.fields.parent?.fields?.issuetype?.name === 'Epic');
+    assert.ok(underAnEpic.length > 20, `${underAnEpic.length} issues under an epic`);
+    for (const issue of data.jiraIssuesDetails) {
+        if (issue.fields.issuetype) assert.equal(typeof issue.fields.issuetype.hierarchyLevel, 'number');
+    }
+    // Parent-only entries (no status: fetched as parents) carry summary, type, fix versions and parent
+    const parentOnly = data.jiraIssuesDetails.filter(issue => !issue.fields.status);
+    assert.ok(parentOnly.length > 0);
+    for (const issue of parentOnly) {
+        assert.equal(typeof issue.fields.summary, 'string');
+        assert.ok(issue.fields.issuetype.name);
+        assert.ok(Array.isArray(issue.fields.fixVersions));
+    }
+    assert.ok(parentOnly.some(issue => issue.fields.issuetype.name === 'Epic'), 'epics are fetched as parents');
+    assert.ok(parentOnly.some(issue => issue.fields.parent), 'a parent-only story carries its epic');
+    const { pullRequestsById, epics } = buildFilterIndex(data);
+    assert.ok(epics.size >= 3, `${epics.size} epics`);
+    const linkedToSubtask = [...pullRequestsById.values()].filter(entry => entry.linkedIssues.some(issue => issue.fields.issuetype.subtask));
+    assert.ok(linkedToSubtask.length > 0);
+    assert.ok(linkedToSubtask.some(entry => entry.epics.size > 0), 'a pull request linked to a sub-task reaches its epic');
+});


### PR DESCRIPTION
A **Story** multi-select in the sidebar, after Epic, keeps the pull requests delivering the selected issues. The story of a linked issue is the issue itself, whatever its type (Story, Bug, Task, Improvement...), or, when the pull request is linked to a sub-task, the sub-task's parent (key and summary come inline with the sub-task, so no extra fetch). Epics are not stories. Options read `KEY Summary` (newest first within each Jira project), the URL parameter is `story` (repeated), unknown keys are dropped on restore.

## Changes

- **Logic** (`public/app-filter.js`): pure `storyOf` next to `epicOf`; `entry.stories` and `index.stories` in the filter index; the story match; `issueOptions` labels trimmed for an issue without a summary.
- **Sidebar and state** (`public/index.html`, `public/app.js`): the Story multi-select with its info icon, `currentStories`, one id in `multiSelectIds` and one parameter in `filterUrlParams`, one `populateIssueFilter` call. Nothing else: the shared reset lists and the generic population helper from the previous two pull requests absorb the rest.
- **Tests**: 47 (`npm test`): the three rows of the story rule, the index stories, the match, epic and story combined as AND, a story linked together with its own sub-task counted once, the fixture path (every linked pull request has a story, a sub-task's story is its parent).
- **Docs**: README, CLAUDE.md, PRD F4.12; a note in the spec's code-structure section for the two helpers that were generalised during implementation.

## Verified

- `npm test`: 47 pass, 0 fail.
- In the browser on the fixture server: selecting a story shows exactly the pull requests an independent computation predicts, a pull request linked to a sub-task is found under its parent story, epic and story combine as AND with the badge at 2, `?story=` restores and drops unknown keys, "Clear filters" and the project switch reset, OSLC lists its own stories, both themes.

Stacked on #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuGDyDk4Av2U5A1oVXhAMF