### PR TITLE
feat: Back and Forward re-apply the filters and the project from the URL (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.4.0** (as of 2026-09-09)
+Current version: **2.5.0** (as of 2026-09-10)
 
 ## Technology Stack
 
@@ -130,7 +130,7 @@ pr-tree/
 **public/app-filter.js**
 - `buildFilterIndex(apiResult)` (pure): one entry per pull request with its linked issues, the `searchText` the text filter searches (title, source branch, issue keys, lower-cased) and the sets of assignees, reviewers, sprint ids and fix version ids the filters compare against, and the epic keys (`epics`) and story keys (`stories`); it also returns `index.epics` and `index.stories`, the epics and stories to list in the filters; built once per data load by `initializeFilter()`, which returns it
 - `evaluatePullRequest(entry, filters, rendered)` (pure): visibility and attention of one pull request
-- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, returns the attention count
+- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, hides the root branches and repositories left without a visible pull request, shows the `.tree-no-match` message while every repository is hidden, returns the attention count
 - `issueLevel`, `epicOf`, `storyOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
 
@@ -313,7 +313,7 @@ Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranc
 Single pass in app-filter.js:
 1. `initializeFilter(apiResult)` builds the index once per data load (Maps and Sets, no array search later)
 2. `filterBranches()` collects the SYNC badges once, then walks repositories → root branches → direct child pull requests → their `.children` container, recursively; every pull request is visited exactly once
-3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible
+3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible; a root branch or a repository with no visible pull request is hidden, and the `.tree-no-match` message rendered by `renderRepositories` is shown while every repository is hidden
 4. Counters (repository, root branch, child counters shown) are summed on the way back up and written through `updateCounterDisplay`; DOM writes only happen when the value changes
 
 Never re-select descendants (`querySelectorAll('.pull-request')`) inside the recursion: the previous implementation did, and a pull request at depth *d* was visited 2^d times (16 million visits per filter change on SECOLLAB).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ pr-tree/
     ├── styles.css         # Application styles (colour tokens, light and dark themes)
     ├── app.js             # Data loading, rendering, filter state
     ├── app-filter.js      # Filter index, pure evaluation, single-pass tree filtering and counters
+    ├── app-url.js         # The filters as URL parameters, pure (filtersFromUrl, urlWithFilters)
     ├── app-shell.js       # Banner, sidebar, theme, keyboard shortcuts, help modal, tab title
     ├── tree-toggle.js     # Collapse/expand helpers and toggle-state capture/restore
     ├── multi-select.js    # Multi-select dropdown component
@@ -124,7 +125,10 @@ pr-tree/
 - Periodic refresh logic (2-minute intervals, tab visibility detection)
 - Loading state management
 - Event handlers for user interactions
-- `populateIssueFilter(elementId, issues, selectedKeys)`: fills an issue multi-select (epics and stories) from the index and returns the selection restricted to the offered keys
+- `populateIssueFilter(elementId, issues)`: fills an issue multi-select (epics and stories) from the index; the selection is restored from the URL afterwards like every other filter
+- `restoreFiltersFromUrl({ preferTypedText })`: the only path from the URL to the state and the controls (each multi-select keeps the values its options offer, SYNC follows the URL only while its statuses are loaded); run after every render once every option list is populated, and on Back/Forward with `preferTypedText: false` so the URL wins over a focused search box
+- `selectProject(projectName, { fromUrl, preferTypedText })`: project switch; from the dropdown the filters are reset and the URL pushed once, from the URL (page load, Back/Forward) the URL is left alone and the render restores its filters; after the render the URL is replaced with the validated filters; a late response for a project no longer selected is dropped
+- `handlePopState()`: Back/Forward; switches the project through `selectProject(name, { fromUrl: true, preferTypedText: false })` or restores and applies the filters of the URL
 - `updateReadyCheckboxes()`: the two ready checkboxes are disabled and unchecked while their multi-select is empty; both checked keeps pull requests needing either attention
 
 **public/app-filter.js**
@@ -133,6 +137,10 @@ pr-tree/
 - `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, hides the root branches and repositories left without a visible pull request, shows the `.tree-no-match` message while every repository is hidden, returns the attention count
 - `issueLevel`, `epicOf`, `storyOf` (pure): the only code that interprets `issuetype` and `parent` (epic > standard issue > sub-task); a sub-task reaches its epic through its parent story, which the server fetches with its own `parent`
 - `parseTextQuery`, `matchesText`, `issueOptions`, `computeAttention`, `countActiveFilters` (pure)
+
+**public/app-url.js**
+- `filtersFromUrl(search)` (pure): the filters a query string describes, in the shape of `currentFilters()`; `ready`, the former name, is read as `readyReviewer`
+- `urlWithFilters(url, { project, filters })` (pure): a copy of the URL with the project and the active filters only; parameters that are not filters are kept
 
 **public/counter-utils.js**
 - `updateCounterDisplay(element, visible, total)`: the `n/total` text and tooltip of a counter; the counts come from the filter pass
@@ -307,6 +315,8 @@ State is synchronized with URL query parameters for deep linking:
 ```
 (`ready`, the former name of `readyReviewer`, is still read from old links but never written.)
 
+The page follows the URL on Back and Forward: `handlePopState()` restores the filters (`restoreFiltersFromUrl`) and applies them, or switches the project when the `project` parameter changed; nothing in that path writes the URL. Each user action is one history entry: a filter change pushes, typing replaces, a manual project switch pushes once, and a page load or a switch from the URL replaces the URL after the render (the address bar catches up with the validated filters).
+
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
 
 ### Filtering Architecture
@@ -431,7 +441,7 @@ try {
 1. **Backend**: Modify `/api/pull-requests/:project` to include new data
 2. **Frontend HTML**: Add filter UI element in index.html
 3. **Frontend State**: Add state variable in app.js
-4. **URL Sync**: Update `updateUrlWithFilters()` and `restoreFiltersFromUrl()`
+4. **URL Sync**: Update `filtersFromUrl()` and `urlWithFilters()` in app-url.js (with a unit test) and `restoreFiltersFromUrl()` in app.js
 5. **Filter Logic**: Add the precomputed set to `buildFilterIndex()` and the match to `evaluatePullRequest()` in app-filter.js, with a unit test
 6. **Event Handler**: Wire up filter change event
 
@@ -483,17 +493,17 @@ Three streams available:
 1. **Module type mismatch**: Backend uses ES modules (.mjs), config uses CommonJS (module.exports)
 2. **Cache staleness**: Remember that data can be up to 2 minutes old
 3. **API rate limits**: Bitbucket can return HTTP 429 if too many requests
-4. **Filter restoration**: the SYNC filter is NOT restored from the URL (its statuses are loaded on demand); every other filter is, including the two ready checkboxes
+4. **Filter restoration**: on a page load the SYNC filter is NOT restored from the URL (its statuses are loaded on demand) while every other filter is, including the two ready checkboxes; on Back/Forward SYNC follows the URL while its statuses are loaded
 5. **Regex patterns**: Must match exact Jira issue key format in PR titles
 6. **Colours**: never hard-code a colour in styles.css; add a token to both the `:root` and `:root[data-theme="dark"]` blocks
 7. **Ready for reviewer / assignee**: computed by `computeAttention()` from the data, never from rendered styles; `evaluatePullRequest` takes `readyReviewer` and `readyAssignee`
 8. **Deep stacks**: SECOLLAB has a 24-deep stack of pull requests; anything recursive over the tree must visit each pull request once (see Filtering Architecture)
 9. **`pullRequestsByDestination` is keyed by branch name across repositories**: two repositories sharing a branch name (e.g. `master`) share the entry; known limitation, not handled
-10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes
+10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes; `restoreFiltersFromUrl` keeps the content of a focused search box on a re-render (the URL holds the trimmed query) but takes the URL on Back/Forward
 11. **Jira hierarchy**: only `issueLevel`/`epicOf`/`storyOf` in app-filter.js read `issuetype` and `parent`; parent-only issues (fetched as parents) have no status
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`, `filtersFromUrl`, `urlWithFilters`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,7 +315,7 @@ State is synchronized with URL query parameters for deep linking:
 ```
 (`ready`, the former name of `readyReviewer`, is still read from old links but never written.)
 
-The page follows the URL on Back and Forward: `handlePopState()` restores the filters (`restoreFiltersFromUrl`) and applies them, or switches the project when the `project` parameter changed; nothing in that path writes the URL. Each user action is one history entry: a filter change pushes, typing replaces, a manual project switch pushes once, and a page load or a switch from the URL replaces the URL after the render (the address bar catches up with the validated filters).
+The page follows the URL on Back and Forward: `handlePopState()` restores the filters (`restoreFiltersFromUrl`) and applies them, or switches the project when the `project` parameter changed; nothing in that path pushes a history entry. Each user action is one history entry: a filter change pushes, typing replaces, a manual project switch pushes once, and a page load or a switch from the URL replaces the URL after the render (the address bar catches up with the validated filters).
 
 Every filter pass goes through `applyFilters()` in app.js: it calls `filterBranches(filters)` (app-filter.js), then updates the active-filter badge and the tab title. `renderEverything(apiResult)` receives the data from its caller and applies the filters once every filter control has been populated and restored from the URL. `handleFilterChange()` reads the controls (`readFilterControls()`), applies and pushes the URL; the search box goes through `handleTextFilterInput()`, which replaces the URL instead of pushing it.
 

--- a/PRD.md
+++ b/PRD.md
@@ -183,6 +183,7 @@ The application integrates with a Jira workflow where:
 - F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
 - F4.13: Filter by "ready for assignee" status: In Progress pull requests with a linked issue assigned to a selected assignee; with both ready filters checked, pull requests needing either attention are kept
 - F4.14: Hide the repositories and branches left without a matching pull request; show a message when no pull request matches
+- F4.15: Back and Forward restore the filters and the project the URL describes; one history entry per user action
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)

--- a/PRD.md
+++ b/PRD.md
@@ -182,6 +182,7 @@ The application integrates with a Jira workflow where:
 - F4.11: Filter by epic (the epic above the linked issues, through the parent story for sub-tasks)
 - F4.12: Filter by story (the linked issue, or the parent of a linked sub-task)
 - F4.13: Filter by "ready for assignee" status: In Progress pull requests with a linked issue assigned to a selected assignee; with both ready filters checked, pull requests needing either attention are kept
+- F4.14: Hide the repositories and branches left without a matching pull request; show a message when no pull request matches
 
 **Acceptance Criteria:**
 - Each filter shows "Show all" option plus all available values (or checkbox for boolean filters)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
     * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer, ready for assignee, ready for reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
     * Enables direct linking to specific filtered views
+    * Back and Forward put the filters, and the project, back as the URL describes
 * Displays Ahead (green) and Behind (red) commit counts
 * Smart reload: Automatically updates the page when new data is available without full page refresh
     * Repaint is only done if there are changes in the data returned by the server
@@ -86,6 +87,8 @@
 * Version 2.5.0
     * Repositories left without a matching pull request are hidden by the filters, like their branches already were
     * When nothing matches, a "No pull request matches the filters" message replaces the tree; the orphaned issues stay listed
+    * Back and Forward re-apply the filters and switch the project as the URL describes (#32); a project switch is one history entry and a page load adds none
+    * SYNC follows the URL through Back and Forward while its statuses are loaded
 * Version 2.4.0
     * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
         * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
     * Filters pull requests based on the fixVersion field of associated Jira issues
     * Dynamically populates with all available fixVersions from the project's Jira issues
 * Allows simultaneous filtering by both assignee and reviewer
+* Hides the repositories and branches left without a matching pull request; when nothing matches, a message replaces the tree
 * Maintains filter selections in URL
     * All filter selections (project, text, sprint, fixVersion, epic, story, assignee, reviewer, ready for assignee, ready for reviewer) are saved in the URL
     * Filters are automatically restored when sharing or reloading the page
@@ -82,6 +83,9 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.5.0
+    * Repositories left without a matching pull request are hidden by the filters, like their branches already were
+    * When nothing matches, a "No pull request matches the filters" message replaces the tree; the orphaned issues stay listed
 * Version 2.4.0
     * Text filter at the top of the sidebar: matches the pull-request title, the source branch name and the linked issue keys, every word typed must match
         * `/` focuses it, Escape clears it, restored from the URL (`q`), the URL is replaced while typing so the history stays clean

--- a/docs/superpowers/plans/2026-09-10-back-forward-filters.md
+++ b/docs/superpowers/plans/2026-09-10-back-forward-filters.md
@@ -1,0 +1,575 @@
+# Back and Forward Re-apply the Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Back and Forward put the filters, and the project, back as the URL describes (issue #32), with one history entry per user action.
+
+**Architecture:** The mapping between the filters and the URL parameters moves to a pure module, `public/app-url.js` (`filtersFromUrl`, `urlWithFilters`), unit-tested. In `public/app.js`, `restoreFiltersFromUrl()` becomes the only path from the URL to the state and the controls (all six multi-selects, SYNC, ready checkboxes, search box), run after every render once every option list is populated and on Back/Forward; the populate functions only populate. `selectProject(name, { fromUrl })` replaces `handleProjectChange`: from the dropdown it resets the filters and pushes one entry, from the URL (page load, Back/Forward) it leaves the URL alone; after the render the URL is replaced with the validated filters. A `popstate` listener switches the project or restores and applies the filters, and never writes the URL.
+
+**Tech Stack:** Vanilla ES modules, `node:test`. No server change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-back-forward-filters-design.md` (issue #32)
+
+**Branch:** `claude/back-forward-filters`, created from `claude/hide-empty-repositories` (already checked out, spec and plan committed). One pull request stacked on the hide-empty-repositories one. Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01TcMUwKXicKzfDozyREWQdD
+```
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (49 tests before this plan; 57 after Task 1).
+
+**Running the app for manual checks:** `PORT=3101 node index.mjs --fixtures` (port 3000 runs another instance, port 3100 an unrelated application), http://localhost:3101/?project=SECOLLAB.
+
+---
+
+### Task 1: The filters as URL parameters (pure module)
+
+**Files:**
+- Create: `public/app-url.js`
+- Create: `test/app-url.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/app-url.test.mjs`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { filterUrlParams, filtersFromUrl, urlWithFilters } from '../public/app-url.js';
+
+const noFilters = { text: '', assignees: [], reviewers: [], sprints: [], fixVersions: [], epics: [], stories: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };
+
+test('filtersFromUrl reads every filter, repeated parameters included', () => {
+    const filters = filtersFromUrl('?project=PROJ&q=banner&assignee=John&assignee=Jane&reviewer=Bob&sprint=1&sprint=2&fixVersion=10&epic=PROJ-1&story=PROJ-2&sync=requested&readyReviewer=true&readyAssignee=true');
+    assert.deepEqual(filters, {
+        text: 'banner',
+        assignees: ['John', 'Jane'],
+        reviewers: ['Bob'],
+        sprints: ['1', '2'],
+        fixVersions: ['10'],
+        epics: ['PROJ-1'],
+        stories: ['PROJ-2'],
+        sync: 'requested',
+        readyReviewer: true,
+        readyAssignee: true
+    });
+});
+
+test('filtersFromUrl defaults every filter without parameters', () => {
+    assert.deepEqual(filtersFromUrl(''), noFilters);
+    assert.deepEqual(filtersFromUrl('?project=PROJ&foo=1'), noFilters);
+});
+
+test('filtersFromUrl reads the former ready parameter as readyReviewer', () => {
+    assert.equal(filtersFromUrl('?ready=true').readyReviewer, true);
+    assert.equal(filtersFromUrl('?ready=true').readyAssignee, false);
+    assert.equal(filtersFromUrl('?readyReviewer=false').readyReviewer, false);
+});
+
+test('urlWithFilters writes the project and the active filters only, and keeps the other parameters', () => {
+    const url = urlWithFilters(new URL('http://localhost:3000/?foo=1&assignee=Old&ready=true&sync=OK'), {
+        project: 'PROJ',
+        filters: { ...noFilters, text: '  banner ', assignees: ['John'], readyReviewer: true }
+    });
+    assert.equal(url.search, '?foo=1&project=PROJ&q=banner&assignee=John&readyReviewer=true');
+});
+
+test('urlWithFilters without a project drops the project parameter', () => {
+    const url = urlWithFilters(new URL('http://localhost:3000/?project=PROJ&q=x'), { project: null, filters: noFilters });
+    assert.equal(url.search, '');
+});
+
+test('urlWithFilters leaves the URL it is given untouched', () => {
+    const original = new URL('http://localhost:3000/?project=PROJ');
+    urlWithFilters(original, { project: 'OTHER', filters: noFilters });
+    assert.equal(original.search, '?project=PROJ');
+});
+
+test('the filters survive a round trip through the URL', () => {
+    const filters = { text: 'a b', assignees: ['J'], reviewers: ['B', 'C'], sprints: ['1'], fixVersions: ['2'], epics: ['P-1'], stories: ['P-2'], sync: 'requested', readyReviewer: true, readyAssignee: true };
+    const url = urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters });
+    assert.deepEqual(filtersFromUrl(url.search), filters);
+});
+
+test('filterUrlParams covers every parameter urlWithFilters writes, plus the former ready', () => {
+    const filters = { text: 't', assignees: ['a'], reviewers: ['r'], sprints: ['1'], fixVersions: ['2'], epics: ['e'], stories: ['s'], sync: 'OK', readyReviewer: true, readyAssignee: true };
+    const written = [...urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters }).searchParams.keys()].filter(key => key !== 'project');
+    assert.deepEqual(new Set([...written, 'ready']), new Set(filterUrlParams));
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: the new file fails to load (`Cannot find module '.../public/app-url.js'`), `ℹ fail` greater than 0.
+
+- [ ] **Step 3: Write the module**
+
+Create `public/app-url.js`:
+
+```js
+/**
+ * The filters as URL parameters: what the address bar shows, what a shared
+ * link carries and what Back and Forward put back. Pure: nothing here reads
+ * the page. Multi-selects use repeated parameters (?assignee=A&assignee=B).
+ */
+
+// Parameters written by the filters. 'ready' is the former name of
+// readyReviewer: still read from old links, only ever removed when writing.
+export const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
+
+/**
+ * The filters a query string describes, in the shape of currentFilters().
+ * @param {string} search - window.location.search, with or without the leading "?"
+ */
+export function filtersFromUrl(search) {
+    const params = new URLSearchParams(search);
+    return {
+        text: params.get('q') || '',
+        assignees: params.getAll('assignee'),
+        reviewers: params.getAll('reviewer'),
+        sprints: params.getAll('sprint'),
+        fixVersions: params.getAll('fixVersion'),
+        epics: params.getAll('epic'),
+        stories: params.getAll('story'),
+        sync: params.get('sync') || 'Show all',
+        readyReviewer: params.get('readyReviewer') === 'true' || params.get('ready') === 'true',
+        readyAssignee: params.get('readyAssignee') === 'true'
+    };
+}
+
+/**
+ * A copy of a URL carrying the project and the active filters, and none of
+ * the previous ones; parameters that are not filters are kept.
+ * @param {URL} url - left untouched
+ * @param {{ project: string | null, filters: object }} state - filters in the shape of currentFilters()
+ * @returns {URL}
+ */
+export function urlWithFilters(url, { project, filters }) {
+    const result = new URL(url);
+    const params = result.searchParams;
+    filterUrlParams.forEach(param => params.delete(param));
+    if (project) {
+        params.set('project', project);
+    } else {
+        params.delete('project');
+    }
+    const text = filters.text.trim();
+    if (text !== '') params.set('q', text);
+    filters.assignees.forEach(value => params.append('assignee', value));
+    filters.reviewers.forEach(value => params.append('reviewer', value));
+    filters.sprints.forEach(value => params.append('sprint', value));
+    filters.fixVersions.forEach(value => params.append('fixVersion', value));
+    filters.epics.forEach(value => params.append('epic', value));
+    filters.stories.forEach(value => params.append('story', value));
+    if (filters.sync !== 'Show all') params.set('sync', filters.sync);
+    if (filters.readyReviewer) params.set('readyReviewer', 'true');
+    if (filters.readyAssignee) params.set('readyAssignee', 'true');
+    return result;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: `ℹ fail 0`, 57 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/app-url.js test/app-url.test.mjs
+git commit -m "feat: the filters as URL parameters in a pure module, app-url.js"
+```
+
+---
+
+### Task 2: The page follows the URL
+
+**Files:**
+- Modify: `public/app.js`
+
+Every edit below names the exact current text; each snippet occurs once in the file.
+
+- [ ] **Step 1: Import the module and drop the moved constant**
+
+After the line
+
+```js
+import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
+```
+
+add:
+
+```js
+import { filtersFromUrl, urlWithFilters } from './app-url.js';
+```
+
+Delete these two lines (the constant now lives in app-url.js and app.js no longer needs it):
+
+```js
+// URL parameters written by the filters ('ready', the former name of readyReviewer, is only ever removed)
+const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
+```
+
+- [ ] **Step 2: Write the URL through the module**
+
+Replace the whole `updateUrlWithFilters` function, from its leading comment `// Writes the filters to the URL. \`replace\` swaps the current history entry` down to its closing `}`, with:
+
+```js
+// Writes the project and the filters to the URL. `replace` swaps the current
+// history entry instead of pushing one: while typing in the search box, and
+// when the address bar catches up after a load.
+function updateUrlWithFilters({ replace = false } = {}) {
+    const url = urlWithFilters(new URL(window.location), { project: currentProject, filters: currentFilters() });
+
+    // Update URL without reloading the page. Safari throws past 100 updates
+    // per 30 seconds: the URL then catches up on the next change
+    try {
+        if (replace) {
+            window.history.replaceState({}, '', url);
+        } else {
+            window.history.pushState({}, '', url);
+        }
+    } catch (error) {
+        // The filters are already applied; only the address bar lags
+    }
+}
+```
+
+- [ ] **Step 3: One path from the URL to the state and the controls**
+
+Replace the whole `restoreFiltersFromUrl` function, from its leading comment `// Update filter restoration from URL` down to its closing `}` (the one after `updateTextFilterClearButton();`), with:
+
+```js
+// Copies the filters the URL describes into the state and the controls. Runs
+// after every render, once every option list is populated, and on Back and
+// Forward. Each multi-select keeps only the values its options offer, so a
+// stale name in a shared link or an ended sprint is dropped (and cannot leave
+// a ready checkbox enabled over an empty selection). SYNC follows the URL only
+// while its statuses are loaded: they are fetched on demand, so a reload starts
+// at "Show all". The URL holds the trimmed query: while the user is typing the
+// box keeps its own content (a re-render must not eat a trailing space); on
+// Back and Forward (`preferTypedText: false`) the URL wins.
+function restoreFiltersFromUrl({ preferTypedText = true } = {}) {
+    const filters = filtersFromUrl(window.location.search);
+
+    const restoreMultiSelect = (id, values) => {
+        const multiSelect = getMultiSelect(id);
+        if (!multiSelect) return values;
+        multiSelect.setSelectedValues(values);
+        return multiSelect.getSelectedValues();
+    };
+    currentSprints = restoreMultiSelect('sprintSelect', filters.sprints);
+    currentFixVersions = restoreMultiSelect('fixVersionSelect', filters.fixVersions);
+    currentEpics = restoreMultiSelect('epicSelect', filters.epics);
+    currentStories = restoreMultiSelect('storySelect', filters.stories);
+    currentAssignees = restoreMultiSelect('assigneeSelect', filters.assignees);
+    currentReviewers = restoreMultiSelect('reviewerSelect', filters.reviewers);
+
+    const syncSelect = document.getElementById('syncSelect');
+    const syncOffered = syncSelect && Array.from(syncSelect.options).some(option => option.value === filters.sync);
+    currentSync = (currentSyncStatuses && syncOffered) ? filters.sync : 'Show all';
+    if (syncSelect) syncSelect.value = currentSync;
+
+    currentReadyForReviewer = filters.readyReviewer;
+    currentReadyForAssignee = filters.readyAssignee;
+    updateReadyCheckboxes();
+
+    currentText = filters.text;
+    const textFilter = document.getElementById('textFilter');
+    if (textFilter && preferTypedText && document.activeElement === textFilter) {
+        currentText = textFilter.value;
+    } else if (textFilter) {
+        textFilter.value = currentText;
+    }
+    updateTextFilterClearButton();
+}
+```
+
+- [ ] **Step 4: Open the project the URL names**
+
+In `loadProjects`, replace
+
+```js
+        projectSelect.addEventListener('change', handleProjectChange);
+
+        // Check for project query parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        const projectParam = urlParams.get('project');
+        if (projectParam) {
+            const projectOption = projectSelect.querySelector(`option[value="${projectParam}"]`);
+            if (projectOption) {
+                projectSelect.value = projectParam;
+                // Pass true to indicate this is initial page load, not a manual switch
+                await handleProjectChange({ target: { value: projectParam } }, true);
+            }
+        }
+```
+
+with:
+
+```js
+        projectSelect.addEventListener('change', event => selectProject(event.target.value));
+
+        // Open the project the URL names, with the filters it carries
+        const projectName = projectFromUrl();
+        if (projectName) {
+            projectSelect.value = projectName;
+            await selectProject(projectName, { fromUrl: true });
+        }
+```
+
+- [ ] **Step 5: `selectProject`, `projectFromUrl` and `handlePopState`**
+
+Replace the whole `handleProjectChange` function, from `async function handleProjectChange(event, isInitialLoad = false) {` down to its closing `}` (the line after `stopPeriodicChecking();` and `    }`), with:
+
+```js
+// The project the URL names, when the dropdown offers it; '' otherwise
+function projectFromUrl() {
+    const projectName = new URLSearchParams(window.location.search).get('project') || '';
+    const options = Array.from(document.getElementById('projectSelect').options);
+    return options.some(option => option.value === projectName) ? projectName : '';
+}
+
+// Switches to a project, or to none with an empty name. From the dropdown the
+// filters start empty and the switch gets one history entry. From the URL
+// (page load, Back and Forward) the URL already describes the state to reach
+// and is left alone: the render restores the filters it carries.
+async function selectProject(projectName, { fromUrl = false } = {}) {
+    // The SYNC statuses belong to the project being left
+    currentSyncStatuses = null;
+    syncLoadFailed = false;
+    currentProject = projectName || null;
+    updateSyncControls();
+    updateDocumentTitle({ project: currentProject, attentionCount: 0 });
+    closeSidebarDrawer();
+
+    if (!currentProject) {
+        if (!fromUrl) updateUrlWithFilters();
+        setToolbarVisible(false);
+        applyFilters(); // no tree to filter: refreshes the badge and the tab title
+        showEmptyState();
+        stopPeriodicChecking();
+        return;
+    }
+
+    if (!fromUrl) {
+        resetFilterControls();
+        readFilterControls();
+        updateUrlWithFilters();
+    }
+    showLoadingState();
+    const apiResult = await fetchData();
+    // Back and Forward make quick switches easy: a late response for a project no longer selected is dropped
+    if (currentProject !== projectName) return;
+    renderEverything(apiResult);
+    // The address bar catches up with the filters the render validated, without a new entry
+    if (apiResult) updateUrlWithFilters({ replace: true });
+    startPeriodicChecking();
+}
+
+// Back and Forward: the page follows the URL, never the other way round.
+// Another project: switch to it, the render restores the filters of that URL.
+// Same project: the filters are restored from the URL and applied. Nothing
+// here writes the URL. Browsers no longer fire popstate on page load.
+function handlePopState() {
+    const projectName = projectFromUrl();
+    if (projectName !== (currentProject || '')) {
+        document.getElementById('projectSelect').value = projectName;
+        selectProject(projectName, { fromUrl: true });
+        return;
+    }
+    // Nothing rendered (loading, or the last load failed): the next render restores from the URL
+    if (!currentApiResult) return;
+    restoreFiltersFromUrl({ preferTypedText: false });
+    applyFilters();
+}
+```
+
+- [ ] **Step 6: The populate functions only populate**
+
+a. In `populateFilters`, delete the two last lines of the body:
+
+```js
+
+    // Restore filter values; renderEverything applies them once every filter is populated
+    restoreFiltersFromUrl();
+```
+
+b. In `populateSprintFilter`, delete from the blank line before `// Restore sprint values from URL after populating options` down to the closing `}` of that `if (currentSprints.length > 0) {` block (the function then ends right after `sprintMultiSelect.setOptions(sprintOptions);`).
+
+c. In `populateFixVersionFilter`, delete from the blank line before `// Restore fixVersion values from URL after populating options` down to the closing `}` of that `if (currentFixVersions.length > 0) {` block (the function then ends right after `fixVersionMultiSelect.setOptions(fixVersionOptions);`).
+
+d. Replace the whole `populateIssueFilter` function (and the comment lines directly above it, if any) with:
+
+```js
+// Fills an issue multi-select (epics or stories) from the index; the selection
+// is restored from the URL afterwards, like every other filter
+function populateIssueFilter(elementId, issues) {
+    const multiSelect = getMultiSelect(elementId);
+    if (multiSelect) multiSelect.setOptions(issueOptions(issues.values()));
+}
+```
+
+- [ ] **Step 7: Restore once every option list is populated**
+
+In `renderEverything`, replace
+
+```js
+    currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
+    currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);
+
+    // Every filter is populated and restored from the URL: apply them once
+    applyFilters();
+```
+
+with:
+
+```js
+    populateIssueFilter('epicSelect', filterIndex.epics);
+    populateIssueFilter('storySelect', filterIndex.stories);
+
+    // Every option list is populated: restore the filters from the URL and apply them once
+    restoreFiltersFromUrl();
+    applyFilters();
+```
+
+- [ ] **Step 8: Listen to popstate**
+
+In the `DOMContentLoaded` listener, after the line `initializeSyncControls();`, add:
+
+```js
+    window.addEventListener('popstate', handlePopState);
+```
+
+- [ ] **Step 9: Check**
+
+Run: `node --check public/app.js && grep -n "handleProjectChange\|filterUrlParams\|isInitialLoad\|projectParam\|selectedKeys" public/app.js; npm test`
+Expected: no syntax error, the grep prints nothing, `ℹ fail 0`, 57 tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add public/app.js
+git commit -m "feat: Back and Forward re-apply the filters and the project from the URL (#32)"
+```
+
+---
+
+### Task 3: Browser check (controller)
+
+Run: `PORT=3101 node index.mjs --fixtures`, open http://localhost:3101/?project=SECOLLAB.
+
+- Page load adds no history entry: `history.length` does not grow after the render, and the URL stays `?project=SECOLLAB`.
+- Select an assignee, then a sprint: Back restores the assignee alone (control, badge, tree, title), Forward the sprint again.
+- Type in the search box, select a reviewer, Back: the reviewer is dropped, the text kept; Back again: the text is gone (typing replaced the entry).
+- With the focus in the search box, Back: the box takes the URL's text.
+- Switch to OSLC from the dropdown: one entry; Back returns to SECOLLAB with its filters, the dropdown follows; Forward returns to OSLC.
+- Load SYNC (fixture statuses answer instantly), pick "SYNC required", Back: "Show all" again; Forward: "SYNC required" again.
+- Open `?project=SECOLLAB&assignee=Nobody&ready=true`: after the render the URL is `?project=SECOLLAB` and Back leaves the page.
+
+Stop the server (kill the process) when done.
+
+---
+
+### Task 4: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+- Modify: `PRD.md`
+
+- [ ] **Step 1: README**
+
+a. In "Features", after the line `    * Enables direct linking to specific filtered views`, add:
+
+```
+    * Back and Forward put the filters, and the project, back as the URL describes
+```
+
+b. In the changelog, at the end of the `* Version 2.5.0` block (after its last `    * ...` line, before `* Version 2.4.0`), add:
+
+```
+    * Back and Forward re-apply the filters and switch the project as the URL describes (#32); a project switch is one history entry and a page load adds none
+    * SYNC follows the URL through Back and Forward while its statuses are loaded
+```
+
+- [ ] **Step 2: CLAUDE.md**
+
+a. In the project structure tree, after the line `    ├── app-filter.js      # Filter index, pure evaluation, single-pass tree filtering and counters`, add:
+
+```
+    ├── app-url.js         # The filters as URL parameters, pure (filtersFromUrl, urlWithFilters)
+```
+
+b. After the `**public/app-filter.js**` block (its last bullet starts with `- \`parseTextQuery\`, \`matchesText\``), add:
+
+```
+**public/app-url.js**
+- `filtersFromUrl(search)` (pure): the filters a query string describes, in the shape of `currentFilters()`; `ready`, the former name, is read as `readyReviewer`
+- `urlWithFilters(url, { project, filters })` (pure): a copy of the URL with the project and the active filters only; parameters that are not filters are kept
+```
+
+c. In the `**public/app.js**` block, replace the bullet starting with `- \`populateIssueFilter(elementId, issues, selectedKeys)\`` with:
+
+```
+- `populateIssueFilter(elementId, issues)`: fills an issue multi-select (epics and stories) from the index; the selection is restored from the URL afterwards like every other filter
+- `restoreFiltersFromUrl({ preferTypedText })`: the only path from the URL to the state and the controls (each multi-select keeps the values its options offer, SYNC follows the URL only while its statuses are loaded); run after every render once every option list is populated, and on Back/Forward with `preferTypedText: false` so the URL wins over the search box
+- `selectProject(projectName, { fromUrl })`: project switch; from the dropdown the filters are reset and the URL pushed once, from the URL (page load, Back/Forward) the URL is left alone and the render restores its filters; after the render the URL is replaced with the validated filters; a late response for a project no longer selected is dropped
+- `handlePopState()`: Back/Forward; switches the project through `selectProject(name, { fromUrl: true })` or restores and applies the filters of the URL
+```
+
+d. In "Frontend State Management", after the line `(\`ready\`, the former name of \`readyReviewer\`, is still read from old links but never written.)`, add a paragraph:
+
+```
+
+The page follows the URL on Back and Forward: `handlePopState()` restores the filters (`restoreFiltersFromUrl`) and applies them, or switches the project when the `project` parameter changed; nothing in that path writes the URL. Each user action is one history entry: a filter change pushes, typing replaces, a manual project switch pushes once, and a page load or a switch from the URL replaces the URL after the render (the address bar catches up with the validated filters).
+```
+
+e. In "Common Pitfalls", replace item 4 with:
+
+```
+4. **Filter restoration**: on a page load the SYNC filter is NOT restored from the URL (its statuses are loaded on demand) while every other filter is, including the two ready checkboxes; on Back/Forward SYNC follows the URL while its statuses are loaded
+```
+
+and item 10 with:
+
+```
+10. **Search box and history**: the text filter writes the URL with `replaceState` (one history entry for a whole typing session); every other filter pushes; `restoreFiltersFromUrl` keeps the content of a focused search box on a re-render (the URL holds the trimmed query) but takes the URL on Back/Forward
+```
+
+f. In "Testing Approach", in the "Unit tests" bullet, replace `\`buildDocumentTitle\`)` with `\`buildDocumentTitle\`, \`filtersFromUrl\`, \`urlWithFilters\`)`.
+
+g. In "Common Tasks" > "Add New Filter", replace `4. **URL Sync**: Update \`updateUrlWithFilters()\` and \`restoreFiltersFromUrl()\`` with:
+
+```
+4. **URL Sync**: Update `filtersFromUrl()` and `urlWithFilters()` in app-url.js (with a unit test) and `restoreFiltersFromUrl()` in app.js
+```
+
+- [ ] **Step 3: PRD.md**
+
+After the `- F4.14: ...` line, add:
+
+```
+- F4.15: Back and Forward restore the filters and the project the URL describes; one history entry per user action
+```
+
+- [ ] **Step 4: Check and commit**
+
+Run: `npm test` (expected `ℹ fail 0`).
+
+```bash
+git add README.md CLAUDE.md PRD.md
+git commit -m "docs: Back and Forward follow the URL (#32)"
+```
+
+The controller pushes the branch and opens the pull request (base `claude/hide-empty-repositories`, `Closes #32`).
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** decision 1 (Task 2 steps 5, 8), decision 2 (step 5: push once from the dropdown, replace after the render; no push on load), decision 3 (steps 3, 6, 7), decision 4 (step 3, SYNC from the URL while loaded), decision 5 (step 3, `preferTypedText`; step 5 passes false on popstate), decision 6 (step 5, late response dropped), decision 7 (Task 1), docs (Task 4), verification (Task 3).
+- **Placeholders:** none.
+- **Type consistency:** `filtersFromUrl` returns the shape of `currentFilters()` (text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee) and `urlWithFilters` reads that shape; `selectProject(projectName, { fromUrl })` is called in steps 4, 5; `projectFromUrl()` in steps 4, 5; `restoreFiltersFromUrl({ preferTypedText })` in steps 3, 5, 7; `populateIssueFilter(elementId, issues)` in steps 6d and 7.

--- a/docs/superpowers/plans/2026-09-10-hide-empty-repositories.md
+++ b/docs/superpowers/plans/2026-09-10-hide-empty-repositories.md
@@ -1,0 +1,206 @@
+# Hide Empty Repositories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide a repository block when the filters leave it without any visible pull request, and show a "No pull request matches the filters" message while every repository is hidden.
+
+**Architecture:** The filter pass (`filterBranches` in `public/app-filter.js`) already hides a root branch whose visible count is 0; the repository gets the same treatment one level up, in the same walk. `renderRepositories` (`public/app.js`) appends a hidden message element after the repositories; the pass, which runs after every render and every filter change, shows it exactly when no repository is left visible. Nothing else changes: not the index, not the evaluation, not the URL.
+
+**Tech Stack:** Vanilla ES modules, `node:test`. No server change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md`
+
+**Branch:** `claude/hide-empty-repositories`, created from `master` (already checked out). Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01TcMUwKXicKzfDozyREWQdD
+```
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (49 tests). The tree pass is DOM code and has no unit test (CLAUDE.md, "Testing Approach": UI is checked in the browser); the browser check is Task 2, done by the controller.
+
+**Running the app for manual checks:** `PORT=3101 node index.mjs --fixtures` (port 3000 runs the user's real server, port 3100 an unrelated application), http://localhost:3101/?project=SECOLLAB.
+
+---
+
+### Task 1: Hide the repository and show the message
+
+**Files:**
+- Modify: `public/app-filter.js` (the `filterBranches` function, JSDoc and loop, around lines 273-305)
+- Modify: `public/app.js` (`renderRepositories`, around lines 626-660)
+
+- [ ] **Step 1: Hide the repository in the filter pass**
+
+In `public/app-filter.js`, replace the JSDoc of `filterBranches` and the function body down to the `return` with:
+
+```js
+/**
+ * Applies the filters to the rendered tree and refreshes the counters. A root
+ * branch or a repository left without a visible pull request is hidden; while
+ * every repository is hidden, the "nothing matches" message is shown instead.
+ * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
+ * @returns {number} how many pull requests are left shown and need attention
+ */
+export function filterBranches(filters) {
+    const pass = {
+        filters,
+        index: filterIndex || buildFilterIndex({}),
+        // The SYNC filter relies on the rendered badges: collect them once
+        pullRequestsWithSyncLabel: new Set(
+            Array.from(document.querySelectorAll('.pull-request .conflicts-count'))
+                .map(badge => badge.closest('.pull-request'))
+                .filter(pullRequest => pullRequest)
+                .map(pullRequest => pullRequest.dataset.id)
+        ),
+        shownAttention: 0
+    };
+
+    let shownRepositories = 0;
+    for (const repository of document.querySelectorAll('.repository')) {
+        let repositoryTotal = 0;
+        let repositoryVisible = 0;
+        for (const rootBranch of repository.querySelectorAll('.root-branch')) {
+            const content = rootBranch.querySelector('.root-branch-content');
+            const counts = content ? filterChildren(content, pass) : { total: 0, visible: 0 };
+            repositoryTotal += counts.total;
+            repositoryVisible += counts.visible;
+
+            // Hide branch if no visible pull requests
+            setDisplay(rootBranch, counts.visible > 0 ? '' : 'none');
+            const counter = rootBranch.querySelector('.branch-pr-counter');
+            if (counter) updateCounterDisplay(counter, counts.visible, counts.total);
+        }
+        const counter = repository.querySelector('.repo-pr-counter');
+        if (counter) updateCounterDisplay(counter, repositoryVisible, repositoryTotal);
+
+        // Hide the repository too when no pull request is left, like its branches
+        setDisplay(repository, repositoryVisible > 0 ? '' : 'none');
+        if (repositoryVisible > 0) shownRepositories++;
+    }
+
+    // renderRepositories renders the message hidden; it takes the place of the
+    // tree while every repository is hidden
+    const noMatch = document.querySelector('.tree-no-match');
+    if (noMatch) noMatch.hidden = shownRepositories > 0;
+
+    return pass.shownAttention;
+}
+```
+
+- [ ] **Step 2: Render the message after the repositories**
+
+In `public/app.js`, in `renderRepositories`, replace the final `return html;` (after the `for (const [repoName, repoPullRequests] ...)` loop) with:
+
+```js
+    // Shown by the filter pass while every repository is hidden
+    if (Object.keys(pullRequestsByRepo).length > 0) {
+        html += `
+            <div class="state-message tree-no-match" hidden>
+                <i class="fas fa-filter"></i>
+                <span>No pull request matches the filters</span>
+            </div>
+        `;
+    }
+    return html;
+```
+
+(`hidden` works on a `.state-message`: the stylesheet has `[hidden] { display: none !important; }`.)
+
+- [ ] **Step 3: Check the syntax and run the tests**
+
+Run: `node --check public/app-filter.js && node --check public/app.js && npm test`
+Expected: no syntax error, `ℹ fail 0`, 49 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/app-filter.js public/app.js
+git commit -m "feat: hide the repositories left without a visible pull request, no-match message"
+```
+
+---
+
+### Task 2: Browser check (controller)
+
+Run: `PORT=3101 node index.mjs --fixtures`, open http://localhost:3101/?project=SECOLLAB.
+
+- Type in the search box a word present in the pull requests of one repository only (a repository name works: source branches carry them in the fixtures, otherwise use a pull-request title word): the other repositories disappear, no empty header stays, the remaining repository keeps its `n/total` counter.
+- Clear the search box: every repository is back with the full counter.
+- Type `zzzz`: the tree is replaced by the filter icon and "No pull request matches the filters"; the orphaned issues section, when present, stays below it.
+- Collapse a repository, type a word that hides it, clear the box: it is back and still collapsed.
+- "Collapse all" then a filter that hides everything, "Expand all", clear: the repositories come back expanded.
+
+Stop the server with Ctrl+C (or kill the process).
+
+---
+
+### Task 3: Documentation and version
+
+**Files:**
+- Modify: `README.md` (Features list around line 42, changelog at line 85)
+- Modify: `CLAUDE.md` (version line, `filterBranches` bullet, Filtering Architecture step 3)
+- Modify: `PRD.md` (F4.14 after the F4.13 line, around line 184)
+- Modify: `package.json` (`version`, `releaseDate`)
+
+- [ ] **Step 1: README**
+
+a. In "Features", insert after the line `* Allows simultaneous filtering by both assignee and reviewer`:
+
+```
+* Hides the repositories and branches left without a matching pull request; when nothing matches, a message replaces the tree
+```
+
+b. Insert before the line `* Version 2.4.0` of the changelog:
+
+```
+* Version 2.5.0
+    * Repositories left without a matching pull request are hidden by the filters, like their branches already were
+    * When nothing matches, a "No pull request matches the filters" message replaces the tree; the orphaned issues stay listed
+```
+
+- [ ] **Step 2: CLAUDE.md**
+
+a. Replace `Current version: **2.4.0** (as of 2026-09-09)` with `Current version: **2.5.0** (as of 2026-09-10)`.
+
+b. In the `**public/app-filter.js**` block, replace the `filterBranches(filters)` bullet with:
+
+```
+- `filterBranches(filters)`: one walk of the rendered tree, direct children only, each pull request visited once; hides, highlights, sums the counters of repositories, root branches and child counters on the way back up, hides the root branches and repositories left without a visible pull request, shows the `.tree-no-match` message while every repository is hidden, returns the attention count
+```
+
+c. In "Filtering Architecture", replace step 3 `3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible` with:
+
+```
+3. Children are evaluated first; a filtered-out parent stays displayed while a descendant is visible; a root branch or a repository with no visible pull request is hidden, and the `.tree-no-match` message rendered by `renderRepositories` is shown while every repository is hidden
+```
+
+- [ ] **Step 3: PRD.md**
+
+Insert after the `- F4.13: ...` line:
+
+```
+- F4.14: Hide the repositories and branches left without a matching pull request; show a message when no pull request matches
+```
+
+- [ ] **Step 4: package.json**
+
+Replace `"version": "2.4.0",` with `"version": "2.5.0",` and `"releaseDate": "2026-09-09",` with `"releaseDate": "2026-09-10",`.
+
+- [ ] **Step 5: Check and commit**
+
+Run: `npm test` (expected `ℹ fail 0`) and `curl -s localhost:3101/api/version` if the fixture server is still running (expected `"version":"2.5.0"` after a restart).
+
+```bash
+git add README.md CLAUDE.md PRD.md package.json
+git commit -m "docs: version 2.5.0, repositories hidden when filtered empty"
+```
+
+The controller pushes the branch and opens the pull request (base `master`).
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** rule and counter refresh (Task 1 step 1), message rendered hidden and toggled by the pass (Task 1 steps 1-2), collapsed state untouched (nothing touches the `collapsed` class; checked in Task 2), version 2.5.0 (Task 3 step 4), docs (Task 3), verification (Task 2).
+- **Placeholders:** none.
+- **Type consistency:** the message element is `.tree-no-match` in `renderRepositories`, in `filterBranches` and in the docs; `shownRepositories` is local to `filterBranches`.

--- a/docs/superpowers/specs/2026-09-10-back-forward-filters-design.md
+++ b/docs/superpowers/specs/2026-09-10-back-forward-filters-design.md
@@ -1,0 +1,119 @@
+# Back and Forward re-apply the filters
+
+**Date:** 2026-09-10
+**Target version:** 2.5.0 (with the hidden empty repositories)
+**Issue:** #32
+**Status:** Decided in an autonomous session, without a review round; section 2 lists what to revisit
+
+## 1. Goal
+
+Every filter change writes the URL (`pushState`, or `replaceState` while
+typing), but nothing listens to `popstate`: Back and Forward change the
+address bar and leave the tree, the controls and the project as they were.
+After this change the page follows the URL: Back and Forward put the filters,
+and the project, back as the URL describes, and each user action costs exactly
+one history entry.
+
+## 2. Decisions
+
+1. **The page follows the URL.** A `popstate` listener reads the URL. Same
+   project: the filters are copied from the URL into the state and the
+   controls, then applied. Other project (or none): the dropdown is set and the
+   project is switched and loaded as on a page load; the render restores the
+   filters the URL carries. Nothing in that path writes the URL: the browser
+   already did.
+2. **One entry per action.** A manual project switch pushes one entry (today
+   two: one with the filters cleared, one with the new project). A page load
+   and a switch coming from the URL push nothing: after the render the URL is
+   *replaced* with the validated filters (stale values dropped), so the address
+   bar catches up without an entry (today the page load pushes a duplicate of
+   the entry the user arrived with). Typing keeps replacing; every other filter
+   change keeps pushing.
+3. **One URL-to-state path.** `restoreFiltersFromUrl()` becomes the only code
+   copying the URL into the state and the controls: the six multi-selects
+   (each keeps only the values its options offer, so a stale name in a shared
+   link cannot leave a ready checkbox enabled), SYNC, the two ready checkboxes
+   and the search box. It runs after every render once every option list is
+   populated, and on Back/Forward. The populate functions only populate;
+   `populateIssueFilter` no longer takes or returns a selection.
+4. **SYNC.** Follows the URL while its statuses are loaded, so Back/Forward
+   across a SYNC change work; after a reload it still starts at "Show all"
+   (the statuses are fetched on demand) and the URL is cleaned by the replace
+   of decision 2.
+5. **Search box.** On a re-render the box being typed in keeps its content
+   (the URL holds the trimmed query); on Back/Forward the URL wins, even with
+   the focus in the box.
+6. **Late responses.** Back/Forward make quick switches easy: the response of
+   a project load is dropped when another project was selected meanwhile
+   (today a late response renders the previous project's data over the new
+   one until the next check).
+7. **Pure URL mapping.** The mapping between the filters and the URL
+   parameters moves to a new `public/app-url.js` (`filtersFromUrl`,
+   `urlWithFilters`), pure and unit-tested; app.js keeps the DOM side. This is
+   the first cut of the split asked in #33.
+8. **Version.** 2.5.0, stacked on `claude/hide-empty-repositories` (same
+   changelog block).
+
+## 3. Out of scope
+
+- Restoring the scroll position of the tree on Back/Forward.
+- A history entry per keystroke in the search box.
+- Restoring SYNC after a reload.
+- The rest of the split of app.js (#33).
+
+## 4. Behaviour
+
+- `public/app-url.js`: `filtersFromUrl(search)` returns `{ text, assignees,
+  reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer,
+  readyAssignee }` (the shape of `currentFilters()`; `ready` is read as
+  `readyReviewer`); `urlWithFilters(url, { project, filters })` returns a copy
+  of the URL with the project and the active filters only, foreign parameters
+  kept, in the parameter order written today.
+- `updateUrlWithFilters({ replace })` builds the URL with `urlWithFilters` and
+  pushes or replaces as before.
+- `restoreFiltersFromUrl({ preferTypedText = true })`:
+  `filtersFromUrl(location.search)`, `setSelectedValues` then
+  `getSelectedValues` on each multi-select, SYNC from the URL when the statuses
+  are loaded and the select offers the value, ready checkboxes through
+  `updateReadyCheckboxes()`, search box as decision 5.
+- `renderEverything`: populate assignees, reviewers, sprints, fix versions,
+  epics and stories, then `restoreFiltersFromUrl()`, then `applyFilters()`.
+- `selectProject(projectName, { fromUrl })` replaces `handleProjectChange`:
+  clears the SYNC statuses, sets the project, the title and the drawer; not
+  from the URL: resets the filter controls and state and pushes the URL; no
+  project: empty state as today; otherwise loading state, fetch, drop a late
+  response, render, replace the URL, start the periodic check.
+- `handlePopState()`: `projectFromUrl()` (the `project` parameter when the
+  dropdown offers it, else none); another project: set the dropdown,
+  `selectProject(name, { fromUrl: true })`; same project with data rendered:
+  `restoreFiltersFromUrl({ preferTypedText: false })`, `applyFilters()`;
+  nothing rendered (loading, or the last load failed): nothing, the next render
+  restores from the URL.
+- `loadProjects()`: `selectProject(projectFromUrl(), { fromUrl: true })` when
+  the URL names a project; the dropdown's change event calls
+  `selectProject(event.target.value)`.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `public/app-url.js` (new) | `filterUrlParams`, `filtersFromUrl`, `urlWithFilters` |
+| `test/app-url.test.mjs` (new) | reading, writing, round trip, `ready` alias, foreign parameters |
+| `public/app.js` | imports, `updateUrlWithFilters`, `restoreFiltersFromUrl`, populate functions, `renderEverything`, `selectProject`, `projectFromUrl`, `handlePopState`, listeners |
+| `README.md`, `CLAUDE.md`, `PRD.md` | feature, structure, pitfalls, F4.15 |
+
+## 6. Verification
+
+`npm test`. In the browser on the fixture server: select an assignee then a
+sprint, Back restores the assignee alone (controls, badge, tree), Forward the
+sprint; type in the search box, select a reviewer, Back drops the reviewer and
+keeps the text; switch project, Back returns to the previous project with its
+filters, Forward to the new one; a page load creates no entry; a manual
+project switch is undone by one Back; with SYNC loaded, Back/Forward across a
+SYNC change restore it; a `?assignee=Nobody` link ends with a clean URL and no
+entry added.
+
+## 7. Delivery
+
+Branch `claude/back-forward-filters` on `claude/hide-empty-repositories`, one
+pull request stacked on the hide-empty-repositories one, closing #32.

--- a/docs/superpowers/specs/2026-09-10-back-forward-filters-design.md
+++ b/docs/superpowers/specs/2026-09-10-back-forward-filters-design.md
@@ -20,8 +20,8 @@ one history entry.
    project: the filters are copied from the URL into the state and the
    controls, then applied. Other project (or none): the dropdown is set and the
    project is switched and loaded as on a page load; the render restores the
-   filters the URL carries. Nothing in that path writes the URL: the browser
-   already did.
+   filters the URL carries. Nothing in that path pushes a history entry: the browser
+   already moved, and the URL is only replaced after the render (decision 2).
 2. **One entry per action.** A manual project switch pushes one entry (today
    two: one with the filters cleared, one with the new project). A page load
    and a switch coming from the URL push nothing: after the render the URL is

--- a/docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md
+++ b/docs/superpowers/specs/2026-09-10-hide-empty-repositories-design.md
@@ -1,0 +1,77 @@
+# Hide repositories emptied by the filters
+
+**Date:** 2026-09-10
+**Target version:** 2.5.0
+**Status:** Decided in an autonomous session, without a review round; section 2 lists what to revisit
+
+## 1. Goal
+
+When the filters leave a repository without any visible pull request, the
+repository block disappears from the tree, like a root branch already does.
+Until now the block stayed on screen with a `0/n` counter and an empty
+content, so a filtered project showed a column of empty repository headers.
+
+## 2. Decisions
+
+1. **Rule.** In the filter pass, a repository whose visible count is 0 is
+   hidden with `display: none`, the same way as a root branch. It is shown
+   again by the next pass that leaves one of its pull requests visible. Its
+   counter is still refreshed while hidden, so it is right the moment the
+   block comes back.
+2. **No filter, no change.** Repositories without any open pull request are
+   never rendered (the repositories come from grouping the pull requests), so
+   with no active filter every repository stays visible. The change is only
+   observable while a filter is active.
+3. **Nothing matches.** When every repository is hidden, a message "No pull
+   request matches the filters" takes the place of the tree, in the style of
+   the loading and error messages. Without it the pane would be blank, which
+   reads as a bug, especially with the sidebar hidden. The orphaned issues
+   section is not filtered and keeps showing under the message, as it did
+   under the empty repositories.
+4. **Collapsed state.** Hiding does not touch the collapsed state: a
+   repository collapsed by the user comes back collapsed. "Collapse all" and
+   "Expand all" keep acting on hidden repositories, so they are in the
+   requested state when they reappear.
+5. **Version.** 2.5.0: a visible behaviour change, no API change.
+
+## 3. Out of scope
+
+- A message for a project with no open pull request at all (the pane stays
+  empty, as today).
+- Hiding the orphaned issues section under filters.
+- A count of the hidden repositories or pull requests.
+
+## 4. Behaviour
+
+- `filterBranches` (app-filter.js): after summing the root branches of a
+  repository, `setDisplay(repository, repositoryVisible > 0 ? '' : 'none')`;
+  the pass counts the repositories left shown and, when the `.tree-no-match`
+  element is present, shows it exactly when none is.
+- `renderRepositories` (app.js): appends the message element, hidden, after
+  the repositories when there is at least one; the filter pass that follows
+  every render decides its visibility. The element uses the `hidden`
+  attribute, which the stylesheet honours with `!important`.
+- No change to `applyFilters`, to the filter index, to the URL or to the
+  evaluation of a pull request.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `public/app-filter.js` | hide the repository, toggle the message, JSDoc |
+| `public/app.js` | the message element in `renderRepositories` |
+| `README.md`, `CLAUDE.md`, `PRD.md`, `package.json` | feature, filtering architecture, F4.14, version 2.5.0 |
+
+## 6. Verification
+
+`npm test` (the DOM pass has no unit test, as before). In the browser on the
+fixture server: a text filter matching the pull requests of a single
+repository hides the other repositories; clearing it brings them back with
+their counters; a filter that matches nothing shows the message and nothing
+else above the orphaned issues; a repository collapsed before being hidden
+comes back collapsed.
+
+## 7. Delivery
+
+Branch `claude/hide-empty-repositories` from `master`; nothing committed until
+asked.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "version",
-  "version": "2.4.0",
-  "releaseDate": "2026-09-09",
+  "version": "2.5.0",
+  "releaseDate": "2026-09-10",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",
   "scripts": {

--- a/public/app-filter.js
+++ b/public/app-filter.js
@@ -271,7 +271,9 @@ export function evaluatePullRequest(entry, { text = '', assignees, reviewers, sp
 // ---------------------------------------------------------------- tree pass
 
 /**
- * Applies the filters to the rendered tree and refreshes the counters.
+ * Applies the filters to the rendered tree and refreshes the counters. A root
+ * branch or a repository left without a visible pull request is hidden; while
+ * every repository is hidden, the "nothing matches" message is shown instead.
  * @param {object} filters - { text, assignees, reviewers, sprints, fixVersions, epics, stories, sync, readyReviewer, readyAssignee }
  * @returns {number} how many pull requests are left shown and need attention
  */
@@ -289,6 +291,7 @@ export function filterBranches(filters) {
         shownAttention: 0
     };
 
+    let shownRepositories = 0;
     for (const repository of document.querySelectorAll('.repository')) {
         let repositoryTotal = 0;
         let repositoryVisible = 0;
@@ -305,7 +308,16 @@ export function filterBranches(filters) {
         }
         const counter = repository.querySelector('.repo-pr-counter');
         if (counter) updateCounterDisplay(counter, repositoryVisible, repositoryTotal);
+
+        // Hide the repository too when no pull request is left, like its branches
+        setDisplay(repository, repositoryVisible > 0 ? '' : 'none');
+        if (repositoryVisible > 0) shownRepositories++;
     }
+
+    // renderRepositories renders the message hidden; it takes the place of the
+    // tree while every repository is hidden
+    const noMatch = document.querySelector('.tree-no-match');
+    if (noMatch) noMatch.hidden = shownRepositories > 0;
 
     return pass.shownAttention;
 }

--- a/public/app-url.js
+++ b/public/app-url.js
@@ -11,6 +11,7 @@ export const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'a
 /**
  * The filters a query string describes, in the shape of currentFilters().
  * @param {string} search - window.location.search, with or without the leading "?"
+ * @returns {{ text: string, assignees: string[], reviewers: string[], sprints: string[], fixVersions: string[], epics: string[], stories: string[], sync: string, readyReviewer: boolean, readyAssignee: boolean }}
  */
 export function filtersFromUrl(search) {
     const params = new URLSearchParams(search);

--- a/public/app-url.js
+++ b/public/app-url.js
@@ -1,0 +1,59 @@
+/**
+ * The filters as URL parameters: what the address bar shows, what a shared
+ * link carries and what Back and Forward put back. Pure: nothing here reads
+ * the page. Multi-selects use repeated parameters (?assignee=A&assignee=B).
+ */
+
+// Parameters written by the filters. 'ready' is the former name of
+// readyReviewer: still read from old links, only ever removed when writing.
+export const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
+
+/**
+ * The filters a query string describes, in the shape of currentFilters().
+ * @param {string} search - window.location.search, with or without the leading "?"
+ */
+export function filtersFromUrl(search) {
+    const params = new URLSearchParams(search);
+    return {
+        text: params.get('q') || '',
+        assignees: params.getAll('assignee'),
+        reviewers: params.getAll('reviewer'),
+        sprints: params.getAll('sprint'),
+        fixVersions: params.getAll('fixVersion'),
+        epics: params.getAll('epic'),
+        stories: params.getAll('story'),
+        sync: params.get('sync') || 'Show all',
+        readyReviewer: params.get('readyReviewer') === 'true' || params.get('ready') === 'true',
+        readyAssignee: params.get('readyAssignee') === 'true'
+    };
+}
+
+/**
+ * A copy of a URL carrying the project and the active filters, and none of
+ * the previous ones; parameters that are not filters are kept.
+ * @param {URL} url - left untouched
+ * @param {{ project: string | null, filters: object }} state - filters in the shape of currentFilters()
+ * @returns {URL}
+ */
+export function urlWithFilters(url, { project, filters }) {
+    const result = new URL(url);
+    const params = result.searchParams;
+    filterUrlParams.forEach(param => params.delete(param));
+    if (project) {
+        params.set('project', project);
+    } else {
+        params.delete('project');
+    }
+    const text = filters.text.trim();
+    if (text !== '') params.set('q', text);
+    filters.assignees.forEach(value => params.append('assignee', value));
+    filters.reviewers.forEach(value => params.append('reviewer', value));
+    filters.sprints.forEach(value => params.append('sprint', value));
+    filters.fixVersions.forEach(value => params.append('fixVersion', value));
+    filters.epics.forEach(value => params.append('epic', value));
+    filters.stories.forEach(value => params.append('story', value));
+    if (filters.sync !== 'Show all') params.set('sync', filters.sync);
+    if (filters.readyReviewer) params.set('readyReviewer', 'true');
+    if (filters.readyAssignee) params.set('readyAssignee', 'true');
+    return result;
+}

--- a/public/app.js
+++ b/public/app.js
@@ -97,6 +97,14 @@ function updateUrlWithFilters({ replace = false } = {}) {
     }
 }
 
+// Selects the values a multi-select offers among the given ones, and returns what it kept
+function restoreMultiSelect(id, values) {
+    const multiSelect = getMultiSelect(id);
+    if (!multiSelect) return values;
+    multiSelect.setSelectedValues(values);
+    return multiSelect.getSelectedValues();
+}
+
 // Copies the filters the URL describes into the state and the controls. Runs
 // after every render, once every option list is populated, and on Back and
 // Forward. Each multi-select keeps only the values its options offer, so a
@@ -109,12 +117,6 @@ function updateUrlWithFilters({ replace = false } = {}) {
 function restoreFiltersFromUrl({ preferTypedText = true } = {}) {
     const filters = filtersFromUrl(window.location.search);
 
-    const restoreMultiSelect = (id, values) => {
-        const multiSelect = getMultiSelect(id);
-        if (!multiSelect) return values;
-        multiSelect.setSelectedValues(values);
-        return multiSelect.getSelectedValues();
-    };
     currentSprints = restoreMultiSelect('sprintSelect', filters.sprints);
     currentFixVersions = restoreMultiSelect('fixVersionSelect', filters.fixVersions);
     currentEpics = restoreMultiSelect('epicSelect', filters.epics);
@@ -216,6 +218,8 @@ async function selectProject(projectName, { fromUrl = false, preferTypedText = t
     // The SYNC statuses belong to the project being left
     currentSyncStatuses = null;
     syncLoadFailed = false;
+    // Nothing is rendered for the project being switched to: a popstate meanwhile waits for the render
+    currentApiResult = null;
     currentProject = projectName || null;
     updateSyncControls();
     updateDocumentTitle({ project: currentProject, attentionCount: 0 });
@@ -246,9 +250,10 @@ async function selectProject(projectName, { fromUrl = false, preferTypedText = t
 }
 
 // Back and Forward: the page follows the URL, never the other way round.
-// Another project: switch to it, the render restores the filters of that URL.
-// Same project: the filters are restored from the URL and applied. Nothing
-// here writes the URL. Browsers no longer fire popstate on page load.
+// Another project: switch to it, the render restores the filters of that
+// URL. Same project: the filters are restored from the URL and applied.
+// Nothing here pushes a history entry. Browsers no longer fire popstate on
+// page load.
 function handlePopState() {
     const projectName = projectFromUrl();
     if (projectName !== (currentProject || '')) {

--- a/public/app.js
+++ b/public/app.js
@@ -655,6 +655,16 @@ function renderRepositories(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
             </div>
         `;
     }
+
+    // Shown by the filter pass while every repository is hidden
+    if (Object.keys(pullRequestsByRepo).length > 0) {
+        html += `
+            <div class="state-message tree-no-match" hidden>
+                <i class="fas fa-filter"></i>
+                <span>No pull request matches the filters</span>
+            </div>
+        `;
+    }
     return html;
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,7 @@ import { initializeFilter, filterBranches, countActiveFilters, issueOptions } fr
 import { createMultiSelect, getMultiSelect } from './multi-select.js';
 import { toggleChildren, toggleRootBranch, toggleRepository, captureToggleStates, restoreToggleStates } from './tree-toggle.js';
 import { initializeAppShell, updateDocumentTitle, closeSidebarDrawer, updateActiveFilterBadge, setToolbarVisible } from './app-shell.js';
+import { filtersFromUrl, urlWithFilters } from './app-url.js';
 
 let currentProject = null;
 let currentText = '';
@@ -26,8 +27,6 @@ let syncLoadFailed = false;
 const multiSelectIds = ['sprintSelect', 'fixVersionSelect', 'epicSelect', 'storySelect', 'assigneeSelect', 'reviewerSelect'];
 // The two ready checkboxes, in sidebar order
 const readyCheckboxIds = ['readyForAssigneeCheck', 'readyForReviewerCheck'];
-// URL parameters written by the filters ('ready', the former name of readyReviewer, is only ever removed)
-const filterUrlParams = ['q', 'sprint', 'fixVersion', 'epic', 'story', 'assignee', 'reviewer', 'sync', 'readyReviewer', 'readyAssignee', 'ready'];
 
 function currentFilters() {
     return {
@@ -79,32 +78,11 @@ function clearAllFilters() {
     handleFilterChange();
 }
 
-// Writes the filters to the URL. `replace` swaps the current history entry
-// instead of pushing one (used while typing in the search box).
+// Writes the project and the filters to the URL. `replace` swaps the current
+// history entry instead of pushing one: while typing in the search box, and
+// when the address bar catches up after a load.
 function updateUrlWithFilters({ replace = false } = {}) {
-    const url = new URL(window.location);
-
-    filterUrlParams.forEach(param => url.searchParams.delete(param));
-
-    // Set project
-    if (currentProject) {
-        url.searchParams.set('project', currentProject);
-    } else {
-        url.searchParams.delete('project');
-    }
-
-    // Set the active filters (multi-selects use the repeated params format)
-    const text = currentText.trim();
-    if (text !== '') url.searchParams.set('q', text);
-    currentAssignees.forEach(v => url.searchParams.append('assignee', v));
-    currentReviewers.forEach(v => url.searchParams.append('reviewer', v));
-    currentSprints.forEach(v => url.searchParams.append('sprint', v));
-    currentFixVersions.forEach(v => url.searchParams.append('fixVersion', v));
-    currentEpics.forEach(v => url.searchParams.append('epic', v));
-    currentStories.forEach(v => url.searchParams.append('story', v));
-    if (currentSync !== "Show all") url.searchParams.set('sync', currentSync);
-    if (currentReadyForReviewer) url.searchParams.set('readyReviewer', 'true');
-    if (currentReadyForAssignee) url.searchParams.set('readyAssignee', 'true');
+    const url = urlWithFilters(new URL(window.location), { project: currentProject, filters: currentFilters() });
 
     // Update URL without reloading the page. Safari throws past 100 updates
     // per 30 seconds: the URL then catches up on the next change
@@ -119,59 +97,43 @@ function updateUrlWithFilters({ replace = false } = {}) {
     }
 }
 
-// Update filter restoration from URL
-function restoreFiltersFromUrl() {
-    const urlParams = new URLSearchParams(window.location.search);
+// Copies the filters the URL describes into the state and the controls. Runs
+// after every render, once every option list is populated, and on Back and
+// Forward. Each multi-select keeps only the values its options offer, so a
+// stale name in a shared link or an ended sprint is dropped (and cannot leave
+// a ready checkbox enabled over an empty selection). SYNC follows the URL only
+// while its statuses are loaded: they are fetched on demand, so a reload starts
+// at "Show all". The URL holds the trimmed query: while the user is typing the
+// box keeps its own content (a re-render must not eat a trailing space); on
+// Back and Forward (`preferTypedText: false`) the URL wins.
+function restoreFiltersFromUrl({ preferTypedText = true } = {}) {
+    const filters = filtersFromUrl(window.location.search);
 
-    // Get all values for multi-select filters (supports repeated params)
-    currentAssignees = urlParams.getAll('assignee');
-    currentReviewers = urlParams.getAll('reviewer');
-    currentSprints = urlParams.getAll('sprint');
-    currentFixVersions = urlParams.getAll('fixVersion');
-    // Epic and story selections are applied by populateIssueFilter once their options exist
-    currentEpics = urlParams.getAll('epic');
-    currentStories = urlParams.getAll('story');
-    currentText = urlParams.get('q') || '';
+    const restoreMultiSelect = (id, values) => {
+        const multiSelect = getMultiSelect(id);
+        if (!multiSelect) return values;
+        multiSelect.setSelectedValues(values);
+        return multiSelect.getSelectedValues();
+    };
+    currentSprints = restoreMultiSelect('sprintSelect', filters.sprints);
+    currentFixVersions = restoreMultiSelect('fixVersionSelect', filters.fixVersions);
+    currentEpics = restoreMultiSelect('epicSelect', filters.epics);
+    currentStories = restoreMultiSelect('storySelect', filters.stories);
+    currentAssignees = restoreMultiSelect('assigneeSelect', filters.assignees);
+    currentReviewers = restoreMultiSelect('reviewerSelect', filters.reviewers);
 
-    if (!currentSyncStatuses) {
-        currentSync = "Show all"; // Not restored from URL because SYNC status is only loaded on demand
-    }
-    // Restored like the other filters; 'ready' is the former name of readyReviewer
-    currentReadyForReviewer = urlParams.get('readyReviewer') === 'true' || urlParams.get('ready') === 'true';
-    currentReadyForAssignee = urlParams.get('readyAssignee') === 'true';
-
-    // Update multi-select components with restored values
-    const assigneeMultiSelect = getMultiSelect('assigneeSelect');
-    const reviewerMultiSelect = getMultiSelect('reviewerSelect');
-    const sprintMultiSelect = getMultiSelect('sprintSelect');
-    const fixVersionMultiSelect = getMultiSelect('fixVersionSelect');
-
-    // Assignee and reviewer options already exist here: keep only the names they offer, so a
-    // stale name in the URL cannot leave a ready checkbox enabled over an empty selection
-    // (sprints and fix versions are populated after this and validate their own selection)
-    if (assigneeMultiSelect) {
-        assigneeMultiSelect.setSelectedValues(currentAssignees);
-        currentAssignees = assigneeMultiSelect.getSelectedValues();
-    }
-    if (reviewerMultiSelect) {
-        reviewerMultiSelect.setSelectedValues(currentReviewers);
-        currentReviewers = reviewerMultiSelect.getSelectedValues();
-    }
-    if (sprintMultiSelect) {
-        sprintMultiSelect.setSelectedValues(currentSprints);
-    }
-    if (fixVersionMultiSelect) {
-        fixVersionMultiSelect.setSelectedValues(currentFixVersions);
-    }
-
-    // Update the sync select and the ready checkboxes
     const syncSelect = document.getElementById('syncSelect');
+    const syncOffered = syncSelect && Array.from(syncSelect.options).some(option => option.value === filters.sync);
+    currentSync = (currentSyncStatuses && syncOffered) ? filters.sync : 'Show all';
     if (syncSelect) syncSelect.value = currentSync;
+
+    currentReadyForReviewer = filters.readyReviewer;
+    currentReadyForAssignee = filters.readyAssignee;
     updateReadyCheckboxes();
 
-    // The URL holds the trimmed query: a box the user is typing in is authoritative
+    currentText = filters.text;
     const textFilter = document.getElementById('textFilter');
-    if (textFilter && document.activeElement === textFilter) {
+    if (textFilter && preferTypedText && document.activeElement === textFilter) {
         currentText = textFilter.value;
     } else if (textFilter) {
         textFilter.value = currentText;
@@ -225,64 +187,78 @@ async function loadProjects() {
         const projectSelect = document.getElementById('projectSelect');
         projectSelect.innerHTML = '<option value="">Select a project</option>' +
             projects.map(project => `<option value="${project}">${project}</option>`).join('');
-        projectSelect.addEventListener('change', handleProjectChange);
+        projectSelect.addEventListener('change', event => selectProject(event.target.value));
 
-        // Check for project query parameter
-        const urlParams = new URLSearchParams(window.location.search);
-        const projectParam = urlParams.get('project');
-        if (projectParam) {
-            const projectOption = projectSelect.querySelector(`option[value="${projectParam}"]`);
-            if (projectOption) {
-                projectSelect.value = projectParam;
-                // Pass true to indicate this is initial page load, not a manual switch
-                await handleProjectChange({ target: { value: projectParam } }, true);
-            }
+        // Open the project the URL names, with the filters it carries
+        const projectName = projectFromUrl();
+        if (projectName) {
+            projectSelect.value = projectName;
+            await selectProject(projectName, { fromUrl: true });
         }
     } catch (error) {
         console.error('Error loading projects:', error);
     }
 }
 
-async function handleProjectChange(event, isInitialLoad = false) {
-    const projectName = event.target.value;
-    if (projectName) {
-        currentProject = projectName;
-        updateDocumentTitle({ project: currentProject, attentionCount: 0 });
-        closeSidebarDrawer();
+// The project the URL names, when the dropdown offers it; '' otherwise
+function projectFromUrl() {
+    const projectName = new URLSearchParams(window.location.search).get('project') || '';
+    const options = Array.from(document.getElementById('projectSelect').options);
+    return options.some(option => option.value === projectName) ? projectName : '';
+}
 
-        // Only clear filters from URL when manually switching projects, not during initial page load
-        if (!isInitialLoad) {
-            const url = new URL(window.location);
-            filterUrlParams.forEach(param => url.searchParams.delete(param));
-            window.history.pushState({}, '', url);
+// Switches to a project, or to none with an empty name. From the dropdown the
+// filters start empty and the switch gets one history entry. From the URL
+// (page load, Back and Forward) the URL already describes the state to reach
+// and is left alone: the render restores the filters it carries.
+async function selectProject(projectName, { fromUrl = false } = {}) {
+    // The SYNC statuses belong to the project being left
+    currentSyncStatuses = null;
+    syncLoadFailed = false;
+    currentProject = projectName || null;
+    updateSyncControls();
+    updateDocumentTitle({ project: currentProject, attentionCount: 0 });
+    closeSidebarDrawer();
 
-            // SYNC data belongs to the previous project; then reset the controls and read them into the state
-            currentSyncStatuses = null;
-            syncLoadFailed = false;
-            updateSyncControls();
-            resetFilterControls();
-            readFilterControls();
-        }
-
-        showLoadingState();
-        renderEverything(await fetchData());
-        updateUrlWithFilters();
-
-        // Start periodic checking
-        startPeriodicChecking();
-    } else {
-        currentProject = null;
-        currentSyncStatuses = null;
-        syncLoadFailed = false;
-        updateSyncControls();
-        updateUrlWithFilters();
+    if (!currentProject) {
+        if (!fromUrl) updateUrlWithFilters();
         setToolbarVisible(false);
         applyFilters(); // no tree to filter: refreshes the badge and the tab title
         showEmptyState();
-
-        // Stop periodic checking
         stopPeriodicChecking();
+        return;
     }
+
+    if (!fromUrl) {
+        resetFilterControls();
+        readFilterControls();
+        updateUrlWithFilters();
+    }
+    showLoadingState();
+    const apiResult = await fetchData();
+    // Back and Forward make quick switches easy: a late response for a project no longer selected is dropped
+    if (currentProject !== projectName) return;
+    renderEverything(apiResult);
+    // The address bar catches up with the filters the render validated, without a new entry
+    if (apiResult) updateUrlWithFilters({ replace: true });
+    startPeriodicChecking();
+}
+
+// Back and Forward: the page follows the URL, never the other way round.
+// Another project: switch to it, the render restores the filters of that URL.
+// Same project: the filters are restored from the URL and applied. Nothing
+// here writes the URL. Browsers no longer fire popstate on page load.
+function handlePopState() {
+    const projectName = projectFromUrl();
+    if (projectName !== (currentProject || '')) {
+        document.getElementById('projectSelect').value = projectName;
+        selectProject(projectName, { fromUrl: true });
+        return;
+    }
+    // Nothing rendered (loading, or the last load failed): the next render restores from the URL
+    if (!currentApiResult) return;
+    restoreFiltersFromUrl({ preferTypedText: false });
+    applyFilters();
 }
 
 // Messages shown in the main pane instead of the tree. Built with DOM nodes so
@@ -421,9 +397,6 @@ function populateFilters(pullRequests) {
 
     // Reflect the current SYNC load state (statuses are only fetched on demand)
     updateSyncControls();
-
-    // Restore filter values; renderEverything applies them once every filter is populated
-    restoreFiltersFromUrl();
 }
 
 // Function to format the refresh time
@@ -530,10 +503,11 @@ function renderEverything(apiResult) {
     populateFilters(currentApiResult.pullRequests);
     populateSprintFilter(currentApiResult.sprints);
     populateFixVersionFilter(currentApiResult.jiraIssuesDetails);
-    currentEpics = populateIssueFilter('epicSelect', filterIndex.epics, currentEpics);
-    currentStories = populateIssueFilter('storySelect', filterIndex.stories, currentStories);
+    populateIssueFilter('epicSelect', filterIndex.epics);
+    populateIssueFilter('storySelect', filterIndex.stories);
 
-    // Every filter is populated and restored from the URL: apply them once
+    // Every option list is populated: restore the filters from the URL and apply them once
+    restoreFiltersFromUrl();
     applyFilters();
     setToolbarVisible(true);
 
@@ -769,14 +743,6 @@ function populateSprintFilter(sprints) {
         label: sprint.name
     }));
     sprintMultiSelect.setOptions(sprintOptions);
-
-    // Restore sprint values from URL after populating options
-    if (currentSprints.length > 0) {
-        // Filter out any sprint IDs that don't exist in the options
-        const validSprintIds = sprintOptions.map(opt => opt.value);
-        currentSprints = currentSprints.filter(id => validSprintIds.includes(id));
-        sprintMultiSelect.setSelectedValues(currentSprints);
-    }
 }
 
 function populateFixVersionFilter(jiraIssuesDetails) {
@@ -806,24 +772,13 @@ function populateFixVersionFilter(jiraIssuesDetails) {
         label: `${version.name} (${version.project})`
     }));
     fixVersionMultiSelect.setOptions(fixVersionOptions);
-
-    // Restore fixVersion values from URL after populating options
-    if (currentFixVersions.length > 0) {
-        // Filter out any fixVersion IDs that don't exist in the options
-        const validFixVersionIds = fixVersionOptions.map(opt => opt.value);
-        currentFixVersions = currentFixVersions.filter(id => validFixVersionIds.includes(id));
-        fixVersionMultiSelect.setSelectedValues(currentFixVersions);
-    }
 }
 
-// Fills an issue multi-select (epics, stories) and returns the selection
-// restricted to the keys it offers (the URL may carry keys of another project)
-function populateIssueFilter(elementId, issues, selectedKeys) {
+// Fills an issue multi-select (epics or stories) from the index; the selection
+// is restored from the URL afterwards, like every other filter
+function populateIssueFilter(elementId, issues) {
     const multiSelect = getMultiSelect(elementId);
-    if (!multiSelect) return selectedKeys;
-    multiSelect.setOptions(issueOptions(issues.values()));
-    multiSelect.setSelectedValues(selectedKeys);
-    return multiSelect.getSelectedValues();
+    if (multiSelect) multiSelect.setOptions(issueOptions(issues.values()));
 }
 
 // Fetches the SYNC status of every pull request of the current project in a
@@ -1236,6 +1191,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializePopovers();
     initializeReadyFilters();
     initializeSyncControls();
+    window.addEventListener('popstate', handlePopState);
 });
 
 // Export functions that need to be accessible globally

--- a/public/app.js
+++ b/public/app.js
@@ -211,7 +211,8 @@ function projectFromUrl() {
 // filters start empty and the switch gets one history entry. From the URL
 // (page load, Back and Forward) the URL already describes the state to reach
 // and is left alone: the render restores the filters it carries.
-async function selectProject(projectName, { fromUrl = false } = {}) {
+// `preferTypedText` reaches restoreFiltersFromUrl: Back and Forward pass false so the URL wins over a focused search box.
+async function selectProject(projectName, { fromUrl = false, preferTypedText = true } = {}) {
     // The SYNC statuses belong to the project being left
     currentSyncStatuses = null;
     syncLoadFailed = false;
@@ -238,7 +239,7 @@ async function selectProject(projectName, { fromUrl = false } = {}) {
     const apiResult = await fetchData();
     // Back and Forward make quick switches easy: a late response for a project no longer selected is dropped
     if (currentProject !== projectName) return;
-    renderEverything(apiResult);
+    renderEverything(apiResult, { preferTypedText });
     // The address bar catches up with the filters the render validated, without a new entry
     if (apiResult) updateUrlWithFilters({ replace: true });
     startPeriodicChecking();
@@ -252,7 +253,7 @@ function handlePopState() {
     const projectName = projectFromUrl();
     if (projectName !== (currentProject || '')) {
         document.getElementById('projectSelect').value = projectName;
-        selectProject(projectName, { fromUrl: true });
+        selectProject(projectName, { fromUrl: true, preferTypedText: false });
         return;
     }
     // Nothing rendered (loading, or the last load failed): the next render restores from the URL
@@ -461,7 +462,7 @@ function renderOrphanedIssues(issues) {
 }
 
 
-function renderEverything(apiResult) {
+function renderEverything(apiResult, { preferTypedText = true } = {}) {
     if (!currentProject) {
         return;
     }
@@ -506,8 +507,8 @@ function renderEverything(apiResult) {
     populateIssueFilter('epicSelect', filterIndex.epics);
     populateIssueFilter('storySelect', filterIndex.stories);
 
-    // Every option list is populated: restore the filters from the URL and apply them once
-    restoreFiltersFromUrl();
+    // Every option list is populated: restore the filters from the URL (see restoreFiltersFromUrl for preferTypedText) and apply them once
+    restoreFiltersFromUrl({ preferTypedText });
     applyFilters();
     setToolbarVisible(true);
 

--- a/test/app-url.test.mjs
+++ b/test/app-url.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { filterUrlParams, filtersFromUrl, urlWithFilters } from '../public/app-url.js';
+
+const noFilters = { text: '', assignees: [], reviewers: [], sprints: [], fixVersions: [], epics: [], stories: [], sync: 'Show all', readyReviewer: false, readyAssignee: false };
+
+test('filtersFromUrl reads every filter, repeated parameters included', () => {
+    const filters = filtersFromUrl('?project=PROJ&q=banner&assignee=John&assignee=Jane&reviewer=Bob&sprint=1&sprint=2&fixVersion=10&epic=PROJ-1&story=PROJ-2&sync=requested&readyReviewer=true&readyAssignee=true');
+    assert.deepEqual(filters, {
+        text: 'banner',
+        assignees: ['John', 'Jane'],
+        reviewers: ['Bob'],
+        sprints: ['1', '2'],
+        fixVersions: ['10'],
+        epics: ['PROJ-1'],
+        stories: ['PROJ-2'],
+        sync: 'requested',
+        readyReviewer: true,
+        readyAssignee: true
+    });
+});
+
+test('filtersFromUrl defaults every filter without parameters', () => {
+    assert.deepEqual(filtersFromUrl(''), noFilters);
+    assert.deepEqual(filtersFromUrl('?project=PROJ&foo=1'), noFilters);
+});
+
+test('filtersFromUrl reads the former ready parameter as readyReviewer', () => {
+    assert.equal(filtersFromUrl('?ready=true').readyReviewer, true);
+    assert.equal(filtersFromUrl('?ready=true').readyAssignee, false);
+    assert.equal(filtersFromUrl('?readyReviewer=false').readyReviewer, false);
+});
+
+test('urlWithFilters writes the project and the active filters only, and keeps the other parameters', () => {
+    const url = urlWithFilters(new URL('http://localhost:3000/?foo=1&assignee=Old&ready=true&sync=OK'), {
+        project: 'PROJ',
+        filters: { ...noFilters, text: '  banner ', assignees: ['John'], readyReviewer: true }
+    });
+    assert.equal(url.search, '?foo=1&project=PROJ&q=banner&assignee=John&readyReviewer=true');
+});
+
+test('urlWithFilters without a project drops the project parameter', () => {
+    const url = urlWithFilters(new URL('http://localhost:3000/?project=PROJ&q=x'), { project: null, filters: noFilters });
+    assert.equal(url.search, '');
+});
+
+test('urlWithFilters leaves the URL it is given untouched', () => {
+    const original = new URL('http://localhost:3000/?project=PROJ');
+    urlWithFilters(original, { project: 'OTHER', filters: noFilters });
+    assert.equal(original.search, '?project=PROJ');
+});
+
+test('the filters survive a round trip through the URL', () => {
+    const filters = { text: 'a b', assignees: ['J'], reviewers: ['B', 'C'], sprints: ['1'], fixVersions: ['2'], epics: ['P-1'], stories: ['P-2'], sync: 'requested', readyReviewer: true, readyAssignee: true };
+    const url = urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters });
+    assert.deepEqual(filtersFromUrl(url.search), filters);
+});
+
+test('filterUrlParams covers every parameter urlWithFilters writes, plus the former ready', () => {
+    const filters = { text: 't', assignees: ['a'], reviewers: ['r'], sprints: ['1'], fixVersions: ['2'], epics: ['e'], stories: ['s'], sync: 'OK', readyReviewer: true, readyAssignee: true };
+    const written = [...urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters }).searchParams.keys()].filter(key => key !== 'project');
+    assert.deepEqual(new Set([...written, 'ready']), new Set(filterUrlParams));
+});

--- a/test/app-url.test.mjs
+++ b/test/app-url.test.mjs
@@ -61,3 +61,10 @@ test('filterUrlParams covers every parameter urlWithFilters writes, plus the for
     const written = [...urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters }).searchParams.keys()].filter(key => key !== 'project');
     assert.deepEqual(new Set([...written, 'ready']), new Set(filterUrlParams));
 });
+
+test('values with spaces and special characters survive the round trip', () => {
+    const filters = { ...noFilters, text: 'a&b+c%d é=f', assignees: ['Jean-Luc Picard'], epics: ['PROJ-1'] };
+    const url = urlWithFilters(new URL('http://localhost:3000/'), { project: 'P', filters });
+    assert.deepEqual(filtersFromUrl(url.search), filters);
+    assert.equal(urlWithFilters(url, { project: '', filters: noFilters }).search, '');
+});


### PR DESCRIPTION
Stacked on #35 (base `claude/hide-empty-repositories`); merge #35 first, then retarget this one to `master` before merging.

Closes #32

## Summary
- The page now follows the URL on Back and Forward: a `popstate` listener restores the filters from the URL into the state and the controls and applies them, or switches the project (dropdown included) when the `project` parameter changed. Nothing in that path pushes a history entry.
- One history entry per user action: a manual project switch pushes once (it pushed twice), a page load and a switch coming from the URL push nothing and replace the URL after the render so the address bar shows the validated filters (the page load pushed a duplicate entry).
- `restoreFiltersFromUrl()` is now the only path from the URL to the state and the controls: every multi-select keeps the values its options offer, SYNC follows the URL while its statuses are loaded (still "Show all" after a reload), the ready checkboxes and the search box follow. The populate functions only populate.
- A late response of a project load is dropped when another project was selected meanwhile (quick Back/Forward switches).
- The mapping between the filters and the URL parameters moves to `public/app-url.js`, pure and unit-tested (first cut of #33).
- Spec and plan in `docs/superpowers`.

## Test plan
- `npm test`: 58 tests pass (9 new for `app-url.js`).
- Fixture server (`PORT=3101 node index.mjs --fixtures`) in the browser, driven step by step with the real controls and `history.back()` / `history.forward()`:
  - a page load adds no history entry and a manual project switch adds exactly one;
  - assignee then sprint: Back restores the assignee alone (control, badge, tree), Forward the sprint again;
  - typing replaces the entry, a reviewer pushes one: Back drops the reviewer and keeps the text, Back again drops the text;
  - Forward with the focus in the search box: the box takes the URL's text;
  - switch to OSLC, Back: SECOLLAB with its assignee, sprint and text (also with the focus left in the search box), Forward: OSLC; two quick Forwards across a load end on the right project;
  - "Select a project": one entry, Back restores the project, Forward the empty state;
  - SYNC loaded then "SYNC required": Back gives "Show all", Forward "SYNC required";
  - `?project=SECOLLAB&assignee=Nobody&ready=true&sprint=999&q=archiving` ends as `?project=SECOLLAB&q=archiving` with no entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcMUwKXicKzfDozyREWQdD
