### PR TITLE
feat: hide the repositories left without a matching pull request (v2.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.4.0** (as of 2026-09-09)
+Current version: **2.5.0** (as of 2026-09-10)
 
 ## Technology Stack
 
@@ -130,7 +130,7 @@ pr-tree/
 **public/app-filter.js**
 - `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`) and story keys (`stories`); it also returns `index.epics` and `index.stories`, the epics and stories to list in the filters; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
-- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, hides the root branches and repositories left without a visible pull request, shows the `.tree-no-match` message while every repository is hidden, returns the attention count
 - `issueLevel`, `epicOf`, `storyOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
@@ -313,7 +313,7 @@ Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranc
 Single pass in app-filter.js:
 1. `initializeFilter(apiResult)` builds the index once per data load (Maps and Sets, no array search later)
 2. `filterBranches()` collects the SYNC badges once, then walks repositories → root branches → direct child pull requests → their `.children` container, recursively; every pull request is visited exactly once
-3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible
+3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible; a root branch or a repository with no visible pull request is hidden, and the `.tree-no-match` message rendered by `renderRepositories` is shown while every repository is hidden
 4. Counters (repository, root branch, child counters shown) are summed on the way back up and written through `updateCounterDisplay`; DOM writes only happen when the value changes
 
 Never re-select descendants (`querySelectorAll('.pull-request')`) inside the recursion: the previous implementation did, and a pull request at depth *d* was visited 2^d times (16 million visits per filter change on SECOLLAB).

--- a/PRD.md
+++ b/PRD.md
@@ -182,6 +182,7 @@ The application integrates with a Jira workflow where:
 - F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
 - F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
 - F4.13: Filter by "ready for assignee" status: In Progress pull requests with a linked issue assigned to a selected assignee; with both ready filters checked, pull requests needing either attention are kept
+- F4.14: Hide the repositories and branches left without a matching pull request; show a message when no pull request matches
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
     * Filters pull requests based on the fixVersion field of associated Jira issues
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
+* Hides the repositories and branches left without a matching pull request; when nothing matches, a message replaces the tree
 * Maintains filter selections in URL
     * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer, ready for assignee, ready for reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
@@ -82,6 +83,9 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.5.0
+    * Repositories left without a matching pull request are hidden by the filters, like their branches already were
+    * When nothing matches, a "No pull request matches the filters" message replaces the tree; the orphaned issues stay listed
 * Version 2.4.0
     * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
         * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean

--- a/docs/superpowers/plans/2026-09-10-hide-empty-repositories.md
+++ b/docs/superpowers/plans/2026-09-10-hide-empty-repositories.md
@@ -1,0 +1,206 @@
+# Hide Empty Repositories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide a repository block when the filters leave it without any visible pull request, and show a "No pull request matches the filters" message while every repository is hidden.
+
+**Architecture:** The filter pass (`filterBranches` in `public/app-filter.js`) already hides a root branch whose visible count is 0; the repository gets the same treatment one level up, in the same walk. `renderRepositories` (`public/app.js`) appends a hidden message element after the repositories; the pass, which runs after every render and every filter change, shows it exactly when no repository is left visible. Nothing else changes: not the index, not the evaluation, not the URL.
+
+**Tech Stack:** Vanilla ES modules, `node:test`. No server change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md`
+
+**Branch:** `claude/hide-empty-repositories`, created from `master` (already checked out). Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01TcMUwKXicKzfDozyREWQdD
+```
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (49 tests). The tree pass is DOM code and has no unit test (CLAUDE.md, "Testing Approach": UI is checked in the browser); the browser check is Task 2, done by the controller.
+
+**Running the app for manual checks:** `PORT=3101 node index.mjs --fixtures` (port 3000 runs the user's real server, port 3100 an unrelated application), http://localhost:3101/?project=SECOLLAB.
+
+---
+
+### Task 1: Hide the repository and show the message
+
+**Files:**
+- Modify: `public/app-filter.js` (the `filterBranches` function, JSDoc and loop, around lines 273-305)
+- Modify: `public/app.js` (`renderRepositories`, around lines 626-660)
+
+- [ ] **Step 1: Hide the repository in the filter pass**
+
+In `public/app-filter.js`, replace the JSDoc of `filterBranches` and the function body down to the `return` with:
+
+```js
+/**
+ * Applies the filters to the rendered tree and refreshes the counters. A root
+ * branch or a repository left without a visible pull request is hidden; while
+ * every repository is hidden, the "nothing matches" message is shown instead.
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
+ * @returns {number} how many pull requests are left shown and need attention
+ */
+export function filterBranches(filters) {
+    const pass = {
+        filters,
+        index: filterIndex || buildFilterIndex({}),
+        // The SYNC filter relies on the rendered badges: collect them once
+        pullRequestsWithSyncLabel: new Set(
+            Array.from(document.querySelectorAll('.pull-request .conflicts-count'))
+                .map(badge => badge.closest('.pull-request'))
+                .filter(pullRequest => pullRequest)
+                .map(pullRequest => pullRequest.dataset.id)
+        ),
+        shownAttention: 0
+    };
+
+    let shownRepositories = 0;
+    for (const repository of document.querySelectorAll('.repository')) {
+        let repositoryTotal = 0;
+        let repositoryVisible = 0;
+        for (const rootBranch of repository.querySelectorAll('.root-branch')) {
+            const content = rootBranch.querySelector('.root-branch-content');
+            const counts = content ? filterChildren(content, pass) : { total: 0, visible: 0 };
+            repositoryTotal += counts.total;
+            repositoryVisible += counts.visible;
+
+            // Hide branch if no visible pull requests
+            setDisplay(rootBranch, counts.visible > 0 ? '' : 'none');
+            const counter = rootBranch.querySelector('.branch-pr-counter');
+            if (counter) updateCounterDisplay(counter, counts.visible, counts.total);
+        }
+        const counter = repository.querySelector('.repo-pr-counter');
+        if (counter) updateCounterDisplay(counter, repositoryVisible, repositoryTotal);
+
+        // Hide the repository too when no pull request is left, like its branches
+        setDisplay(repository, repositoryVisible > 0 ? '' : 'none');
+        if (repositoryVisible > 0) shownRepositories++;
+    }
+
+    // renderRepositories renders the message hidden; it takes the place of the
+    // tree while every repository is hidden
+    const noMatch = document.querySelector('.tree-no-match');
+    if (noMatch) noMatch.hidden = shownRepositories > 0;
+
+    return pass.shownAttention;
+}
+```
+
+- [ ] **Step 2: Render the message after the repositories**
+
+In `public/app.js`, in `renderRepositories`, replace the final `return html;` (after the `for (const [repoName, repoPullRequests] ...)` loop) with:
+
+```js
+    // Shown by the filter pass while every repository is hidden
+    if (Object.keys(pullRequestsByRepo).length > 0) {
+        html += `
+            <div class="state-message tree-no-match" hidden>
+                <i class="fas fa-filter"></i>
+                <span>No pull request matches the filters</span>
+            </div>
+        `;
+    }
+    return html;
+```
+
+(`hidden` works on a `.state-message`: the stylesheet has `[hidden] { display: none !important; }`.)
+
+- [ ] **Step 3: Check the syntax and run the tests**
+
+Run: `node --check public/app-filter.js && node --check public/app.js && npm test`
+Expected: no syntax error, `ℹ fail 0`, 49 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/app-filter.js public/app.js
+git commit -m "feat: hide the repositories left without a visible pull request, no-match message"
+```
+
+---
+
+### Task 2: Browser check (controller)
+
+Run: `PORT=3101 node index.mjs --fixtures`, open http://localhost:3101/?project=SECOLLAB.
+
+- Type in the search box a word present in the pull requests of one repository only (a repository name works: source branches carry them in the fixtures, otherwise use a pull-request title word): the other repositories disappear, no empty header stays, the remaining repository keeps its `n/total` counter.
+- Clear the search box: every repository is back with the full counter.
+- Type `zzzz`: the tree is replaced by the filter icon and "No pull request matches the filters"; the orphaned issues section, when present, stays below it.
+- Collapse a repository, type a word that hides it, clear the box: it is back and still collapsed.
+- "Collapse all" then a filter that hides everything, "Expand all", clear: the repositories come back expanded.
+
+Stop the server with Ctrl+C (or kill the process).
+
+---
+
+### Task 3: Documentation and version
+
+**Files:**
+- Modify: `README.md` (Features list around line 42, changelog at line 85)
+- Modify: `CLAUDE.md` (version line, `filterBranches` bullet, Filtering Architecture step 3)
+- Modify: `PRD.md` (F4.14 after the F4.13 line, around line 184)
+- Modify: `package.json` (`version`, `releaseDate`)
+
+- [ ] **Step 1: README**
+
+a. In "Features", insert after the line `* Allows simultaneous filtering by both assignee and reviewer`:
+
+```
+* Hides the repositories and branches left without a matching pull request; when nothing matches, a message replaces the tree
+```
+
+b. Insert before the line `* Version 2.4.0` of the changelog:
+
+```
+* Version 2.5.0
+    * Repositories left without a matching pull request are hidden by the filters, like their branches already were
+    * When nothing matches, a "No pull request matches the filters" message replaces the tree; the orphaned issues stay listed
+```
+
+- [ ] **Step 2: CLAUDE.md**
+
+a. Replace `Current version: **2.4.0** (as of 2026-09-09)` with `Current version: **2.5.0** (as of 2026-09-10)`.
+
+b. In the `**public/app-filter.js**` block, replace the `filterBranches(filters)` bullet with:
+
+```
+- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, hides the root branches and repositories left without a visible pull request, shows the `.tree-no-match` message while every repository is hidden, returns the attention count
+```
+
+c. In "Filtering Architecture", replace step 3 `3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible` with:
+
+```
+3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible; a root branch or a repository with no visible pull request is hidden, and the `.tree-no-match` message rendered by `renderRepositories` is shown while every repository is hidden
+```
+
+- [ ] **Step 3: PRD.md**
+
+Insert after the `- F4.13: ...` line:
+
+```
+- F4.14: Hide the repositories and branches left without a matching pull request; show a message when no pull request matches
+```
+
+- [ ] **Step 4: package.json**
+
+Replace `"version": "2.4.0",` with `"version": "2.5.0",` and `"releaseDate": "2026-09-09",` with `"releaseDate": "2026-09-10",`.
+
+- [ ] **Step 5: Check and commit**
+
+Run: `npm test` (expected `ℹ fail 0`) and `curl -s localhost:3101/api/version` if the fixture server is still running (expected `"version":"2.5.0"` after a restart).
+
+```bash
+git add README.md CLAUDE.md PRD.md package.json
+git commit -m "docs: version 2.5.0, repositories hidden when filtered empty"
+```
+
+The controller pushes the branch and opens the pull request (base `master`).
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** rule and counter refresh (Task 1 step 1), message rendered hidden and toggled by the pass (Task 1 steps 1-2), collapsed state untouched (nothing touches the `collapsed` class; checked in Task 2), version 2.5.0 (Task 3 step 4), docs (Task 3), verification (Task 2).
+- **Placeholders:** none.
+- **Type consistency:** the message element is `.tree-no-match` in `renderRepositories`, in `filterBranches` and in the docs; `shownRepositories` is local to `filterBranches`.

--- a/docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md
+++ b/docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md
@@ -1,0 +1,77 @@
+# Hide repositories emptied by the filters
+
+**Date:** 2026-09-10
+**Target version:** 2.5.0
+**Status:** Decided in an autonomous session, without a review round; section 2 lists what to revisit
+
+## 1. Goal
+
+When the filters leave a repository without any visible pull request, the
+repository block disappears from the tree, like a root branch already does.
+Until now the block stayed on screen with a `0/n` counter and an empty
+content, so a filtered project showed a column of empty repository headers.
+
+## 2. Decisions
+
+1. **Rule.** In the filter pass, a repository whose visible count is 0 is
+   hidden with `display: none`, the same way as a root branch. It is shown
+   again by the next pass that leaves one of its pull requests visible. Its
+   counter is still refreshed while hidden, so it is right the moment the
+   block comes back.
+2. **No filter, no change.** Repositories without any open pull request are
+   never rendered (the repositories come from grouping the pull requests), so
+   with no active filter every repository stays visible. The change is only
+   observable while a filter is active.
+3. **Nothing matches.** When every repository is hidden, a message "No pull
+   request matches the filters" takes the place of the tree, in the style of
+   the loading and error messages. Without it the pane would be blank, which
+   reads as a bug, especially with the sidebar hidden. The orphaned issues
+   section is not filtered and keeps showing under the message, as it did
+   under the empty repositories.
+4. **Collapsed state.** Hiding does not touch the collapsed state: a
+   repository collapsed by the user comes back collapsed. "Collapse all" and
+   "Expand all" keep acting on hidden repositories, so they are in the
+   requested state when they reappear.
+5. **Version.** 2.5.0: a visible behaviour change, no API change.
+
+## 3. Out of scope
+
+- A message for a project with no open pull request at all (the pane stays
+  empty, as today).
+- Hiding the orphaned issues section under filters.
+- A count of the hidden repositories or pull requests.
+
+## 4. Behaviour
+
+- `filterBranches` (app-filter.js): after summing the root branches of a
+  repository, `setDisplay(repository, repositoryVisible > 0 ? '' : 'none')`;
+  the pass counts the repositories left shown and, when the `.tree-no-match`
+  element is present, shows it exactly when none is.
+- `renderRepositories` (app.js): appends the message element, hidden, after
+  the repositories when there is at least one; the filter pass that follows
+  every render decides its visibility. The element uses the `hidden`
+  attribute, which the stylesheet honours with `!important`.
+- No change to `applyFilters`, to the filter index, to the URL or to the
+  evaluation of a pull request.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `public/app-filter.js` | hide the repository, toggle the message, JSDoc |
+| `public/app.js` | the message element in `renderRepositories` |
+| `README.md`, `CLAUDE.md`, `PRD.md`, `package.json` | feature, filtering architecture, F4.14, version 2.5.0 |
+
+## 6. Verification
+
+`npm test` (the DOM pass has no unit test, as before). In the browser on the
+fixture server: a text filter matching the pull requests of a single
+repository hides the other repositories; clearing it brings them back with
+their counters; a filter that matches nothing shows the message and nothing
+else above the orphaned issues; a repository collapsed before being hidden
+comes back collapsed.
+
+## 7. Delivery
+
+Branch `claude/hide-empty-repositories` from `master`; nothing committed until
+asked.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "version",
-  "version": "2.4.0",
-  "releaseDate": "2026-09-09",
+  "version": "2.5.0",
+  "releaseDate": "2026-09-10",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -271,7 +271,9 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 // ---------------------------------------------------------------- tree pass
 
 /**
- * Applies the filters to the rendered tree and refreshes the counters.
+ * Applies the filters to the rendered tree and refreshes the counters. A root
+ * branch or a repository left without a visible pull request is hidden; while
+ * every repository is hidden, the "nothing matches" message is shown instead.
  * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
  * @returns {number} how many pull requests are left shown and need attention
  */
@@ -289,6 +291,7 @@ export function filterBranches(filters) {
         shownAttention: 0
     };
 
+    let shownRepositories = 0;
     for (const repository of document.querySelectorAll('.repository')) {
         let repositoryTotal = 0;
         let repositoryVisible = 0;
@@ -305,7 +308,16 @@ export function filterBranches(filters) {
         }
         const counter = repository.querySelector('.repo-pr-counter');
         if (counter) updateCounterDisplay(counter, repositoryVisible, repositoryTotal);
+
+        // Hide the repository too when no pull request is left, like its branches
+        setDisplay(repository, repositoryVisible > 0 ? '' : 'none');
+        if (repositoryVisible > 0) shownRepositories++;
     }
+
+    // renderRepositories renders the message hidden; it takes the place of the
+    // tree while every repository is hidden
+    const noMatch = document.querySelector('.tree-no-match');
+    if (noMatch) noMatch.hidden = shownRepositories > 0;
 
     return pass.shownAttention;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -655,6 +655,16 @@ function renderRepositories(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
             </div>
         `;
     }
+
+    // Shown by the filter pass while every repository is hidden
+    if (Object.keys(pullRequestsByRepo).length > 0) {
+        html += `
+            <div class="state-message tree-no-match" hidden>
+                <i class="fas fa-filter"></i>
+                <span>No pull request matches the filters</span>
+            </div>
+        `;
+    }
     return html;
 }
 


### PR DESCRIPTION
## Summary
- The filter pass now hides a repository block when the filters leave it without any visible pull request, as it already did for root branches. The `n/total` counter keeps being refreshed while the block is hidden, and the collapsed state is left untouched.
- While every repository is hidden, a "No pull request matches the filters" message takes the place of the tree, in the style of the loading and error messages. The orphaned issues section stays listed below it.
- Version 2.5.0. Spec and plan in `docs/superpowers`.

## Test plan
- `npm test`: 49 tests pass (the tree pass is DOM code and has no unit test, as before).
- Fixture server (`PORT=3101 node index.mjs --fixtures`), SECOLLAB: a text filter matching one repository hides the other two (counters `0/100`, `0/2` kept up to date); clearing the box brings them back; `zzzz` shows the message above the orphaned issues; a repository collapsed before being hidden comes back collapsed; "Collapse all" / "Expand all" keep working on hidden repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcMUwKXicKzfDozyREWQdD
