### PR TITLE
feat: ready-for-assignee filter, both ready filters restored from the URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Multi-project support with dropdown selection
 - Pull request visualization ordered by most recently updated
 - Jira issue integration with status tracking
-- Advanced filtering (text, sprint, fix version, epic, assignee, reviewer, sync status)
+- Advanced filtering (text, sprint, fix version, epic, story, assignee, reviewer, sync status)
 - Real-time conflict detection
 - Commit ahead/behind tracking
 - Smart reload (auto-updates every 2 minutes when data changes)
@@ -124,13 +124,13 @@ pr-tree/
 - Periodic refresh logic (2-minute intervals, tab visibility detection)
 - Loading state management
 - Event handlers for user interactions
-- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select from the index and returns the selection restricted to the offered keys
+- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select (epics and stories) from the index and returns the selection restricted to the offered keys
 
 **public/app-filter.js**
-- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`); it also returns `index.epics`, the epics to list in the filter; built once per data load by `initializeFilter()`, which returns it
+- `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`) and story keys (`stories`); it also returns `index.epics` and `index.stories`, the epics and stories to list in the filters; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
-- `issueLevel`, `epicOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
+- `issueLevel`, `epicOf`, `storyOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
 **public/counter-utils.js**
@@ -290,6 +290,7 @@ let currentText = '';          // text filter
 let currentSprints = [];        // sprint ids
 let currentFixVersions = [];    // fix version ids
 let currentEpics = [];         // epic keys
+let currentStories = [];       // story keys
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -300,7 +301,7 @@ let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied 
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&story=PROJ-200&sync=requested&ready=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
@@ -486,10 +487,10 @@ Three streams available:
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
-11. **Jira hierarchy**: only `issueLevel`/`epicOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
+11. **Jira hierarchy**: only `issueLevel`/`epicOf`/`storyOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ pr-tree/
 - Loading state management
 - Event handlers for user interactions
 - `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select (epics and stories) from the index and returns the selection restricted to the offered keys
+- `updateReadyCheckboxes()`: the two ready checkboxes are disabled and unchecked while their multi-select is empty; both checked keeps pull requests needing either attention
 
 **public/app-filter.js**
 - `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`) and story keys (`stories`); it also returns `index.epics` and `index.stories`, the epics and stories to list in the filters; built once per data load by `initializeFilter()`, which returns it
@@ -295,13 +296,14 @@ let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
 let currentReadyForReviewer = false;
+let currentReadyForAssignee = false;
 let currentApiResult = null;
 let currentSyncStatuses = null; // last /api/sync-statuses response, re-applied on re-render
 ```
 
 State is synchronized with URL query parameters for deep linking:
 ```
-?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&story=PROJ-200&sync=requested&ready=true
+?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&story=PROJ-200&sync=requested&readyReviewer=true&readyAssignee=true
 ```
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
@@ -480,10 +482,10 @@ Three streams available:
 1. **Module type mismatch**: Backend uses ES modules (.mjs), config uses CommonJS (module.exports)
 2. **Cache staleness**: Remember that data can be up to 2 minutes old
 3. **API rate limits**: Bitbucket can return HTTP 429 if too many requests
-4. **Filter restoration**: SYNC and "ready for reviewer" filters NOT restored from URL (calculated async)
+4. **Filter restoration**: the SYNC filter is NOT restored from the URL (its statuses are loaded on demand); every other filter is, including the two ready checkboxes
 5. **Regex patterns**: Must match exact Jira issue key format in PR titles
 6. **Colours**: never hard-code a colour in styles.css; add a token to both the `:root` and `:root[data-theme="dark"]` blocks
-7. **Ready for reviewer**: computed by `computeAttention()` from the data, never from rendered styles
+7. **Ready for reviewer / assignee**: computed by `computeAttention()` from the data, never from rendered styles; `evaluatePullRequest` takes `readyReviewer` and `readyAssignee`
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
 10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,7 @@ State is synchronized with URL query parameters for deep linking:
 ```
 ?project=PROJ&q=banner&assignee=John&reviewer=Jane&sprint=Sprint1&epic=PROJ-100&story=PROJ-200&sync=requested&readyReviewer=true&readyAssignee=true
 ```
+(`ready`, the former name of `readyReviewer`, is still read from old links but never written.)
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
 

--- a/PRD.md
+++ b/PRD.md
@@ -180,6 +180,7 @@ The application integrates with a Jira workflow where:
 - F4.9: Hierarchical filtering (preserve parent-child relationships)
 - F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
 - F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
+- F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
@@ -480,6 +481,7 @@ The application integrates with a Jira workflow where:
 |  Sprint        | Repository 1                          [X / Y]   |
 |  Fix version   |   Branch A                            [X / Y]   |
 |  Epic          |                                                 |
+|  Story         |                                                 |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
 |  Reviewer      |       JIRA-123 [In Progress]                    |
 |  Ready         |     PR #2                                       |

--- a/PRD.md
+++ b/PRD.md
@@ -181,13 +181,14 @@ The application integrates with a Jira workflow where:
 - F4.10: Filter by text: title, source branch name and linked issue keys must contain every word typed
 - F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
 - F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
+- F4.13: Filter by "ready for assignee" status: In Progress pull requests with a linked issue assigned to a selected assignee; with both ready filters checked, pull requests needing either attention are kept
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)
 - Applying filters hides non-matching PRs instantly
 - Filtered counters update to show X of Y PRs visible
 - URL updates with all filter selections
-- Sharing URL restores all filters (except SYNC and ready-for-reviewer, which require async calculation)
+- Sharing URL restores all filters (except SYNC, whose statuses are loaded on demand)
 - PRs highlighted in red when action required from filtered user
 - Parent PRs remain visible if any children match filter
 - Ready for reviewer filter correctly identifies PRs in "In Review" status needing reviewer action
@@ -483,8 +484,9 @@ The application integrates with a Jira workflow where:
 |  Epic          |                                                 |
 |  Story         |                                                 |
 |  Assignee      |     PR #1 [SYNC] [Ahead:3] [Behind:1]           |
+|  Ready assignee|                                                 |
 |  Reviewer      |       JIRA-123 [In Progress]                    |
-|  Ready         |     PR #2                                       |
+|  Ready reviewer|     PR #2                                       |
 |  SYNC + Load   |   Branch B                            [X / Y]   |
 |                |     PR #3 [Ahead:2]                             |
 | (does not      | Orphaned Issues                                 |
@@ -778,6 +780,7 @@ The following are explicitly **not** part of current requirements:
 - **In Progress**: Jira issue status indicating active development work
 - **Orphaned Issue**: Jira issue marked "In Review" without associated PR
 - **Ready for Reviewer**: PR with associated issue in "In Review" status that hasn't been approved yet
+- **Ready for Assignee**: PR with associated issue in "In Progress" status assigned to the selected assignee
 - **SYNC**: Indicator that PR branch has conflicts with its parent branch
 - **Commit Ahead**: Number of commits in PR branch not in destination
 - **Commit Behind**: Number of commits in destination not in PR branch

--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@
     * Highlights in red those where an effort is expected
 * Provides a ready for reviewer filter
     * Filters In Review pull requests which reviewer has not already approved
+* Provides a ready for assignee filter
+    * Filters In Progress pull requests with a linked issue assigned to the selected assignee
+    * With both ready filters checked, pull requests needing either attention are kept
 * Provides a fix version filter
     * Filters pull requests based on the fixVersion field of associated Jira issues
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer, ready for assignee, ready for reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -86,6 +89,8 @@
         * The server now fetches the summary, type and parent of parent issues (previously their fix versions only)
         * Fixture data carries epics
     * Story filter: pull requests of the selected issues, the linked issue itself or the parent of a linked sub-task
+    * Ready for assignee filter: In Progress pull requests with a linked issue assigned to the selected assignee, the counterpart of Ready for reviewer
+    * Both ready filters are now restored from the URL (`readyAssignee`, `readyReviewer`); only the SYNC filter is still reset on reload
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
     * `/` focuses the search box, Escape clears it
 * Provides an epic filter
     * Keeps the pull requests whose linked issues belong to the selected epics; a pull request linked to a sub-task follows the epic of its parent story
+* Provides a story filter
+    * Keeps the pull requests delivering the selected issues: the linked issue itself, or the parent of a linked sub-task
 * Provides an assignee filter
     * Filters pull requests based on the assignee of associated Jira issues
     * Highlights in red those where an effort is expected
@@ -36,7 +38,7 @@
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
 * Maintains filter selections in URL
-    * All filter selections (project, text, sprint, fixVersion, epic, assignee, reviewer) are saved in the URL
+    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
 * Displays Ahead (green) and Behind (red) commit counts
@@ -83,6 +85,7 @@
     * Epic filter: pull requests of the selected epics, resolved through the parent story when the pull request is linked to a sub-task
         * The server now fetches the summary, type and parent of parent issues (previously their fix versions only)
         * Fixture data carries epics
+    * Story filter: pull requests of the selected issues, the linked issue itself or the parent of a linked sub-task
 * Version 2.3.0
     * Filtering is now a single pass over the tree
         * Each pull request is visited once; the previous recursion revisited a stacked pull request once per ancestor, so a 24-deep stack (as in SECOLLAB) cost about 16 million visits and 20 seconds per filter change

--- a/docs/superpowers/plans/2026-09-10-ready-for-assignee.md
+++ b/docs/superpowers/plans/2026-09-10-ready-for-assignee.md
@@ -1,0 +1,349 @@
+# Ready for Assignee Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Ready for assignee" checkbox under the Assignee filter, the twin of "Ready for reviewer", and restore both "Ready" filters from the URL.
+
+**Architecture:** The rule already exists: `computeAttention().assignee` (in progress, linked issue assigned to a selected assignee) drives the highlight. The filter reuses it in `evaluatePullRequest`, where `ready` is renamed `readyReviewer` and `readyAssignee` is added, both defaulting to false; when both are checked the match is an OR. In `app.js` one `updateReadyCheckboxes()` helper owns the disabled/checked state of the two checkboxes; the URL gains `readyReviewer` / `readyAssignee`, both restored on load (the old `ready` is read as `readyReviewer` and never written again).
+
+**Tech Stack:** Vanilla ES modules, `node:test`. No server change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-ready-for-assignee-design.md` (issue #31)
+
+**Branch:** `claude/filters-4-ready-assignee`, created from `claude/filters-3-story` (already created, spec and plan committed). One pull request stacked on #30. Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01AuGDyDk4Av2U5A1oVXhAMF
+```
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (47 tests before this task).
+
+**Running the app for manual checks:** `PORT=3101 node index.mjs --fixtures` (port 3100 is used by another application on this machine), http://localhost:3101, pick SECOLLAB.
+
+---
+
+### Task 1: Ready for assignee filter
+
+**Files:**
+- Modify: `public/app-filter.js`
+- Modify: `test/app-filter.test.mjs`, `test/fixtures.test.mjs`
+- Modify: `public/index.html`
+- Modify: `public/app.js`
+- Modify: `README.md`, `CLAUDE.md`, `PRD.md`
+
+- [ ] **Step 1: Rename `ready` in the existing tests and write the failing tests**
+
+In `test/app-filter.test.mjs`:
+
+- In the `countActiveFilters` test, replace `ready: false` with `readyReviewer: false, readyAssignee: false` in `defaults`, replace the two `ready: true` with `readyReviewer: true` (the expected counts stay 2 and 6), and add:
+
+```js
+    assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], readyAssignee: true }), 2);
+    assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], reviewers: ['J'], readyAssignee: true, readyReviewer: true }), 4);
+```
+
+- Replace the `noFilter` constant of the "index and evaluation" section with `const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };`.
+- In the test `evaluatePullRequest ready filter keeps pull requests with reviewer attention only`, replace both `ready: true` with `readyReviewer: true`.
+- In the last test of the story section (`epic and story filters combine as AND...`), replace `ready: false` with `readyReviewer: false, readyAssignee: false`.
+- Append after the `evaluatePullRequest ready filter...` test:
+
+```js
+test('evaluatePullRequest ready-for-assignee filter keeps pull requests with assignee attention only', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10); // PROJ-1 is assigned to Jane
+    const inProgress = { statusInProgress: true, statusInReview: false, hasSyncLabel: false };
+    const jane = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'], readyAssignee: true }, inProgress);
+    assert.equal(jane.visible, true);
+    assert.equal(jane.attention.assignee, true);
+    const bob = evaluatePullRequest(entry, { ...noFilter, assignees: ['Bob'], readyAssignee: true }, inProgress);
+    assert.equal(bob.visible, false); // no linked issue assigned to Bob
+    const inReview = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'], readyAssignee: true }, rendered);
+    assert.equal(inReview.visible, false); // in review: no assignee attention
+    assert.equal(inReview.attention.assignee, false);
+});
+
+test('both ready filters checked keep the pull requests needing either attention', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    const both = { ...noFilter, assignees: ['Jane'], reviewers: ['Jane'], readyAssignee: true, readyReviewer: true };
+    assert.equal(evaluatePullRequest(entry, both, { statusInProgress: true, statusInReview: false, hasSyncLabel: false }).visible, true); // assignee attention
+    assert.equal(evaluatePullRequest(entry, both, rendered).visible, true); // reviewer attention: Jane has not approved
+    assert.equal(evaluatePullRequest(entry, both, { statusInProgress: false, statusInReview: false, hasSyncLabel: false }).visible, false); // neither
+});
+```
+
+In `test/fixtures.test.mjs`, replace `ready: false` in the `noFilter` constant with `readyReviewer: false, readyAssignee: false`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: the two new tests fail (`readyAssignee` is ignored, so `bob`/`inReview` visibility assertions fail) and the `countActiveFilters` test fails on the new assertions; `ℹ fail` greater than 0.
+
+- [ ] **Step 3: Implement the match in app-filter.js**
+
+In `public/app-filter.js`:
+
+a. Replace `countActiveFilters` with:
+
+```js
+/**
+ * Counts the filters that are not at their default value.
+ * A multi-select with several values counts once.
+ */
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, readyReviewer = false, readyAssignee = false }) {
+    return [
+        parseTextQuery(text).length > 0,
+        assignees.length > 0,
+        reviewers.length > 0,
+        sprints.length > 0,
+        fixVersions.length > 0,
+        epics.length > 0,
+        stories.length > 0,
+        readyReviewer === true,
+        readyAssignee === true,
+        sync !== 'Show all'
+    ].filter(Boolean).length;
+}
+```
+
+b. In `evaluatePullRequest`: the JSDoc `@param {object} filters` line lists `{ text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }`; the signature becomes:
+
+```js
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, readyReviewer = false, readyAssignee = false }, { statusInProgress, statusInReview, hasSyncLabel }) {
+```
+
+and the two `readyMatch` lines are replaced with:
+
+```js
+    // Ready filters: with one or both checked, keep the pull requests that need the
+    // attention of the selected reviewers or assignees. A pull request is never in
+    // review and in progress at once, so the two boxes combine as OR
+    const readyMatch = (!readyReviewer && !readyAssignee) ||
+        (readyReviewer && attention.reviewer) ||
+        (readyAssignee && attention.assignee);
+```
+
+c. The `filterBranches` JSDoc lists the same filters; in `filterPullRequest`, the comment `so the ready filter never` becomes `so the ready filters never`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: `ℹ fail 0`, 49 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/app-filter.js test/app-filter.test.mjs test/fixtures.test.mjs
+git commit -m "feat: ready-for-assignee match, ready filters renamed readyReviewer/readyAssignee"
+```
+
+- [ ] **Step 6: The checkbox rows in index.html**
+
+In `public/index.html`:
+
+a. Insert right after the Assignee `filter-item` block (the `</div>` closing the block that contains `assigneeSelect`) and before the Reviewer block:
+
+```html
+  <div class="filter-item filter-item-checkbox">
+    <input type="checkbox" id="readyForAssigneeCheck" disabled>
+    <label for="readyForAssigneeCheck">Ready for assignee</label>
+    <i class="fas fa-info-circle info-icon"
+       title="Pull requests in progress with a linked issue assigned to a selected assignee"></i>
+  </div>
+```
+
+b. In the existing "Ready for reviewer" row, replace the info icon line with:
+
+```html
+    <i class="fas fa-info-circle info-icon"
+       title="Pull requests in review that a selected reviewer has not approved yet"></i>
+```
+
+- [ ] **Step 7: State, URL and controls in app.js**
+
+In `public/app.js`:
+
+a. Add `let currentReadyForAssignee = false;` right after `let currentReadyForReviewer = false;`.
+
+b. Replace the `filterUrlParams` constant and its comment with:
+
+```js
+// URL parameters written by the filters ('ready', the former name of readyReviewer, is only ever removed)
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
+```
+
+c. In `currentFilters()`, replace `ready: currentReadyForReviewer` with:
+
+```js
+        readyReviewer: currentReadyForReviewer,
+        readyAssignee: currentReadyForAssignee
+```
+
+d. In `resetFilterControls()`, replace the two `readyCheck` lines with:
+
+```js
+    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+        const checkbox = document.getElementById(id);
+        if (checkbox) checkbox.checked = false;
+    });
+```
+
+and in the comment above the function replace `the ready checkbox` with `the ready checkboxes`.
+
+e. In `updateUrlWithFilters()`, replace `if (currentReadyForReviewer) url.searchParams.set('ready', 'true');` with:
+
+```js
+    if (currentReadyForReviewer) url.searchParams.set('readyReviewer', 'true');
+    if (currentReadyForAssignee) url.searchParams.set('readyAssignee', 'true');
+```
+
+f. In `restoreFiltersFromUrl()`, replace the line `currentReadyForReviewer = false; // Not restored because it requires a fully displayed and updated pr tree` with:
+
+```js
+    // Restored like the other filters; 'ready' is the former name of readyReviewer
+    currentReadyForReviewer = urlParams.get('readyReviewer') === 'true' || urlParams.get('ready') === 'true';
+    currentReadyForAssignee = urlParams.get('readyAssignee') === 'true';
+```
+
+and replace the block from `// Update sync select and ready checkbox` down to the closing `}` of `if (readyCheck) { ... }` with:
+
+```js
+    // Update the sync select and the ready checkboxes
+    const syncSelect = document.getElementById('syncSelect');
+    if (syncSelect) syncSelect.value = currentSync;
+    updateReadyCheckboxes();
+```
+
+g. Replace `initializeReadyForReviewerFilter()` with:
+
+```js
+function initializeReadyFilters() {
+    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+        const checkbox = document.getElementById(id);
+        if (checkbox) checkbox.addEventListener('change', handleFilterChange);
+    });
+    updateReadyCheckboxes();
+}
+
+// The ready checkboxes depend on their multi-select: disabled and unchecked
+// while no assignee (or reviewer) is selected, otherwise they show the state
+function updateReadyCheckboxes() {
+    if (currentAssignees.length === 0) currentReadyForAssignee = false;
+    if (currentReviewers.length === 0) currentReadyForReviewer = false;
+    const assigneeCheck = document.getElementById('readyForAssigneeCheck');
+    if (assigneeCheck) {
+        assigneeCheck.disabled = currentAssignees.length === 0;
+        assigneeCheck.checked = currentReadyForAssignee;
+    }
+    const reviewerCheck = document.getElementById('readyForReviewerCheck');
+    if (reviewerCheck) {
+        reviewerCheck.disabled = currentReviewers.length === 0;
+        reviewerCheck.checked = currentReadyForReviewer;
+    }
+}
+```
+
+and in the `DOMContentLoaded` listener replace `initializeReadyForReviewerFilter();` with `initializeReadyFilters();`.
+
+h. In `readFilterControls()`, replace everything from `// Get sync and ready values from regular form elements` down to the closing `}` of the `if (readyCheck) { ... }` enable/disable block with:
+
+```js
+    // Get sync and ready values from regular form elements
+    const syncSelect = document.getElementById("syncSelect");
+    const assigneeCheck = document.getElementById('readyForAssigneeCheck');
+    const reviewerCheck = document.getElementById('readyForReviewerCheck');
+
+    currentSync = syncSelect ? syncSelect.value : "Show all";
+    currentReadyForAssignee = assigneeCheck ? assigneeCheck.checked : false;
+    currentReadyForReviewer = reviewerCheck ? reviewerCheck.checked : false;
+    updateReadyCheckboxes();
+```
+
+and in the comment above the function replace `(ready checkbox, clear button)` with `(ready checkboxes, clear button)`.
+
+i. In `populateFilters()`, delete the line `const readyCheck = document.getElementById('readyForReviewerCheck');` and the block:
+
+```js
+    // Update checkbox state
+    if (readyCheck) {
+        readyCheck.disabled = currentReviewers.length === 0;
+        readyCheck.checked = currentReadyForReviewer;
+    }
+```
+
+(`restoreFiltersFromUrl()`, called right after, sets both checkboxes through `updateReadyCheckboxes()`).
+
+Run: `node --check public/app.js` and `grep -n "readyForReviewerCheck\|currentReadyForReviewer\|'ready'" public/app.js` — every remaining occurrence must be one of: the `let`, `filterUrlParams`, `currentFilters()`, `resetFilterControls`, `updateUrlWithFilters`, `restoreFiltersFromUrl`, `initializeReadyFilters`, `updateReadyCheckboxes`, `readFilterControls`.
+
+- [ ] **Step 8: Check the app in the browser**
+
+Run: `PORT=3101 node index.mjs --fixtures`, open http://localhost:3101/?project=SECOLLAB.
+
+- "Ready for assignee" is disabled; select an assignee: it enables; check it: only the in-progress pull requests of that assignee remain (the highlighted ones), the badge counts it, the URL has `readyAssignee=true`.
+- Reload: the box is still checked and the tree still filtered. Same with `readyReviewer=true` after selecting a reviewer and checking "Ready for reviewer".
+- Clear the assignee selection: the box unchecks and disables, the URL loses `readyAssignee`.
+- Select yourself as assignee and reviewer, check both boxes: the tree shows the union of both attentions.
+- "Clear filters" and a project switch uncheck both.
+
+Stop the server with Ctrl+C.
+
+- [ ] **Step 9: Run the tests and commit**
+
+Run: `npm test`
+Expected: `ℹ fail 0`
+
+```bash
+git add public/index.html public/app.js
+git commit -m "feat: ready-for-assignee checkbox, both ready filters restored from the URL"
+```
+
+- [ ] **Step 10: Documentation**
+
+a. `README.md`:
+
+- In "Features", insert after the "Provides a ready for reviewer filter" block:
+
+```
+* Provides a ready for assignee filter
+    * Filters In Progress pull requests with a linked issue assigned to the selected assignee
+    * With both ready filters checked, pull requests needing either attention are kept
+```
+
+- Replace `    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer) are saved in the URL` with `    * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer, ready for assignee, ready for reviewer) are saved in the URL`.
+- In the "Version 2.4.0" changelog block, add after the story filter line:
+
+```
+    * Ready for assignee filter: In Progress pull requests with a linked issue assigned to the selected assignee, the counterpart of Ready for reviewer
+    * Both ready filters are now restored from the URL (`readyAssignee`, `readyReviewer`); only the SYNC filter is still reset on reload
+```
+
+b. `CLAUDE.md`:
+
+- In "Frontend State Management", add `let currentReadyForAssignee = false;` after `let currentReadyForReviewer = false;`, and in the URL example replace `&ready=true` with `&readyReviewer=true&readyAssignee=true`.
+- In the `**public/app.js**` block of "Key Files Explained", add a bullet: `- `updateReadyCheckboxes()`: the two ready checkboxes are disabled and unchecked while their multi-select is empty; both checked keeps pull requests needing either attention`.
+- In "Common Pitfalls", replace item 4 with `4. **Filter restoration**: the SYNC filter is NOT restored from the URL (its statuses are loaded on demand); every other filter is, including the two ready checkboxes` and item 7 with `7. **Ready for reviewer / assignee**: computed by `computeAttention()` from the data, never from rendered styles; `evaluatePullRequest` takes `readyReviewer` and `readyAssignee``.
+
+c. `PRD.md`:
+
+- Add after the F4.12 line: `- F4.13: Filter by "ready for assignee" status: In Progress pull requests with a linked issue assigned to a selected assignee; with both ready filters checked, pull requests needing either attention are kept`.
+- Replace `- Sharing URL restores all filters (except SYNC and ready-for-reviewer, which require async calculation)` with `- Sharing URL restores all filters (except SYNC, whose statuses are loaded on demand)`.
+- In the 8.1 diagram, insert `|  Ready assignee|                                                 |` right after the `|  Assignee      |` line and replace `|  Ready         |` with `|  Ready reviewer|`.
+- In the glossary (16.1), add after the "Ready for Reviewer" line: `- **Ready for Assignee**: PR with associated issue in "In Progress" status assigned to the selected assignee`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add README.md CLAUDE.md PRD.md
+git commit -m "docs: ready for assignee filter"
+```
+
+The controller pushes the branch and opens the pull request (base `claude/filters-3-story`, `Closes #31`, `Stacked on #30`).
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** rule and OR (Step 3), placement and info icons (Step 6), URL parameters with the `ready` alias and restoration (Step 7 e–f), disabled/unchecked coupling (Step 7 g–h), reset paths (Step 7 d, `resetFilterControls` covers "Clear filters" and the project switch), tests (Step 1), docs (Step 10), verification (Step 8).
+- **Placeholders:** none.
+- **Type consistency:** `readyReviewer` / `readyAssignee` are the names in `currentFilters()`, `countActiveFilters`, `evaluatePullRequest`, the tests and the URL; `updateReadyCheckboxes` is defined in Step 7 g and called in 7 f, g, h.

--- a/docs/superpowers/specs/2026-09-09-text-epic-story-filters-design.md
+++ b/docs/superpowers/specs/2026-09-09-text-epic-story-filters-design.md
@@ -192,6 +192,12 @@ looks one level up, and the data hash changes once after deployment.
 
 ## 9. Code structure
 
+Superseded in two places during implementation (see the review follow-ups in
+the plan): the option helpers live in `app-filter.js` as the pure, tested
+`issueOptions`, and one generic `populateIssueFilter(elementId, issues,
+selectedKeys)` in `app.js` replaces `populateEpicFilter` and
+`populateStoryFilter`.
+
 | File | PR 1 (text) | PR 2 (epic) | PR 3 (story) |
 |---|---|---|---|
 | `public/index.html` | search box under the sidebar header | Epic multi-select after Fix version | Story multi-select after Epic |

--- a/docs/superpowers/specs/2026-09-10-ready-for-assignee-design.md
+++ b/docs/superpowers/specs/2026-09-10-ready-for-assignee-design.md
@@ -1,0 +1,76 @@
+# Ready for assignee filter
+
+**Date:** 2026-09-10
+**Target version:** 2.4.0 (with the text, epic and story filters)
+**Issue:** #31
+**Status:** Agreed
+
+## 1. Goal
+
+A checkbox **Ready for assignee**, the assignee-side twin of "Ready for
+reviewer": while at least one assignee is selected, it keeps only the pull
+requests that need that assignee's attention, i.e. the ones that already get
+the assignee highlight. Along the way both "Ready" filters become restorable
+from the URL, which has been possible since attention is computed from the
+data.
+
+## 2. Decisions
+
+1. **Rule.** A pull request passes the filter when `computeAttention().assignee`
+   is true: a linked issue is In Progress (the pull request carries the
+   `status-in-progress` class) and a linked issue is assigned to a selected
+   assignee. This is the same rule as the red assignee highlight.
+2. **Placement.** The checkbox row sits directly under the Assignee filter,
+   like "Ready for reviewer" sits under Reviewer. Disabled while no assignee
+   is selected; unchecked automatically when the selection becomes empty.
+3. **Both boxes checked.** The tree keeps the pull requests matching either
+   box (OR). A pull request is never in progress and in review at once, so AND
+   would always give an empty tree.
+4. **URL.** Parameters `readyAssignee=true` and `readyReviewer=true`, both
+   restored on reload like every other filter. The former `ready` parameter is
+   read as `readyReviewer` for old links and never written again. The "reset
+   when the page is reloaded" info icons go away; each checkbox gets an info
+   icon that states its rule instead.
+
+## 3. Out of scope
+
+- Restoring the SYNC filter from the URL (its data is loaded on demand).
+- Any change to the highlight or to the attention count in the tab title.
+
+## 4. Behaviour
+
+- `evaluatePullRequest` filters: `ready` becomes `readyReviewer`; `readyAssignee`
+  is added; both default to `false` so older tests and callers keep working.
+  Match: `(!readyReviewer && !readyAssignee) || (readyReviewer && attention.reviewer) || (readyAssignee && attention.assignee)`.
+- `countActiveFilters`: each checked box counts as one active filter.
+- `app.js`: `currentReadyForAssignee` next to `currentReadyForReviewer`; one
+  `updateReadyCheckboxes()` helper keeps both checkboxes disabled and unchecked
+  while their multi-select is empty and reflects the state otherwise; it is
+  called from `readFilterControls`, `restoreFiltersFromUrl` and at
+  initialisation. "Clear filters" and the project switch uncheck both.
+- `index.html`: the new checkbox row after the Assignee filter; the reviewer
+  row keeps its place under Reviewer.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `public/app-filter.js` | `readyReviewer` / `readyAssignee` in `countActiveFilters` and `evaluatePullRequest`, OR match, JSDoc |
+| `public/index.html` | Assignee checkbox row, info icon titles on both rows |
+| `public/app.js` | state, URL parameters, `updateReadyCheckboxes()`, `initializeReadyFilters()`, reset and read paths |
+| `test/app-filter.test.mjs`, `test/fixtures.test.mjs` | renamed `ready`, new assignee and OR tests |
+| `README.md`, `CLAUDE.md`, `PRD.md` | feature, URL parameters, pitfalls |
+
+## 6. Verification
+
+`npm test`, then in the browser on the fixture server: the checkbox is disabled
+until an assignee is selected; checked, it keeps exactly the highlighted
+in-progress pull requests of that assignee; `readyAssignee=true` and
+`readyReviewer=true` survive a reload; clearing the assignee unchecks and
+disables it; both boxes together show the union; "Clear filters" and the
+project switch reset both.
+
+## 7. Delivery
+
+Branch `claude/filters-4-ready-assignee` on `claude/filters-3-story`, one pull
+request stacked on #30, closing #31.

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -149,8 +149,9 @@ function splitIssueKey(key) {
  * - assignee: the PR is in progress and a linked issue is assigned to a selected assignee
  * - reviewer: the PR is in review and a selected reviewer (never the author) has not approved
  *
- * The title of a PR with attention is highlighted; the "Ready for reviewer"
- * filter keeps the PRs with reviewer attention.
+ * The title of a PR with attention is highlighted; the "Ready for reviewer" and
+ * "Ready for assignee" filters keep the PRs with, respectively, reviewer and
+ * assignee attention.
  */
 export function computeAttention(pullRequestData, { statusInProgress, statusInReview, linkedIssues, assignees, reviewers }) {
     const assignee = assignees.length > 0 && statusInProgress &&

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -23,7 +23,7 @@ export function initializeFilter(apiResult) {
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, readyReviewer = false, readyAssignee = false }) {
     return [
         parseTextQuery(text).length > 0,
         assignees.length > 0,
@@ -32,7 +32,8 @@ export function countActiveFilters({ text = '', assignees, reviewers, sprints, f
         fixVersions.length > 0,
         epics.length > 0,
         stories.length > 0,
-        ready === true,
+        readyReviewer === true,
+        readyAssignee === true,
         sync !== 'Show all'
     ].filter(Boolean).length;
 }
@@ -228,12 +229,12 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, readyReviewer = false, readyAssignee = false }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -253,8 +254,12 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const syncMatch = sync === 'Show all' ||
         (sync === 'requested' && hasSyncLabel) ||
         (sync === 'OK' && !hasSyncLabel);
-    // Ready for reviewer: in review, and a selected reviewer has not approved yet
-    const readyMatch = !ready || attention.reviewer;
+    // Ready filters: with one or both checked, keep the pull requests that need the
+    // attention of the selected reviewers or assignees. A pull request is never in
+    // review and in progress at once, so the two boxes combine as OR
+    const readyMatch = (!readyReviewer && !readyAssignee) ||
+        (readyReviewer && attention.reviewer) ||
+        (readyAssignee && attention.assignee);
 
     return {
         visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && storyMatch && syncMatch && readyMatch,
@@ -266,7 +271,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(filters) {
@@ -330,8 +335,8 @@ function filterPullRequest(pullRequestElement, pass) {
     const entry = pass.index.pullRequestsById.get(Number(pullRequestElement.dataset.id));
     let isVisible = false;
     if (entry) {
-        // Attention is computed from data before visibility, so the ready filter never
-        // depends on what a previous pass rendered
+        // Attention is computed from data before visibility, so the ready filters never
+        // depend on what a previous pass rendered
         const { visible, attention } = evaluatePullRequest(entry, pass.filters, {
             statusInProgress: pullRequestElement.classList.contains('status-in-progress'),
             statusInReview: pullRequestElement.classList.contains('status-in-review'),

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -23,7 +23,7 @@ export function initializeFilter(apiResult) {
  * Counts the filters that are not at their default value.
  * A multi-select with several values counts once.
  */
-export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }) {
+export function countActiveFilters({ text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }) {
     return [
         parseTextQuery(text).length > 0,
         assignees.length > 0,
@@ -31,6 +31,7 @@ export function countActiveFilters({ text = '', assignees, reviewers, sprints, f
         sprints.length > 0,
         fixVersions.length > 0,
         epics.length > 0,
+        stories.length > 0,
         ready === true,
         sync !== 'Show all'
     ].filter(Boolean).length;
@@ -99,6 +100,19 @@ export function epicOf(issue, issuesByKey) {
     return null;
 }
 
+/**
+ * The story an issue belongs to: the issue itself when it is a standard issue,
+ * its parent when it is a sub-task (the inline parent carries the key and the
+ * summary), nothing for an epic. Pure.
+ * @returns {{ key: string, summary: string } | null}
+ */
+export function storyOf(issue) {
+    const level = issueLevel(issue);
+    if (level === 'standard') return issueReference(issue);
+    if (level === 'subtask' && issue.fields.parent) return issueReference(issue.fields.parent);
+    return null;
+}
+
 // ---------------------------------------------------- issue filter options
 
 /**
@@ -155,7 +169,7 @@ export function computeAttention(pullRequestData, { statusInProgress, statusInRe
  * Indexes the API result for the filters: one entry per pull request with its
  * linked issues, the text the text filter searches and the sets the other
  * filters compare against. Pure.
- * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }> }}
+ * @returns {{ pullRequestsById: Map<number, object>, epics: Map<string, { key, summary }>, stories: Map<string, { key, summary }> }}
  */
 export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIssuesDetails = [], sprintIssues = {} }) {
     const issuesByKey = new Map(jiraIssuesDetails.map(issue => [issue.key, issue]));
@@ -172,12 +186,17 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 
     const pullRequestsById = new Map();
     const epics = new Map();
+    const stories = new Map();
     for (const pullRequest of pullRequests) {
         const issueKeys = jiraIssuesMap[pullRequest.id] || [];
         const linkedIssues = issueKeys.map(key => issuesByKey.get(key)).filter(issue => issue);
         const pullRequestEpics = linkedIssues.map(issue => epicOf(issue, issuesByKey)).filter(epic => epic);
         for (const epic of pullRequestEpics) {
             epics.set(epic.key, epic);
+        }
+        const pullRequestStories = linkedIssues.map(issue => storyOf(issue)).filter(story => story);
+        for (const story of pullRequestStories) {
+            stories.set(story.key, story);
         }
         const entry = {
             pullRequest,
@@ -195,12 +214,13 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
             fixVersions: new Set(linkedIssues
                 .flatMap(issue => issue.fields.fixVersions || [])
                 .map(version => String(version.id))),
-            epics: new Set(pullRequestEpics.map(epic => epic.key))
+            epics: new Set(pullRequestEpics.map(epic => epic.key)),
+            stories: new Set(pullRequestStories.map(story => story.key))
         };
         pullRequestsById.set(pullRequest.id, entry);
     }
 
-    return { pullRequestsById, epics };
+    return { pullRequestsById, epics, stories };
 }
 
 // -------------------------------------------------------------- evaluation
@@ -208,12 +228,12 @@ export function buildFilterIndex({ pullRequests = [], jiraIssuesMap = {}, jiraIs
 /**
  * Applies the filters to one indexed pull request. Pure.
  * @param {object} entry - an entry of buildFilterIndex().pullRequestsById
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
  * @param {object} rendered - what the tree shows for this pull request:
  *   statusInProgress, statusInReview (from the Jira statuses) and hasSyncLabel
  * @returns {{ visible: boolean, attention: { assignee, reviewer, any } }}
  */
-export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
+export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sprints, fixVersions, epics = [], stories = [], sync, ready }, { statusInProgress, statusInReview, hasSyncLabel }) {
     const attention = computeAttention(entry.pullRequest, {
         statusInProgress,
         statusInReview,
@@ -229,6 +249,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const sprintMatch = sprints.length === 0 || sprints.some(sprintId => entry.sprints.has(String(sprintId)));
     const fixVersionMatch = fixVersions.length === 0 || fixVersions.some(versionId => entry.fixVersions.has(String(versionId)));
     const epicMatch = epics.length === 0 || epics.some(key => entry.epics.has(key));
+    const storyMatch = stories.length === 0 || stories.some(key => entry.stories.has(key));
     const syncMatch = sync === 'Show all' ||
         (sync === 'requested' && hasSyncLabel) ||
         (sync === 'OK' && !hasSyncLabel);
@@ -236,7 +257,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
     const readyMatch = !ready || attention.reviewer;
 
     return {
-        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && syncMatch && readyMatch,
+        visible: textMatch && assigneeMatch && reviewerMatch && sprintMatch && fixVersionMatch && epicMatch && storyMatch && syncMatch && readyMatch,
         attention
     };
 }
@@ -245,7 +266,7 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 
 /**
  * Applies the filters to the rendered tree and refreshes the counters.
- * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, sync, ready }
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, ready }
  * @returns {number} how many pull requests are left shown and need attention
  */
 export function filterBranches(filters) {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -124,7 +124,7 @@ export function storyOf(issue) {
 export function issueOptions(issues) {
     return [...issues]
         .sort((a, b) => compareIssueKeys(a.key, b.key))
-        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}` }));
+        .map(issue => ({ value: issue.key, label: `${issue.key} ${issue.summary}`.trim() }));
 }
 
 // Jira project alphabetically, then issue number descending

--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,8 @@ let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
 const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'storySelect', 'assigneeSelect', 'reviewerSelect'];
+// The two ready checkboxes, in sidebar order
+const readyCheckboxIds = ['readyForAssigneeCheck', 'readyForReviewerCheck'];
 // URL parameters written by the filters ('ready', the former name of readyReviewer, is only ever removed)
 const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
 
@@ -53,7 +55,8 @@ function applyFilters() {
 }
 
 // Puts every filter control back to its default without applying anything:
-// the search box, the multi-selects, the ready checkboxes and the SYNC select
+// the search box, the multi-selects, the ready checkboxes (unchecked; their
+// disabled state follows the selection in readFilterControls) and the SYNC select
 function resetFilterControls() {
     const textFilter = document.getElementById('textFilter');
     if (textFilter) textFilter.value = '';
@@ -61,7 +64,7 @@ function resetFilterControls() {
         const multiSelect = getMultiSelect(id);
         if (multiSelect) multiSelect.clearAll(false);
     });
-    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+    readyCheckboxIds.forEach(id => {
         const checkbox = document.getElementById(id);
         if (checkbox) checkbox.checked = false;
     });
@@ -143,11 +146,16 @@ function restoreFiltersFromUrl() {
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
 
+    // Assignee and reviewer options already exist here: keep only the names they offer, so a
+    // stale name in the URL cannot leave a ready checkbox enabled over an empty selection
+    // (sprints and fix versions are populated after this and validate their own selection)
     if (assigneeMultiSelect) {
         assigneeMultiSelect.setSelectedValues(currentAssignees);
+        currentAssignees = assigneeMultiSelect.getSelectedValues();
     }
     if (reviewerMultiSelect) {
         reviewerMultiSelect.setSelectedValues(currentReviewers);
+        currentReviewers = reviewerMultiSelect.getSelectedValues();
     }
     if (sprintMultiSelect) {
         sprintMultiSelect.setSelectedValues(currentSprints);
@@ -184,15 +192,17 @@ function initializeSyncControls() {
 }
 
 function initializeReadyFilters() {
-    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+    readyCheckboxIds.forEach(id => {
         const checkbox = document.getElementById(id);
         if (checkbox) checkbox.addEventListener('change', handleFilterChange);
     });
     updateReadyCheckboxes();
 }
 
-// The ready checkboxes depend on their multi-select: disabled and unchecked
-// while no assignee (or reviewer) is selected, otherwise they show the state
+// The ready checkboxes depend on their multi-select: while no assignee (or
+// reviewer) is selected the matching state is cleared (so a readyAssignee=true
+// without an assignee in the URL is dropped) and the box is disabled and
+// unchecked; otherwise the box shows the state
 function updateReadyCheckboxes() {
     if (currentAssignees.length === 0) currentReadyForAssignee = false;
     if (currentReviewers.length === 0) currentReadyForReviewer = false;

--- a/public/app.js
+++ b/public/app.js
@@ -120,6 +120,7 @@ function restoreFiltersFromUrl() {
     currentReviewers = urlParams.getAll('reviewer');
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
+    // Epic and story selections are applied by populateIssueFilter once their options exist
     currentEpics = urlParams.getAll('epic');
     currentStories = urlParams.getAll('story');
     currentText = urlParams.get('q') || '';

--- a/public/app.js
+++ b/public/app.js
@@ -8,6 +8,7 @@ let currentText = '';
 let currentSprints = [];
 let currentFixVersions = [];
 let currentEpics = [];
+let currentStories = [];
 let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
@@ -21,9 +22,9 @@ let syncStatusLoading = false;
 let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
-const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'assigneeSelect', 'reviewerSelect'];
+const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'storySelect', 'assigneeSelect', 'reviewerSelect'];
 // URL parameters written by the filters
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'assignee', 'reviewer', 'sync', 'ready'];
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'ready'];
 
 function currentFilters() {
     return {
@@ -33,6 +34,7 @@ function currentFilters() {
         sprints: currentSprints,
         fixVersions: currentFixVersions,
         epics: currentEpics,
+        stories: currentStories,
         sync: currentSync,
         ready: currentReadyForReviewer
     };
@@ -92,6 +94,7 @@ function updateUrlWithFilters({ replace = false } = {}) {
     currentSprints.forEach(v => url.searchParams.append('sprint', v));
     currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
     currentEpics.forEach(v => url.searchParams.append('epic', v));
+    currentStories.forEach(v => url.searchParams.append('story', v));
     if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
     if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
 
@@ -118,6 +121,7 @@ function restoreFiltersFromUrl() {
     currentSprints = urlParams.getAll('sprint');
     currentFixVersions = urlParams.getAll('fixVersion');
     currentEpics = urlParams.getAll('epic');
+    currentStories = urlParams.getAll('story');
     currentText = urlParams.get('q') || '';
 
     if (!currentSyncStatuses) {
@@ -287,6 +291,7 @@ function readFilterControls() {
     const sprintMultiSelect = getMultiSelect('sprintSelect');
     const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
     const epicMultiSelect = getMultiSelect('epicSelect');
+    const storyMultiSelect = getMultiSelect('storySelect');
 
     currentText = textFilter ? textFilter.value : '';
     currentAssignees = assigneeMultiSelect ? assigneeMultiSelect.getSelectedValues() : [];
@@ -294,6 +299,7 @@ function readFilterControls() {
     currentSprints = sprintMultiSelect ? sprintMultiSelect.getSelectedValues() : [];
     currentFixVersions = fixVersionMultiSelect ? fixVersionMultiSelect.getSelectedValues() : [];
     currentEpics = epicMultiSelect ? epicMultiSelect.getSelectedValues() : [];
+    currentStories = storyMultiSelect ? storyMultiSelect.getSelectedValues() : [];
 
     // Get sync and ready values from regular form elements
     const syncSelect = document.getElementById("syncSelect");
@@ -510,6 +516,7 @@ function renderEverything(apiResult) {
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
     currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
+    currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);
 
     // Every filter is populated and restored from the URL: apply them once
     applyFilters();

--- a/public/app.js
+++ b/public/app.js
@@ -13,6 +13,7 @@ let currentAssignees = [];
 let currentReviewers = [];
 let currentSync = "Show all";
 let currentReadyForReviewer = false;
+let currentReadyForAssignee = false;
 let currentApiResult = null;
 let reloadInterval = 100;
 // SYNC statuses are only fetched when the user clicks the load button; the
@@ -23,8 +24,8 @@ let syncLoadFailed = false;
 
 // Multi-select filters, in sidebar order
 const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'storySelect', 'assigneeSelect', 'reviewerSelect'];
-// URL parameters written by the filters
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'ready'];
+// URL parameters written by the filters ('ready', the former name of readyReviewer, is only ever removed)
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
 
 function currentFilters() {
     return {
@@ -36,7 +37,8 @@ function currentFilters() {
         epics: currentEpics,
         stories: currentStories,
         sync: currentSync,
-        ready: currentReadyForReviewer
+        readyReviewer: currentReadyForReviewer,
+        readyAssignee: currentReadyForAssignee
     };
 }
 
@@ -51,7 +53,7 @@ function applyFilters() {
 }
 
 // Puts every filter control back to its default without applying anything:
-// the search box, the multi-selects, the ready checkbox and the SYNC select
+// the search box, the multi-selects, the ready checkboxes and the SYNC select
 function resetFilterControls() {
     const textFilter = document.getElementById('textFilter');
     if (textFilter) textFilter.value = '';
@@ -59,8 +61,10 @@ function resetFilterControls() {
         const multiSelect = getMultiSelect(id);
         if (multiSelect) multiSelect.clearAll(false);
     });
-    const readyCheck = document.getElementById('readyForReviewerCheck');
-    if (readyCheck) readyCheck.checked = false;
+    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+        const checkbox = document.getElementById(id);
+        if (checkbox) checkbox.checked = false;
+    });
     const syncSelect = document.getElementById('syncSelect');
     if (syncSelect) syncSelect.value = 'Show all';
 }
@@ -96,7 +100,8 @@ function updateUrlWithFilters({ replace = false } = {}) {
     currentEpics.forEach(v => url.searchParams.append('epic', v));
     currentStories.forEach(v => url.searchParams.append('story', v));
     if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
-    if (currentReadyForReviewer) url.searchParams.set('ready', 'true');
+    if (currentReadyForReviewer) url.searchParams.set('readyReviewer', 'true');
+    if (currentReadyForAssignee) url.searchParams.set('readyAssignee', 'true');
 
     // Update URL without reloading the page. Safari throws past 100 updates
     // per 30 seconds: the URL then catches up on the next change
@@ -128,7 +133,9 @@ function restoreFiltersFromUrl() {
     if (!currentSyncStatuses) {
         currentSync = "Show all"; // Not restored from URL because SYNC status is only loaded on demand
     }
-    currentReadyForReviewer = false; // Not restored because it requires a fully displayed and updated pr tree
+    // Restored like the other filters; 'ready' is the former name of readyReviewer
+    currentReadyForReviewer = urlParams.get('readyReviewer') === 'true' || urlParams.get('ready') === 'true';
+    currentReadyForAssignee = urlParams.get('readyAssignee') === 'true';
 
     // Update multi-select components with restored values
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
@@ -149,15 +156,10 @@ function restoreFiltersFromUrl() {
         fixVersionMultiSelect.setSelectedValues(currentFixVersions);
     }
 
-    // Update sync select and ready checkbox
+    // Update the sync select and the ready checkboxes
     const syncSelect = document.getElementById('syncSelect');
-    const readyCheck = document.getElementById('readyForReviewerCheck');
-
     if (syncSelect) syncSelect.value = currentSync;
-    if (readyCheck) {
-        readyCheck.checked = currentReadyForReviewer;
-        readyCheck.disabled = currentReviewers.length === 0;
-    }
+    updateReadyCheckboxes();
 
     // The URL holds the trimmed query: a box the user is typing in is authoritative
     const textFilter = document.getElementById('textFilter');
@@ -181,13 +183,28 @@ function initializeSyncControls() {
     updateSyncControls();
 }
 
-function initializeReadyForReviewerFilter() {
-    const readyCheck = document.getElementById('readyForReviewerCheck');
-    if (readyCheck) {
-        readyCheck.addEventListener('change', handleFilterChange);
-        // Set initial state - disabled when no reviewers selected
-        readyCheck.disabled = currentReviewers.length === 0;
-        readyCheck.checked = currentReadyForReviewer;
+function initializeReadyFilters() {
+    ['readyForAssigneeCheck', 'readyForReviewerCheck'].forEach(id => {
+        const checkbox = document.getElementById(id);
+        if (checkbox) checkbox.addEventListener('change', handleFilterChange);
+    });
+    updateReadyCheckboxes();
+}
+
+// The ready checkboxes depend on their multi-select: disabled and unchecked
+// while no assignee (or reviewer) is selected, otherwise they show the state
+function updateReadyCheckboxes() {
+    if (currentAssignees.length === 0) currentReadyForAssignee = false;
+    if (currentReviewers.length === 0) currentReadyForReviewer = false;
+    const assigneeCheck = document.getElementById('readyForAssigneeCheck');
+    if (assigneeCheck) {
+        assigneeCheck.disabled = currentAssignees.length === 0;
+        assigneeCheck.checked = currentReadyForAssignee;
+    }
+    const reviewerCheck = document.getElementById('readyForReviewerCheck');
+    if (reviewerCheck) {
+        reviewerCheck.disabled = currentReviewers.length === 0;
+        reviewerCheck.checked = currentReadyForReviewer;
     }
 }
 
@@ -284,7 +301,7 @@ function showErrorState() {
 }
 
 // Copies the filter controls into the state variables and refreshes the
-// controls that depend on them (ready checkbox, clear button)
+// controls that depend on them (ready checkboxes, clear button)
 function readFilterControls() {
     const textFilter = document.getElementById('textFilter');
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
@@ -304,19 +321,13 @@ function readFilterControls() {
 
     // Get sync and ready values from regular form elements
     const syncSelect = document.getElementById("syncSelect");
-    const readyCheck = document.getElementById("readyForReviewerCheck");
+    const assigneeCheck = document.getElementById('readyForAssigneeCheck');
+    const reviewerCheck = document.getElementById('readyForReviewerCheck');
 
     currentSync = syncSelect ? syncSelect.value : "Show all";
-    currentReadyForReviewer = readyCheck ? readyCheck.checked : false;
-
-    // Enable/disable checkbox based on reviewer selection (disabled when no reviewers selected)
-    if (readyCheck) {
-        readyCheck.disabled = currentReviewers.length === 0;
-        if (currentReviewers.length === 0) {
-            readyCheck.checked = false;
-            currentReadyForReviewer = false;
-        }
-    }
+    currentReadyForAssignee = assigneeCheck ? assigneeCheck.checked : false;
+    currentReadyForReviewer = reviewerCheck ? reviewerCheck.checked : false;
+    updateReadyCheckboxes();
 
     updateTextFilterClearButton();
 }
@@ -368,7 +379,6 @@ function initializeTextFilter() {
 function populateFilters(pullRequests) {
     const assigneeMultiSelect = getMultiSelect('assigneeSelect');
     const reviewerMultiSelect = getMultiSelect('reviewerSelect');
-    const readyCheck = document.getElementById('readyForReviewerCheck');
 
     // Extract unique assignees from Jira issues and sort them alphabetically
     const assignees = new Set();
@@ -401,12 +411,6 @@ function populateFilters(pullRequests) {
 
     // Reflect the current SYNC load state (statuses are only fetched on demand)
     updateSyncControls();
-
-    // Update checkbox state
-    if (readyCheck) {
-        readyCheck.disabled = currentReviewers.length === 0;
-        readyCheck.checked = currentReadyForReviewer;
-    }
 
     // Restore filter values; renderEverything applies them once every filter is populated
     restoreFiltersFromUrl();
@@ -1210,7 +1214,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadProjects();
     fetchAndDisplayVersion();
     initializePopovers();
-    initializeReadyForReviewerFilter();
+    initializeReadyFilters();
     initializeSyncControls();
 });
 

--- a/public/index.html
+++ b/public/index.html
@@ -181,6 +181,13 @@
     </div>
   </div>
 
+  <div class="filter-item filter-item-checkbox">
+    <input type="checkbox" id="readyForAssigneeCheck" disabled>
+    <label for="readyForAssigneeCheck">Ready for assignee</label>
+    <i class="fas fa-info-circle info-icon"
+       title="Pull requests in progress with a linked issue assigned to a selected assignee"></i>
+  </div>
+
   <div class="filter-item">
     <span class="filter-label">Reviewer</span>
     <div class="multi-select" id="reviewerSelect" data-filter="reviewer">
@@ -204,7 +211,8 @@
   <div class="filter-item filter-item-checkbox">
     <input type="checkbox" id="readyForReviewerCheck" disabled>
     <label for="readyForReviewerCheck">Ready for reviewer</label>
-    <i class="fas fa-info-circle info-icon" title="This filter will be reset when the page is reloaded"></i>
+    <i class="fas fa-info-circle info-icon"
+       title="Pull requests in review that a selected reviewer has not approved yet"></i>
   </div>
 
   <hr class="sidebar-divider">

--- a/public/index.html
+++ b/public/index.html
@@ -139,6 +139,29 @@
   </div>
 
   <div class="filter-item">
+    <span class="filter-label">Story
+      <i class="fas fa-info-circle info-icon"
+         title="Issue delivered by the pull request: the linked issue, or the parent of a linked sub-task"></i>
+    </span>
+    <div class="multi-select" id="storySelect" data-filter="story">
+      <div class="multi-select-trigger" tabindex="0">
+        <span class="multi-select-display">Show all</span>
+        <i class="fas fa-chevron-down multi-select-arrow"></i>
+      </div>
+      <div class="multi-select-dropdown">
+        <div class="multi-select-search">
+          <input type="text" placeholder="Search..." class="multi-select-search-input">
+        </div>
+        <div class="multi-select-options"></div>
+        <div class="multi-select-actions">
+          <button type="button" class="multi-select-clear">Clear all</button>
+          <button type="button" class="multi-select-select-all">Select all</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="filter-item">
     <span class="filter-label">Assignee</span>
     <div class="multi-select" id="assigneeSelect" data-filter="assignee">
       <div class="multi-select-trigger" tabindex="0">

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -82,6 +82,7 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ ...defaults, stories: ['PROJ-200'] }), 1);
     assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], readyAssignee: true }), 2);
     assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], reviewers: ['J'], readyAssignee: true, readyReviewer: true }), 4);
+    assert.equal(countActiveFilters({ ...defaults, ready: true }), 0); // the former name of readyReviewer is ignored
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -178,7 +179,9 @@ test('evaluatePullRequest ready-for-assignee filter keeps pull requests with ass
     assert.equal(jane.visible, true);
     assert.equal(jane.attention.assignee, true);
     const bob = evaluatePullRequest(entry, { ...noFilter, assignees: ['Bob'], readyAssignee: true }, inProgress);
-    assert.equal(bob.visible, false); // no linked issue assigned to Bob
+    assert.equal(bob.attention.assignee, false); // no linked issue assigned to Bob
+    const inReviewUnchecked = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'] }, rendered);
+    assert.equal(inReviewUnchecked.visible, true); // same pull request, box unchecked
     const inReview = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'], readyAssignee: true }, rendered);
     assert.equal(inReview.visible, false); // in review: no assignee attention
     assert.equal(inReview.attention.assignee, false);
@@ -191,6 +194,8 @@ test('both ready filters checked keep the pull requests needing either attention
     assert.equal(evaluatePullRequest(entry, both, { statusInProgress: true, statusInReview: false, hasSyncLabel: false }).visible, true); // assignee attention
     assert.equal(evaluatePullRequest(entry, both, rendered).visible, true); // reviewer attention: Jane has not approved
     assert.equal(evaluatePullRequest(entry, both, { statusInProgress: false, statusInReview: false, hasSyncLabel: false }).visible, false); // neither
+    const reviewerOnly = { ...noFilter, assignees: ['Jane'], reviewers: ['Jane'], readyReviewer: true };
+    assert.equal(evaluatePullRequest(entry, reviewerOnly, { statusInProgress: true, statusInReview: false, hasSyncLabel: false }).visible, false); // assignee attention does not satisfy the reviewer box
 });
 
 // ------------------------------------------------------------------ text filter

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -71,15 +71,17 @@ test('no attention without assignee or reviewer filters', () => {
 });
 
 test('countActiveFilters counts filters, not selected values', () => {
-    const defaults = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+    const defaults = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };
     assert.equal(countActiveFilters(defaults), 0);
-    assert.equal(countActiveFilters({ ...defaults, reviewers: ['Jane', 'Bob'], ready: true }), 2);
+    assert.equal(countActiveFilters({ ...defaults, reviewers: ['Jane', 'Bob'], readyReviewer: true }), 2);
     assert.equal(countActiveFilters({ ...defaults, sync: 'requested' }), 1);
-    assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', ready: true }), 6);
+    assert.equal(countActiveFilters({ assignees: ['A'], reviewers: ['J'], sprints: ['1'], fixVersions: ['2'], sync: 'OK', readyReviewer: true }), 6);
     assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
     assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
     assert.equal(countActiveFilters({ ...defaults, epics: ['PROJ-100', 'PROJ-101'] }), 1);
     assert.equal(countActiveFilters({ ...defaults, stories: ['PROJ-200'] }), 1);
+    assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], readyAssignee: true }), 2);
+    assert.equal(countActiveFilters({ ...defaults, assignees: ['A'], reviewers: ['J'], readyAssignee: true, readyReviewer: true }), 4);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -106,7 +108,7 @@ const sampleApiResult = {
 };
 
 const rendered = { statusInProgress: false, statusInReview: true, hasSyncLabel: false };
-const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };
 
 test('buildFilterIndex links issues, assignees, reviewers, sprints and fix versions per pull request', () => {
     const { pullRequestsById } = buildFilterIndex(sampleApiResult);
@@ -160,12 +162,35 @@ test('evaluatePullRequest SYNC filter follows the rendered badge', () => {
 test('evaluatePullRequest ready filter keeps pull requests with reviewer attention only', () => {
     const { pullRequestsById } = buildFilterIndex(sampleApiResult);
     const entry = pullRequestsById.get(10);
-    const jane = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Jane'], ready: true }, rendered);
+    const jane = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Jane'], readyReviewer: true }, rendered);
     assert.equal(jane.visible, true);
     assert.equal(jane.attention.reviewer, true);
-    const bobApproved = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Bob'], ready: true }, rendered);
+    const bobApproved = evaluatePullRequest(entry, { ...noFilter, reviewers: ['Bob'], readyReviewer: true }, rendered);
     assert.equal(bobApproved.visible, false);
     assert.equal(bobApproved.attention.any, false);
+});
+
+test('evaluatePullRequest ready-for-assignee filter keeps pull requests with assignee attention only', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10); // PROJ-1 is assigned to Jane
+    const inProgress = { statusInProgress: true, statusInReview: false, hasSyncLabel: false };
+    const jane = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'], readyAssignee: true }, inProgress);
+    assert.equal(jane.visible, true);
+    assert.equal(jane.attention.assignee, true);
+    const bob = evaluatePullRequest(entry, { ...noFilter, assignees: ['Bob'], readyAssignee: true }, inProgress);
+    assert.equal(bob.visible, false); // no linked issue assigned to Bob
+    const inReview = evaluatePullRequest(entry, { ...noFilter, assignees: ['Jane'], readyAssignee: true }, rendered);
+    assert.equal(inReview.visible, false); // in review: no assignee attention
+    assert.equal(inReview.attention.assignee, false);
+});
+
+test('both ready filters checked keep the pull requests needing either attention', () => {
+    const { pullRequestsById } = buildFilterIndex(sampleApiResult);
+    const entry = pullRequestsById.get(10);
+    const both = { ...noFilter, assignees: ['Jane'], reviewers: ['Jane'], readyAssignee: true, readyReviewer: true };
+    assert.equal(evaluatePullRequest(entry, both, { statusInProgress: true, statusInReview: false, hasSyncLabel: false }).visible, true); // assignee attention
+    assert.equal(evaluatePullRequest(entry, both, rendered).visible, true); // reviewer attention: Jane has not approved
+    assert.equal(evaluatePullRequest(entry, both, { statusInProgress: false, statusInReview: false, hasSyncLabel: false }).visible, false); // neither
 });
 
 // ------------------------------------------------------------------ text filter
@@ -358,5 +383,5 @@ test('epic and story filters combine as AND, and a story linked together with it
         jiraIssuesMap: { 30: ['PROJ-200', 'PROJ-300'] }
     });
     assert.deepEqual([...both.pullRequestsById.get(30).stories], ['PROJ-200']);
-    assert.equal(countActiveFilters({ assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false, epics: ['PROJ-100'], stories: ['PROJ-200'] }), 2);
+    assert.equal(countActiveFilters({ assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', readyReviewer: false, readyAssignee: false, epics: ['PROJ-100'], stories: ['PROJ-200'] }), 2);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -308,6 +308,7 @@ test('issueOptions labels "KEY Summary" and sorts by project then newest issue f
         { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
     ]);
     assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
+    assert.deepEqual(issueOptions([{ key: 'X-2', summary: '' }]), [{ value: 'X-2', label: 'X-2' }]); // parent fetched without a summary by an older server
 });
 
 // ----------------------------------------------------------------- story filter
@@ -343,4 +344,19 @@ test('evaluatePullRequest story filter matches any selected story', () => {
     assert.equal(evaluate(22, ['PROJ-200', 'PROJ-201']), true);
     assert.equal(evaluate(23, ['PROJ-200']), false);
     assert.equal(evaluate(23, []), true);
+});
+
+test('epic and story filters combine as AND, and a story linked together with its own sub-task counts once', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, filters) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, ...filters }, rendered).visible;
+    assert.equal(evaluate(21, { epics: ['PROJ-100'], stories: ['PROJ-200'] }), true);
+    assert.equal(evaluate(21, { epics: ['PROJ-100'], stories: ['PROJ-201'] }), false);
+    assert.equal(evaluate(22, { epics: ['PROJ-100'], stories: ['PROJ-201'] }), false); // the story matches, the epic does not
+    const both = buildFilterIndex({
+        ...hierarchyApiResult,
+        pullRequests: [{ id: 30, title: 'PROJ-200 PROJ-300 both', source: { branch: { name: 'feature/both' } }, author, participants: [] }],
+        jiraIssuesMap: { 30: ['PROJ-200', 'PROJ-300'] }
+    });
+    assert.deepEqual([...both.pullRequestsById.get(30).stories], ['PROJ-200']);
+    assert.equal(countActiveFilters({ assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false, epics: ['PROJ-100'], stories: ['PROJ-200'] }), 2);
 });

--- a/test/app-filter.test.mjs
+++ b/test/app-filter.test.mjs
@@ -79,6 +79,7 @@ test('countActiveFilters counts filters, not selected values', () => {
     assert.equal(countActiveFilters({ ...defaults, text: '   ' }), 0);
     assert.equal(countActiveFilters({ ...defaults, text: 'banner' }), 1);
     assert.equal(countActiveFilters({ ...defaults, epics: ['PROJ-100', 'PROJ-101'] }), 1);
+    assert.equal(countActiveFilters({ ...defaults, stories: ['PROJ-200'] }), 1);
 });
 
 // ------------------------------------------------------------------ index and evaluation
@@ -307,4 +308,39 @@ test('issueOptions labels "KEY Summary" and sorts by project then newest issue f
         { value: 'PROJ-10', label: 'PROJ-10 Ten' }, { value: 'PROJ-9', label: 'PROJ-9 Nine' }
     ]);
     assert.deepEqual(issueOptions(new Map([['X-1', { key: 'X-1', summary: 'One' }]]).values()), [{ value: 'X-1', label: 'X-1 One' }]);
+});
+
+// ----------------------------------------------------------------- story filter
+
+import { storyOf } from '../public/app-filter.js';
+
+test('storyOf is the issue itself, the parent of a sub-task, and nothing for an epic', () => {
+    assert.deepEqual(storyOf(storyInEpic), { key: 'PROJ-200', summary: 'Chat panel' });
+    assert.deepEqual(storyOf(bugWithoutEpic), { key: 'PROJ-201', summary: 'Crash on save' });
+    assert.deepEqual(storyOf(subtaskOfStory), { key: 'PROJ-200', summary: 'Chat panel' });
+    assert.deepEqual(storyOf(subtaskOfUnknown), { key: 'PROJ-999', summary: 'Unknown story' }); // the inline parent is enough
+    assert.equal(storyOf(epicAi), null);
+    assert.equal(storyOf({ key: 'PROJ-303', fields: { issuetype: subtaskType } }), null); // sub-task without parent
+});
+
+test('buildFilterIndex collects the stories of every pull request and the list of stories', () => {
+    const { pullRequestsById, stories } = buildFilterIndex(hierarchyApiResult);
+    assert.deepEqual([...pullRequestsById.get(20).stories], ['PROJ-200']);
+    assert.deepEqual([...pullRequestsById.get(21).stories], ['PROJ-200']); // the parent of the sub-task
+    assert.deepEqual([...pullRequestsById.get(22).stories], ['PROJ-201']);
+    assert.deepEqual([...pullRequestsById.get(23).stories], []); // an epic is not a story
+    assert.deepEqual([...pullRequestsById.get(24).stories], ['PROJ-200', 'PROJ-203']); // two issues, two stories
+    assert.deepEqual([...stories.keys()], ['PROJ-200', 'PROJ-201', 'PROJ-203']);
+    assert.equal(buildFilterIndex({}).stories.size, 0);
+});
+
+test('evaluatePullRequest story filter matches any selected story', () => {
+    const { pullRequestsById } = buildFilterIndex(hierarchyApiResult);
+    const evaluate = (id, stories) => evaluatePullRequest(pullRequestsById.get(id), { ...noFilter, stories }, rendered).visible;
+    assert.equal(evaluate(20, ['PROJ-200']), true);
+    assert.equal(evaluate(21, ['PROJ-200']), true);
+    assert.equal(evaluate(22, ['PROJ-200']), false);
+    assert.equal(evaluate(22, ['PROJ-200', 'PROJ-201']), true);
+    assert.equal(evaluate(23, ['PROJ-200']), false);
+    assert.equal(evaluate(23, []), true);
 });

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -144,7 +144,7 @@ test('the filter index built on the SECOLLAB fixture links every pull request', 
     assert.ok(withIssues.length > data.pullRequests.length * 0.8);
     const inSprint = [...pullRequestsById.values()].filter(entry => entry.sprints.size > 0);
     assert.ok(inSprint.length > 10, `${inSprint.length} pull requests in a sprint`);
-    const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', ready: false };
+    const noFilter = { assignees: [], reviewers: [], sprints: [], fixVersions: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };
     const rendered = { statusInProgress: false, statusInReview: false, hasSyncLabel: false };
     for (const entry of pullRequestsById.values()) {
         assert.equal(evaluatePullRequest(entry, noFilter, rendered).visible, true);

--- a/test/fixtures.test.mjs
+++ b/test/fixtures.test.mjs
@@ -174,3 +174,14 @@ test('the SECOLLAB fixture carries epics and parent-only issues with their hiera
     assert.ok(linkedToSubtask.length > 0);
     assert.ok(linkedToSubtask.some(entry => entry.epics.size > 0), 'a pull request linked to a sub-task reaches its epic');
 });
+
+test('the filter index resolves a story for every pull request linked to an issue', () => {
+    const data = generateProjectData('SECOLLAB', projects.SECOLLAB);
+    const { pullRequestsById, stories } = buildFilterIndex(data);
+    const linked = [...pullRequestsById.values()].filter(entry => entry.linkedIssues.length > 0);
+    assert.ok(linked.every(entry => entry.stories.size > 0));
+    assert.ok(stories.size > 50, `${stories.size} stories`);
+    const withSubtask = linked.find(entry => entry.linkedIssues.some(issue => issue.fields.issuetype.subtask));
+    const subtask = withSubtask.linkedIssues.find(issue => issue.fields.issuetype.subtask);
+    assert.ok(withSubtask.stories.has(subtask.fields.parent.key), 'the story of a sub-task is its parent');
+});


### PR DESCRIPTION
A **Ready for assignee** checkbox under the Assignee filter, the twin of "Ready for reviewer": enabled while at least one assignee is selected, it keeps the pull requests that need that assignee's attention, i.e. the ones already highlighted for it (a linked issue In Progress, a linked issue assigned to a selected assignee). With both "Ready" boxes checked the tree keeps the pull requests matching either one, since a pull request is never in progress and in review at once.

Both "Ready" filters are now restored from the URL (`readyAssignee=true`, `readyReviewer=true`); the former `ready` parameter is read as `readyReviewer` for old links and never written again. The "reset when the page is reloaded" info icons are replaced by icons stating each rule. As a side effect, the periodic refresh no longer silently unchecks "Ready for reviewer".

## Changes

- **Logic** (`public/app-filter.js`): `ready` becomes `readyReviewer`, `readyAssignee` is added, both default to false; the OR match on the two attentions; each box counts as one active filter.
- **Sidebar and state** (`public/index.html`, `public/app.js`): the new checkbox row, `currentReadyForAssignee`, the URL parameters, one `updateReadyCheckboxes()` that keeps each box disabled and unchecked while its multi-select is empty, `initializeReadyFilters()`, the dead checkbox block of `populateFilters` removed. After review: the assignee and reviewer state is read back from the multi-selects on restore, so a stale name in a shared link cannot leave a box enabled over an empty selection.
- **Tests**: 49 (`npm test`): the assignee rule, the union, the exclusivity of the two boxes, the legacy key ignored.
- **Docs**: README, CLAUDE.md (pitfalls 4 and 7, URL example), PRD F4.13.

## Verified

- `npm test`: 49 pass, 0 fail.
- In the browser on the fixture server: the box is disabled until an assignee is selected, checked it keeps exactly the 5 in-progress pull requests of that assignee (independent computation, all highlighted, tab title at 5); `readyAssignee=true` and `readyReviewer=true` survive a reload; clearing the assignee unchecks and disables it; both boxes show the union; "Clear filters" and the project switch reset both; a stale assignee in the URL leaves the box off; the legacy `ready` parameter is dropped.

Closes #31
Stacked on #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuGDyDk4Av2U5A1oVXhAMF