### PR TITLE
Serve README.md through one route: the project directory is no longer served (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.5.1** (as of 2026-09-10)
+Current version: **2.5.2** (as of 2026-09-10)
 
 ## Technology Stack
 
@@ -80,7 +80,7 @@ pr-tree/
 - `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
 - Response hashing for change detection
 - Comprehensive logging system (access.log, error.log, performance.log)
-- Static file serving for public directory
+- Static file serving for the public directory; `README.md` is served through a dedicated route (the help modal fetches it) and nothing else of the project directory is reachable over HTTP
 
 **cache.mjs** (98 lines)
 - Abstraction layer over node-cache
@@ -503,6 +503,7 @@ Three streams available:
 - **No HTTPS enforcement**: Should only run on localhost or behind secure proxy
 - **CORS not configured**: Frontend and backend must be same-origin
 - **No input validation**: Trust that config.js and projects.js are correct
+- **Only public/ and README.md are served**: never mount a static middleware on the project directory, it would serve config.js, the logs and the sources (fixed in 2.5.2); `test/server.test.mjs` checks it
 
 ### Performance Optimization
 - **Minimize API calls**: Use existing cached data when possible
@@ -526,7 +527,7 @@ Three streams available:
 13. **Late responses**: `selectProject` and `checkForUpdates` capture the project before their fetch and drop the response when the project changed meanwhile; `loadSyncStatuses` compares the load generation `resetSyncStatuses` bumps (Back/Forward make quick switches easy); any new fetch that paints something must do the same
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`, `projectFromUrl`, `filtersFromUrl`, `urlWithFilters`, `renderRepositories`, `renderOrphanedIssues`, `findRootBranches`, `calculateTotalPullRequests`, `calculateDescendants`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`, `projectFromUrl`, `filtersFromUrl`, `urlWithFilters`, `renderRepositories`, `renderOrphanedIssues`, `findRootBranches`, `calculateTotalPullRequests`, `calculateDescendants`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency; `test/server.test.mjs` starts the server in fixture mode on an ephemeral port (`PORT=0`) and checks what it serves (the app, the API, `README.md`, nothing else of the project directory)
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/PRD.md
+++ b/PRD.md
@@ -344,6 +344,7 @@ The application integrates with a Jira workflow where:
 - **NFR-SEC2**: Configuration file with credentials must be git-ignored
 - **NFR-SEC3**: Application must use HTTPS when deployed outside localhost
 - **NFR-SEC4**: No sensitive data logged to access/error logs
+- **NFR-SEC5**: Only the `public/` directory and `README.md` are served over HTTP; no other file of the project directory (configuration, logs, sources) is reachable
 
 ### 6.6 Maintainability
 - **NFR-M1**: Code must follow consistent naming conventions (camelCase)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.5.2
+    * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
+    * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked
+    * `npm test` starts the server in fixture mode and checks what it serves from the project directory
 * Version 2.5.1
     * A periodic refresh or a SYNC load that ends after a project switch no longer paints the previous project's data or `?` badges over the new one; the late response is dropped, and the SYNC load button is available for the new project right away
     * Selecting "Select a project" clears the filters and their option lists like a project switch does, and writes a bare URL; previously the previous project's filters stayed and were written to the URL without a project

--- a/docs/superpowers/plans/2026-09-10-serve-readme-route.md
+++ b/docs/superpowers/plans/2026-09-10-serve-readme-route.md
@@ -1,0 +1,249 @@
+# Serve README.md Through One Route Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the static middleware mounted on the project directory (which serves `config.js`, the logs and the sources) with one route that sends `README.md`, proven by a test that runs the server.
+
+**Architecture:** `index.mjs` keeps `express.static('public')` and gets `app.get('/README.md', ...)` with `res.sendFile`; the root `express.static(__dirname, ...)` goes. The listen callback logs `server.address().port` so the server can run on `PORT=0`. A new `test/server.test.mjs` spawns `node index.mjs --fixtures` with `PORT=0`, reads the port from stdout and checks what is served.
+
+**Tech Stack:** Node 24 (global `fetch`, `import.meta.dirname`), Express 5, `node:test`. No frontend change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-serve-readme-route-design.md`
+
+**Branch:** `claude/serve-readme-route`, created from `master` (already checked out). Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay
+```
+
+**CRLF:** `index.mjs` uses CRLF line endings on every line (800 lines, 800 carriage returns). After editing it, check `grep -c $'\r' index.mjs` equals `wc -l < index.mjs` and that `git diff --stat index.mjs` reports about 15 changed lines; if the whole file shows as changed, restore the endings with `perl -pi -e 's/\r?\n/\r\n/' index.mjs` and check again. New files (the test) use LF like the other tests.
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (73 tests before this plan, 76 after). The server test appends a few lines to `access.log` and `performance.log` in the project directory (the server opens its logs there); this is accepted by the spec.
+
+---
+
+### Task 1: The regression test, then the route
+
+**Files:**
+- Create: `test/server.test.mjs`
+- Modify: `index.mjs:46-53` (static middlewares) and `index.mjs:796-801` (listen)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/server.test.mjs`:
+
+```js
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Runs the server in fixture mode on an ephemeral port and checks what it
+ * serves: the app, the API, README.md for the help modal, and nothing else
+ * from the project directory (config.js holds the credentials).
+ */
+
+const root = path.resolve(import.meta.dirname, '..');
+let server;
+let baseUrl;
+
+before(async () => {
+    server = spawn(process.execPath, ['index.mjs', '--fixtures'], {
+        cwd: root,
+        env: { ...process.env, PORT: '0' },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    baseUrl = await new Promise((resolve, reject) => {
+        let output = '';
+        server.stdout.on('data', chunk => {
+            output += chunk;
+            const match = output.match(/Server is running at (http:\/\/localhost:\d+)/);
+            if (match) resolve(match[1]);
+        });
+        server.stderr.on('data', chunk => { output += chunk; });
+        server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
+        setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
+    });
+});
+
+after(() => {
+    if (server) server.kill();
+});
+
+test('README.md is served for the help modal', async () => {
+    const response = await fetch(`${baseUrl}/README.md`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /^text\/markdown/);
+    assert.equal(await response.text(), readFileSync(path.join(root, 'README.md'), 'utf8'));
+});
+
+test('no other file of the project directory is served', async () => {
+    const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+    for (const file of files) {
+        const response = await fetch(`${baseUrl}/${file}`);
+        assert.equal(response.status, 404, `${file} must not be served`);
+    }
+});
+
+test('the app and the API still answer', async () => {
+    const page = await fetch(`${baseUrl}/`);
+    assert.equal(page.status, 200);
+    assert.match(page.headers.get('content-type'), /^text\/html/);
+    const version = await (await fetch(`${baseUrl}/api/version`)).json();
+    const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+    assert.equal(version.version, packageJson.version);
+});
+```
+
+- [ ] **Step 2: Run the test to see it fail**
+
+Run: `npm test`
+Expected: `test/server.test.mjs` fails. With the current `index.mjs` the startup log prints `http://localhost:0` (the `PORT` string, not the bound port), so the `before` hook resolves a URL on port 0 and every fetch fails with a connection error; that is the failure to expect. (Once Step 3 logs the real port and before the middleware is removed, the failure would be `config.js must not be served`: 200 instead of 404.)
+
+- [ ] **Step 3: Replace the root static middleware with the route, log the bound port**
+
+In `index.mjs`, replace
+
+```js
+// Serve all files in the public folder
+app.use(express.static('public'));
+
+// Serve README.md from the root directory
+app.use(express.static(__dirname, {
+    index: false, // Prevent serving index.html from root
+    extensions: ['md'] // Allow serving .md files without extension
+}));
+```
+
+with
+
+```js
+// Serve all files in the public folder
+app.use(express.static('public'));
+
+// The help modal fetches the README from the root. This route is the only
+// thing served from the project directory: a static middleware mounted on it
+// served config.js (the credentials), the logs and the sources too.
+app.get('/README.md', (req, res) => {
+    res.sendFile(path.join(__dirname, 'README.md'));
+});
+```
+
+and replace the listen block at the end of the file
+
+```js
+app.listen(port, () => {
+    log(`Server is running at http://localhost:${port}`, accessLogStream);
+    if (fixtureSource) {
+        log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
+    }
+});
+```
+
+with
+
+```js
+const server = app.listen(port, () => {
+    // The port actually bound: PORT=0 lets the OS pick one (the server test does that)
+    log(`Server is running at http://localhost:${server.address().port}`, accessLogStream);
+    if (fixtureSource) {
+        log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
+    }
+});
+```
+
+Keep the CRLF endings (see the header of this plan).
+
+- [ ] **Step 4: Run the tests to see them pass**
+
+Run: `npm test`
+Expected: `ℹ tests 76`, `ℹ fail 0`.
+
+- [ ] **Step 5: Check the diff**
+
+Run: `grep -c $'\r' index.mjs; wc -l < index.mjs; git diff --stat`
+Expected: the two counts are equal; `index.mjs` shows about 15 changed lines and no other tracked file changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add index.mjs test/server.test.mjs
+git commit -m "fix: serve README.md through one route, the project directory is no longer served (#40)
+
+The static middleware mounted on the project directory served config.js
+(the Bitbucket and Jira credentials), the logs and the sources to anyone
+who could reach the port. The startup log now shows the port actually
+bound, so the new server test can run on PORT=0.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 2: Version 2.5.2 and the documentation
+
+**Files:**
+- Modify: `package.json:3` (version)
+- Modify: `README.md` (changelog, after the `## Changelog:` line)
+- Modify: `CLAUDE.md` (version line, `index.mjs` description, security considerations, testing approach)
+- Modify: `PRD.md` (6.5 Security)
+
+- [ ] **Step 1: package.json**
+
+Set `"version": "2.5.2"` (the `releaseDate` stays `2026-09-10`).
+
+- [ ] **Step 2: README changelog**
+
+Insert right after the line `## Changelog:` (before `* Version 2.5.1`):
+
+```
+* Version 2.5.2
+    * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
+    * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked
+    * `npm test` starts the server in fixture mode and checks what it serves from the project directory
+```
+
+- [ ] **Step 3: CLAUDE.md**
+
+Four edits:
+
+1. `Current version: **2.5.1** (as of 2026-09-10)` becomes `Current version: **2.5.2** (as of 2026-09-10)`.
+2. In the `**index.mjs**` bullet list of "Key Files Explained", replace `- Static file serving for public directory` with `- Static file serving for the public directory; `README.md` is served through a dedicated route (the help modal fetches it) and nothing else of the project directory is reachable over HTTP`.
+3. In "Security Considerations", add after the `**No input validation**` bullet: `- **Only public/ and README.md are served**: never mount a static middleware on the project directory, it would serve config.js, the logs and the sources (fixed in 2.5.2); `test/server.test.mjs` checks it`.
+4. In "Testing Approach", the `**Unit tests**` bullet ends with `and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency`; append `; `test/server.test.mjs` starts the server in fixture mode on an ephemeral port (`PORT=0`) and checks what it serves (the app, the API, `README.md`, nothing else of the project directory)` before the final period of that sentence, i.e. the bullet ends with `no DOM, no extra dependency; `test/server.test.mjs` starts the server ... of the project directory)`.
+
+- [ ] **Step 4: PRD.md**
+
+In `### 6.5 Security`, add after the NFR-SEC4 line:
+
+```
+- **NFR-SEC5**: Only the `public/` directory and `README.md` are served over HTTP; no other file of the project directory (configuration, logs, sources) is reachable
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: `ℹ tests 76`, `ℹ fail 0` (the server test compares `/api/version` with package.json, so the bump must be consistent).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json README.md CLAUDE.md PRD.md
+git commit -m "docs: version 2.5.2, README.md served through one route (#40)
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 3 (controller): verification and pull request
+
+- [ ] `npm test` ends with `ℹ fail 0` and 76 tests.
+- [ ] `PORT=3101 node index.mjs --fixtures` in the background; `curl -sI localhost:3101/config.js` answers `404`, `curl -sI localhost:3101/README.md` answers `200` with `text/markdown`, `curl -sI localhost:3101/access.log` answers `404`; stop the server.
+- [ ] Push the branch and open the pull request to `master` with `Closes #40`.

--- a/docs/superpowers/specs/2026-09-10-serve-readme-route-design.md
+++ b/docs/superpowers/specs/2026-09-10-serve-readme-route-design.md
@@ -1,0 +1,80 @@
+# Serve README.md through one route
+
+**Date:** 2026-09-10
+**Issue:** #40
+**Target version:** 2.5.2
+**Status:** Decided in an autonomous session, without a review round (the user asked for the brainstorm to be done alone); section 2 lists the decisions to revisit
+
+## 1. Goal
+
+The help modal fetches `README.md` from the server root. `index.mjs` serves it
+through a second `express.static` mounted on the project directory, and that
+middleware serves every non-dotfile of the checkout: `config.js` with the
+Bitbucket and Jira credentials, the three logs, the sources, `CLAUDE.md`
+(checked on a fixture server: HEAD `/config.js` answers 200 with the 798 bytes
+of the file). The server listens on all interfaces, so anyone who can reach the
+port can download the credentials. Replace the middleware with a route that
+sends `README.md` and nothing else, and keep a test that proves it.
+
+## 2. Decisions
+
+1. **One route.** `app.get('/README.md', ...)` answers with
+   `res.sendFile(path.join(__dirname, 'README.md'))`; the middleware
+   `express.static(__dirname, { index: false, extensions: ['md'] })` is
+   removed. Nothing else was fetched from the root: the frontend fetches
+   `README.md` (`fetchAndRenderReadme` in `app-shell.js`) and the `/api/*`
+   routes, and `public/` keeps its own static middleware.
+2. **Regression test.** `test/server.test.mjs` starts the server in fixture
+   mode on an ephemeral port and checks that `/README.md` answers 200 as
+   markdown with the content of the file, that `/config.js`,
+   `/config.js.default`, `/index.mjs`, `/cache.mjs`, `/package.json`,
+   `/access.log`, `/CLAUDE.md` and `/fixtures/generate.mjs` answer 404, and
+   that `/` and `/api/version` still answer. It is the first test that runs
+   the server. The server opens its log streams in the project directory, so a
+   test run appends a few lines to `access.log` and `performance.log` there,
+   as any run of the server does; accepted rather than adding a log-directory
+   option for the sake of a test.
+3. **The actual port in the startup log.** `app.listen` returns the server;
+   the startup line logs `server.address().port`, so `PORT=0` (the OS picks a
+   free port) reports the port actually bound, and the test reads it from
+   stdout. No other change to startup.
+4. **Version 2.5.2:** a fix, no feature, no API change.
+5. **Still bound to all interfaces.** Binding to `127.0.0.1` would be a
+   behaviour change for a dashboard used from another machine on the LAN; it
+   is left as a separate decision, noted in #40.
+
+## 3. Out of scope
+
+- Binding the server to `127.0.0.1`.
+- Making `express.static('public')` independent of the working directory.
+- Any change to the help modal or to the frontend.
+
+## 4. Behaviour
+
+- `GET /README.md`: 200, `Content-Type: text/markdown; charset=utf-8`, the
+  file as on disk.
+- `GET /config.js`, `/index.mjs`, `/package.json`, `/access.log`, `/CLAUDE.md`
+  and any other file of the project directory: 404 (Express default).
+- `GET /` (the app) and `/api/*`: unchanged.
+- Startup log: `Server is running at http://localhost:<port actually bound>`.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `index.mjs` (CRLF file) | the route replaces the root static middleware; the listen callback logs the actual port |
+| `test/server.test.mjs` | new: starts the fixture server on port 0, checks the routes above |
+| `README.md`, `CLAUDE.md`, `PRD.md`, `package.json` | changelog 2.5.2, what is served from the project directory, NFR-SEC5, version |
+
+## 6. Verification
+
+`npm test`: the new test fails before the fix (`config.js` served with 200)
+and passes after; 76 tests. Manual, on a fixture server (`PORT=3101 node
+index.mjs --fixtures`): `curl -sI localhost:3101/config.js` answers 404,
+`curl -sI localhost:3101/README.md` answers 200 `text/markdown`, the help
+modal of the page still shows the README.
+
+## 7. Delivery
+
+Branch `claude/serve-readme-route` from `master`, pull request to `master`,
+closes #40. First of a stack: the branch of #41 starts from it.

--- a/index.mjs
+++ b/index.mjs
@@ -46,11 +46,12 @@ let lastResponse = null;
 // Serve all files in the public folder
 app.use(express.static('public'));
 
-// Serve README.md from the root directory
-app.use(express.static(__dirname, {
-    index: false, // Prevent serving index.html from root
-    extensions: ['md'] // Allow serving .md files without extension
-}));
+// The help modal fetches the README from the root. This route is the only
+// thing served from the project directory: a static middleware mounted on it
+// served config.js (the credentials), the logs and the sources too.
+app.get('/README.md', (req, res) => {
+    res.sendFile(path.join(__dirname, 'README.md'));
+});
 
 // Serve the version details
 app.get('/api/version', (req, res) => {
@@ -793,8 +794,9 @@ async function computeConflicts(repoName, spec) {
     return { conflicts };
 }
 
-app.listen(port, () => {
-    log(`Server is running at http://localhost:${port}`, accessLogStream);
+const server = app.listen(port, () => {
+    // The port actually bound: PORT=0 lets the OS pick one (the server test does that)
+    log(`Server is running at http://localhost:${server.address().port}`, accessLogStream);
     if (fixtureSource) {
         log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
     }

--- a/index.mjs
+++ b/index.mjs
@@ -50,7 +50,12 @@ app.use(express.static('public'));
 // thing served from the project directory: a static middleware mounted on it
 // served config.js (the credentials), the logs and the sources too.
 app.get('/README.md', (req, res) => {
-    res.sendFile(path.join(__dirname, 'README.md'));
+    res.sendFile(path.join(__dirname, 'README.md'), error => {
+        if (!error) return;
+        // Without this callback Express would answer with the error and its absolute path
+        log(`Error serving README.md: ${error.message}`, errorLogStream);
+        if (!res.headersSent) res.status(404).send('Not Found');
+    });
 });
 
 // Serve the version details

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "releaseDate": "2026-09-10",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -28,6 +28,7 @@ before(async () => {
             if (match) resolve(match[1]);
         });
         server.stderr.on('data', chunk => { output += chunk; });
+        server.on('error', reject);
         server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
         setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
     });
@@ -45,8 +46,10 @@ test('README.md is served for the help modal', async () => {
 });
 
 test('no other file of the project directory is served', async () => {
+    // A literal `..` is normalised away by fetch itself, so only the encoded forms reach the server
     const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
-        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs',
+        '..%2fconfig.js', 'README.md%2f..%2fconfig.js'];
     for (const file of files) {
         const response = await fetch(`${baseUrl}/${file}`);
         assert.equal(response.status, 404, `${file} must not be served`);

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1,0 +1,63 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Runs the server in fixture mode on an ephemeral port and checks what it
+ * serves: the app, the API, README.md for the help modal, and nothing else
+ * from the project directory (config.js holds the credentials).
+ */
+
+const root = path.resolve(import.meta.dirname, '..');
+let server;
+let baseUrl;
+
+before(async () => {
+    server = spawn(process.execPath, ['index.mjs', '--fixtures'], {
+        cwd: root,
+        env: { ...process.env, PORT: '0' },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    baseUrl = await new Promise((resolve, reject) => {
+        let output = '';
+        server.stdout.on('data', chunk => {
+            output += chunk;
+            const match = output.match(/Server is running at (http:\/\/localhost:\d+)/);
+            if (match) resolve(match[1]);
+        });
+        server.stderr.on('data', chunk => { output += chunk; });
+        server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
+        setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
+    });
+});
+
+after(() => {
+    if (server) server.kill();
+});
+
+test('README.md is served for the help modal', async () => {
+    const response = await fetch(`${baseUrl}/README.md`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /^text\/markdown/);
+    assert.equal(await response.text(), readFileSync(path.join(root, 'README.md'), 'utf8'));
+});
+
+test('no other file of the project directory is served', async () => {
+    const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+    for (const file of files) {
+        const response = await fetch(`${baseUrl}/${file}`);
+        assert.equal(response.status, 404, `${file} must not be served`);
+    }
+});
+
+test('the app and the API still answer', async () => {
+    const page = await fetch(`${baseUrl}/`);
+    assert.equal(page.status, 200);
+    assert.match(page.headers.get('content-type'), /^text\/html/);
+    const version = await (await fetch(`${baseUrl}/api/version`)).json();
+    const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+    assert.equal(version.version, packageJson.version);
+});


### PR DESCRIPTION
## Summary

`index.mjs` mounted a second `express.static` on the project directory to serve `README.md` for the help modal. That middleware served every non-dotfile of the checkout: `config.js` with the Bitbucket and Jira credentials, the three logs, the sources, `CLAUDE.md` (checked on a fixture server: `HEAD /config.js` answered 200 with the 798 bytes of the file). The server listens on all interfaces, so anyone who could reach the port could download the credentials.

- One route now sends `README.md` (`res.sendFile`); nothing else of the project directory is reachable over HTTP.
- The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked.
- New `test/server.test.mjs`: starts the server in fixture mode on an ephemeral port and checks that `/README.md` answers 200 as markdown, that `config.js`, the logs and the sources answer 404, and that the app and `/api/version` still answer. It is the first test that runs the server (it appends a few lines to the logs in the checkout, as any run does).
- A read error on `README.md` (missing file) is logged and answered with a plain 404, instead of the Express error text that carried the absolute server path (found by the code review); the test also probes the encoded traversal forms `/..%2fconfig.js` and `/README.md%2f..%2fconfig.js`.
- Version 2.5.2; README changelog, CLAUDE.md and PRD.md (NFR-SEC5) follow.

Spec: `docs/superpowers/specs/2026-09-10-serve-readme-route-design.md`, plan: `docs/superpowers/plans/2026-09-10-serve-readme-route.md`. Decided in an autonomous session; the decision to revisit is whether the server should also bind to `127.0.0.1` (left out: a behaviour change for anyone using the dashboard from another machine).

Closes #40.

## Verification

- `npm test`: 76 tests, 0 failures (73 before).
- On a fixture server on port 3101: `/README.md` answers 200 `text/markdown` with the file; `/config.js`, `/config.js.default`, `/access.log`, `/index.mjs`, `/cache.mjs`, `/package.json`, `/CLAUDE.md`, `/fixtures/generate.mjs` and the extensionless `/README` answer 404; `/` and `/api/version` answer 200; the startup log reads `Server is running at http://localhost:3101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay
