### PR TITLE
Remove what nothing uses: three dependencies, the per-PR conflicts endpoint, dead cache exports, obsolete config fields (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.5.1** (as of 2026-09-10)
+Current version: **2.5.2** (as of 2026-09-10)
 
 ## Technology Stack
 
@@ -80,7 +80,7 @@ pr-tree/
 - `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
 - Response hashing for change detection
 - Comprehensive logging system (access.log, error.log, performance.log)
-- Static file serving for public directory
+- Static file serving for the public directory; `README.md` is served through a dedicated route (the help modal fetches it) and nothing else of the project directory is reachable over HTTP
 
 **cache.mjs** (98 lines)
 - Abstraction layer over node-cache
@@ -503,6 +503,7 @@ Three streams available:
 - **No HTTPS enforcement**: Should only run on localhost or behind secure proxy
 - **CORS not configured**: Frontend and backend must be same-origin
 - **No input validation**: Trust that config.js and projects.js are correct
+- **Only public/ and README.md are served**: never mount a static middleware on the project directory, it would serve config.js, the logs and the sources (fixed in 2.5.2); `test/server.test.mjs` checks it
 
 ### Performance Optimization
 - **Minimize API calls**: Use existing cached data when possible
@@ -526,7 +527,7 @@ Three streams available:
 13. **Late responses**: `selectProject` and `checkForUpdates` capture the project before their fetch and drop the response when the project changed meanwhile; `loadSyncStatuses` compares the load generation `resetSyncStatuses` bumps (Back/Forward make quick switches easy); any new fetch that paints something must do the same
 
 ### Testing Approach
-- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`, `projectFromUrl`, `filtersFromUrl`, `urlWithFilters`, `renderRepositories`, `renderOrphanedIssues`, `findRootBranches`, `calculateTotalPullRequests`, `calculateDescendants`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency
+- **Unit tests**: `npm test` runs `node:test` over `test/*.test.mjs` for the pure logic (`parseTextQuery`, `matchesText`, `issueLevel`, `epicOf`, `storyOf`, `computeAttention`, `countActiveFilters`, `buildFilterIndex`, `evaluatePullRequest`, `buildDocumentTitle`, `projectFromUrl`, `filtersFromUrl`, `urlWithFilters`, `renderRepositories`, `renderOrphanedIssues`, `findRootBranches`, `calculateTotalPullRequests`, `calculateDescendants`) and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency; `test/server.test.mjs` starts the server in fixture mode on an ephemeral port (`PORT=0`) and checks what it serves (the app, the API, `README.md`, nothing else of the project directory)
 - **Performance**: start `npm run start:fixtures`, open SECOLLAB, and time a filter change in the browser console (e.g. `performance.now()` around a checkbox `.click()` of a multi-select); a pass should stay around a millisecond of JavaScript
 - **UI**: manual testing in the browser (layout, filters, theme)
 - **Regression testing**: Test all filters after making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,16 @@
 - Orphaned issue detection (Jira issues in review without PRs)
 
 ### Version
-Current version: **2.5.2** (as of 2026-09-10)
+Current version: **2.6.0** (as of 2026-09-10)
 
 ## Technology Stack
 
 ### Backend
 - **Runtime**: Node.js with ES Modules (.mjs)
-- **Framework**: Express.js (v4.19.2)
-- **HTTP Client**: node-fetch (v3.3.2)
+- **Framework**: Express.js (v5.2.1)
+- **HTTP Client**: the `fetch` built into Node.js (20.11 or later)
 - **Caching**: node-cache (v5.1.2)
-- **Configuration**: dotenv (v16.4.5)
+- **Three-way merge**: node-diff3 (v3.2.1), for the conflict computation
 - **Authentication**: Basic Auth (Base64 encoded) for Bitbucket and Jira APIs
 
 ### Frontend
@@ -48,7 +48,6 @@ pr-tree/
 ├── projects.js            # Project definitions & Jira regex patterns
 ├── package.json           # Dependencies & version metadata
 ├── .gitignore             # Excludes config.js, node_modules, logs
-├── start.bat              # Windows startup script
 ├── fixtures/              # Fixture mode: generated data served instead of Atlassian (npm run start:fixtures)
 │   ├── generate.mjs       # Deterministic generator modelled on the real projects
 │   └── index.mjs          # Command-line/env options, config replacement, data source
@@ -74,7 +73,7 @@ pr-tree/
 
 **index.mjs** (506 lines)
 - Main Express application server
-- API endpoint definitions (`/api/projects`, `/api/pull-requests/:project`, `/api/pull-request-conflicts/:repoName/:spec`)
+- API endpoint definitions (`/api/version`, `/api/projects`, `/api/pull-requests/:project`, `/api/sync-statuses/:project`, `/api/cache/stats`)
 - Bitbucket API integration (fetch PRs, commit diffs)
 - Jira API integration (fetch issues, sprints, orphaned issues)
 - `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
@@ -89,7 +88,7 @@ pr-tree/
   - Project data: 120 seconds (default)
   - Projects list: 300 seconds (5 minutes)
   - Conflicts: 300 seconds (5 minutes)
-  - Sprints: 600 seconds (10 minutes)
+- The sprints are fetched with the project data and cached with it (no separate cache)
 - Cache statistics endpoint support
 
 **projects.js**
@@ -236,20 +235,6 @@ Main data endpoint. Returns comprehensive project data (cached 2 minutes).
 - If dataHash unchanged from last response, only updates `lastRefreshTime`
 - Only fetches commit counts (ahead/behind) when hash changes
 - This prevents Bitbucket API rate limiting (HTTP 429)
-
-### GET /api/pull-request-conflicts/:repoName/:spec
-Checks for merge conflicts in a PR (cached 5 minutes).
-
-**Parameters:**
-- `repoName`: Repository slug
-- `spec`: Bitbucket diff spec (e.g., "sourceBranch..destBranch")
-
-**Response:**
-```json
-{
-  "conflicts": true
-}
-```
 
 ### GET /api/sync-statuses/:project
 Returns the SYNC (conflicts) status of every open PR of a project in a single response (cached 5 minutes). Only called by the frontend when the user clicks the load button next to the SYNC filter — never automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ pr-tree/
 **index.mjs** (506 lines)
 - Main Express application server
 - API endpoint definitions (`/api/version`, `/api/projects`, `/api/pull-requests/:project`, `/api/sync-statuses/:project`, `/api/cache/stats`)
+- The per-pull-request conflict computation (`computeConflicts`, `conflictsLimiter`, `getCachedConflicts`) survives only as an internal of `/api/sync-statuses/:project`
 - Bitbucket API integration (fetch PRs, commit diffs)
 - Jira API integration (fetch issues, sprints, orphaned issues)
 - `fetchJiraIssuesDetails()` fetches the linked issues (summary, status, priority, fix versions, assignee, parent, issue type), then the parents that were not linked themselves (summary, issue type, fix versions, parent): sub-tasks inherit the fix versions of their parent, and the frontend resolves epics and stories from `parent`
@@ -341,15 +342,15 @@ Never re-select descendants (`querySelectorAll('.pull-request')`) inside the rec
 2. Run `npm ci` (not `npm install` - uses package-lock.json exactly)
 3. Copy `config.js.default` to `config.js`
 4. Fill in Bitbucket credentials:
-   - Username (e.g., `username_workspace`)
-   - App Password (create at https://bitbucket.org/account/settings/app-passwords/)
+   - Username: the e-mail of the Atlassian account (the Bitbucket username is rejected with an API token)
+   - Password: an API token with scopes (https://id.atlassian.com/manage-profile/security/api-tokens, "Create API token with scopes", app Bitbucket, scopes `read:repository:bitbucket` and `read:pullrequest:bitbucket`); app passwords were removed by Atlassian in July 2026
    - Workspace slug
 5. Fill in Jira credentials:
    - Site name (subdomain of atlassian.net)
    - Username (email)
-   - API token (create at https://id.atlassian.com/manage-profile/security/api-tokens)
+   - API token without scopes, from the same page (a Bitbucket-scoped token is rejected by Jira)
 6. Update `projects.js` with your projects
-7. Run `node index.mjs`
+7. Run `npm start`
 8. Navigate to http://localhost:3000
 
 ### Running Without Atlassian Access (Fixture Mode)
@@ -564,7 +565,7 @@ Version information stored in package.json:
   - Endpoints: board, sprint
 
 ### Authentication
-- Bitbucket: Basic Auth with username and app password
+- Bitbucket: Basic Auth with the account e-mail and a scoped API token
 - Jira: Basic Auth with email and API token
 - Tokens stored in config.js (Base64 encoded in headers)
 

--- a/PRD.md
+++ b/PRD.md
@@ -344,6 +344,7 @@ The application integrates with a Jira workflow where:
 - **NFR-SEC2**: Configuration file with credentials must be git-ignored
 - **NFR-SEC3**: Application must use HTTPS when deployed outside localhost
 - **NFR-SEC4**: No sensitive data logged to access/error logs
+- **NFR-SEC5**: Only the `public/` directory and `README.md` are served over HTTP; no other file of the project directory (configuration, logs, sources) is reachable
 
 ### 6.6 Maintainability
 - **NFR-M1**: Code must follow consistent naming conventions (camelCase)

--- a/PRD.md
+++ b/PRD.md
@@ -264,7 +264,7 @@ The application integrates with a Jira workflow where:
 - F8.2: Identify issues assigned to each sprint
 - F8.3: Associate PRs with sprints via linked issues
 - F8.4: Provide sprint filter dropdown
-- F8.5: Cache sprint data (10-minute TTL)
+- F8.5: Sprints are fetched and cached with the project data (no separate cache)
 
 **Acceptance Criteria:**
 - Sprint filter populated with all active sprints
@@ -394,10 +394,10 @@ The application integrates with a Jira workflow where:
 
 #### Backend
 - **Runtime:** Node.js (ES Modules)
-- **Framework:** Express.js v4.19.2
-- **HTTP Client:** node-fetch v3.3.2
+- **Framework:** Express.js v5.2.1
+- **HTTP Client:** the `fetch` built into Node.js 20.11 or later
 - **Caching:** node-cache v5.1.2
-- **Configuration:** dotenv v16.4.5
+- **Three-way merge:** node-diff3 v3.2.1 (conflict computation)
 
 #### Frontend
 - **Core:** HTML5, CSS3, Vanilla JavaScript (ES6)
@@ -444,7 +444,6 @@ The application integrates with a Jira workflow where:
 - Project data: 120 seconds
 - Projects list: 300 seconds
 - Conflicts: 300 seconds
-- Sprints: 600 seconds
 
 **Hash-Based Change Detection:**
 - Compute MD5 hash of PR + Jira data
@@ -458,7 +457,7 @@ The application integrates with a Jira workflow where:
 | `/api/version` | GET | None | Application version metadata |
 | `/api/projects` | GET | 300s | List of configured projects |
 | `/api/pull-requests/:project` | GET | 120s | Comprehensive project data |
-| `/api/pull-request-conflicts/:repo/:spec` | GET | 300s | Merge conflict detection |
+| `/api/sync-statuses/:project` | GET | 300s | SYNC (conflict) status of every open pull request, loaded on demand |
 | `/api/cache/stats` | GET | None | Cache performance statistics |
 
 ### 7.6 Logging Infrastructure
@@ -709,7 +708,7 @@ The following are explicitly **not** part of current requirements:
 | Risk | Impact | Probability | Mitigation |
 |------|--------|-------------|------------|
 | Bitbucket API rate limiting | High | Medium | Implement aggressive caching, hash-based change detection |
-| Jira API performance degradation | Medium | Low | Cache sprint data for 10 minutes, batch issue fetches |
+| Jira API performance degradation | Medium | Low | Cache sprint data with the project data (2 minutes), batch issue fetches |
 | Memory leak in long-running server | High | Low | Monitor memory usage, implement cache size limits |
 | Breaking API changes from Atlassian | High | Low | Version pin APIs, monitor deprecation notices |
 | Large PR volume causing timeout | Medium | Medium | Implement pagination, lazy loading |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 * Copy config.js.default to config.js
 * Fill in the required configuration values in config.js
 * Update projects.js to include your own projects if needed, and remove those you might not need
-* Open a terminal (we are assuming here you have `nodejs` and `npm` installed)
+* Open a terminal (Node.js 20.11 or later and `npm` are assumed to be installed; the server uses the `fetch` built into Node)
 * Run `npm ci`
 * Run `node index.mjs`
 * Go to http://localhost:3000
@@ -84,6 +84,11 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.6.0
+    * Removed what nothing used (#41)
+        * The `/api/pull-request-conflicts/:repoName/:spec` endpoint: the SYNC load has used `/api/sync-statuses/:project` since 2.1.0
+        * The `node-fetch`, `dotenv` and `fetch` dependencies: the server uses the `fetch` built into Node (20.11 or later), `PORT` is read from the environment as before
+        * The sprint cache that was never wired (the sprints are fetched with the project data), the `clearCache` and `clearAllCache` exports, two multi-select methods, the `repoName` and `issuesRegex` fields of `config.js.default`, `start.bat` (`npm start` does the same)
 * Version 2.5.2
     * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
     * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@
 * `--fixture-scale=3` multiplies the volumes, `--fixture-chain-depth=8` shortens the deepest stack (environment variables `PR_TREE_FIXTURES`, `PR_TREE_FIXTURE_SCALE` and `PR_TREE_FIXTURE_CHAIN_DEPTH` work too)
 
 ## Changelog:
+* Version 2.5.2
+    * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
+    * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked
+    * `npm test` starts the server in fixture mode and checks what it serves from the project directory
 * Version 2.5.1
     * A periodic refresh or a SYNC load that ends after a project switch no longer paints the previous project's data or `?` badges over the new one; the late response is dropped, and the SYNC load button is available for the new project right away
     * Selecting "Select a project" clears the filters and their option lists like a project switch does, and writes a bare URL; previously the previous project's filters stayed and were written to the URL without a project

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@
 ## Installation
 * Clone this repository
 * Copy config.js.default to config.js
-* Fill in the required configuration values in config.js
+* Fill in the configuration values in config.js: the comments say which Atlassian tokens to create and where
 * Update projects.js to include your own projects if needed, and remove those you might not need
 * Open a terminal (Node.js 20.11 or later and `npm` are assumed to be installed; the server uses the `fetch` built into Node)
 * Run `npm ci`
-* Run `node index.mjs`
+* Run `npm start`
 * Go to http://localhost:3000
 
 ## Running without Atlassian access (fixture mode)
@@ -87,8 +87,9 @@
 * Version 2.6.0
     * Removed what nothing used (#41)
         * The `/api/pull-request-conflicts/:repoName/:spec` endpoint: the SYNC load has used `/api/sync-statuses/:project` since 2.1.0
-        * The `node-fetch`, `dotenv` and `fetch` dependencies: the server uses the `fetch` built into Node (20.11 or later), `PORT` is read from the environment as before
+        * The `node-fetch`, `dotenv` and `fetch` dependencies: the server uses the `fetch` built into Node (20.11 or later, declared in `package.json`), `PORT` is read from the environment as before but a private `.env` file is no longer loaded; a network failure now reaches `error.log` with its reason and the URL (the built-in `fetch` only says "fetch failed")
         * The sprint cache that was never wired (the sprints are fetched with the project data), the `clearCache` and `clearAllCache` exports, two multi-select methods, the `repoName` and `issuesRegex` fields of `config.js.default`, `start.bat` (`npm start` does the same)
+        * The comments of `config.js.default` describe the credentials Atlassian accepts today: the account e-mail and a scoped API token for Bitbucket (app passwords were removed in July 2026), an API token for Jira
 * Version 2.5.2
     * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
     * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked

--- a/cache.mjs
+++ b/cache.mjs
@@ -13,7 +13,6 @@ const CACHE_KEYS = {
     PROJECT_DATA: (projectName) => `project_${projectName}`,
     CONFLICTS: (repoName, spec) => `conflicts_${repoName}_${spec}`,
     SYNC_STATUSES: (projectName) => `sync_statuses_${projectName}`,
-    SPRINTS: (projectName) => `sprints_${projectName}`,
     PROJECTS_LIST: 'projects_list'
 };
 
@@ -86,16 +85,6 @@ export async function getCachedSyncStatuses(projectName, fetchSyncStatuses) {
 }
 
 /**
- * Get sprints data from cache or fetch from source
- * @param {string} projectName - Project identifier
- * @param {function} fetchSprints - Function to fetch sprints if cache miss
- * @returns {Promise<Array>} Sprints data
- */
-export async function getCachedSprints(projectName, fetchSprints) {
-    return getOrSetCache(CACHE_KEYS.SPRINTS(projectName), fetchSprints, 600); // 10 minutes TTL
-}
-
-/**
  * Raise the TTL of every cached entry so that nothing expires before the given
  * number of seconds from now. Entries expiring later are left untouched.
  * Used to keep serving cached data while Atlassian requests are paused after an HTTP 429.
@@ -109,21 +98,6 @@ export function raiseAllCacheTtls(seconds) {
             cache.ttl(key, seconds);
         }
     }
-}
-
-/**
- * Clear specific cache entry
- * @param {string} key - Cache key to clear
- */
-export function clearCache(key) {
-    cache.del(key);
-}
-
-/**
- * Clear all cache entries
- */
-export function clearAllCache() {
-    cache.flushAll();
 }
 
 /**

--- a/cache.mjs
+++ b/cache.mjs
@@ -54,10 +54,11 @@ export async function getCachedProjectData(projectName, fetchProjectData) {
 }
 
 /**
- * Get conflicts data from cache or fetch from source
+ * Get the conflicts of one pull request from cache or compute them: the entry
+ * behind /api/sync-statuses/:project, called once per pull request
  * @param {string} repoName - Repository name
- * @param {string} spec - Specification string
- * @param {function} fetchConflicts - Function to fetch conflicts if cache miss
+ * @param {string} spec - Bitbucket diff spec, destHash..sourceHash
+ * @param {function} fetchConflicts - Function computing the conflicts on a cache miss
  * @returns {Promise<Object>} Conflicts data
  */
 export async function getCachedConflicts(repoName, spec, fetchConflicts) {

--- a/config.js.default
+++ b/config.js.default
@@ -5,13 +5,11 @@ module.exports = {
         username: 'xxx', // for me was frjaunatre_sodius
         password: 'xxx', // you can create an app password at https://bitbucket.org/account/settings/app-passwords/
         workspace: 'xxx', // should be sodius
-        repoName: 'xxx' // for us was products.secollab
     },
     jira: {
         siteName: 'xxx', // should be sodiuswillert
         username: 'xxx', // for me was frjaunatre@sodiuswillert.com
         apiKey: 'xxx', // you can create an API key at https://id.atlassian.com/manage-profile/security/api-tokens
-        issuesRegex: /(XXX-\d+)/g // for us was replacing XXX with SECOLLAB
     },
     projects: projects,
 };

--- a/config.js.default
+++ b/config.js.default
@@ -2,14 +2,14 @@ const projects = require('./projects');
 
 module.exports = {
     bitbucket: {
-        username: 'xxx', // for me was frjaunatre_sodius
-        password: 'xxx', // you can create an app password at https://bitbucket.org/account/settings/app-passwords/
-        workspace: 'xxx', // should be sodius
+        username: 'xxx', // the e-mail of your Atlassian account (the Bitbucket username is rejected with an API token)
+        password: 'xxx', // an API token with scopes: https://id.atlassian.com/manage-profile/security/api-tokens, "Create API token with scopes", app Bitbucket, scopes read:repository:bitbucket and read:pullrequest:bitbucket (app passwords were removed by Atlassian in July 2026)
+        workspace: 'xxx', // the workspace slug, as in https://bitbucket.org/<workspace>/
     },
     jira: {
-        siteName: 'xxx', // should be sodiuswillert
-        username: 'xxx', // for me was frjaunatre@sodiuswillert.com
-        apiKey: 'xxx', // you can create an API key at https://id.atlassian.com/manage-profile/security/api-tokens
+        siteName: 'xxx', // the subdomain of your Jira site: <siteName>.atlassian.net
+        username: 'xxx', // the e-mail of your Atlassian account
+        apiKey: 'xxx', // an API token without scopes, from the same page (a Bitbucket-scoped token is rejected by Jira)
     },
     projects: projects,
 };

--- a/docs/superpowers/plans/2026-09-10-remove-unused.md
+++ b/docs/superpowers/plans/2026-09-10-remove-unused.md
@@ -1,0 +1,442 @@
+# Remove What Nothing Uses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the dependencies, the endpoint, the exports, the methods, the config fields and the file that nothing uses, and make the documentation follow (#41).
+
+**Architecture:** Pure removals. The server keeps `express`, `node-cache` and `node-diff3` and uses the `fetch` built into Node; the sync-statuses endpoint keeps the conflict computation it needs; the frontend loses two multi-select methods and two render leftovers. The server test gains one check (the removed route answers 404).
+
+**Tech Stack:** Node 24 (built-in `fetch`), Express 5, `node:test`.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-remove-unused-design.md`
+
+**Branch:** `claude/remove-unused`, created from `claude/serve-readme-route` (already checked out). Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay
+```
+
+**CRLF:** `index.mjs`, `cache.mjs`, `public/multi-select.js` and `package-lock.json` use CRLF line endings on every line. After editing one of them, check `grep -c $'\r' <file>` equals `wc -l < <file>` and that `git diff --stat <file>` reports only the lines you meant to change; if the whole file shows as changed, restore the endings with `perl -pi -e 's/\r?\n/\r\n/' <file>` and check again. The other files use LF.
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (76 tests before this plan, 77 after Task 2). The server test starts the server in fixture mode on `PORT=0`; never start the server yourself on a fixed port (3000 and 3100 are taken on this machine; 3101 is for the controller's manual checks).
+
+---
+
+### Task 1: The three dependencies
+
+**Files:**
+- Modify: `package.json` (dependencies), `package-lock.json` (CRLF, rewritten by npm)
+- Modify: `index.mjs:1-22` (CRLF; the imports and `dotenv.config()`)
+
+- [ ] **Step 1: Uninstall**
+
+Run: `npm uninstall fetch node-fetch dotenv`
+Expected: `package.json` keeps `express`, `node-cache` and `node-diff3` only; `package-lock.json` loses the entries of `fetch`, `node-fetch`, `dotenv` and of the packages only they depended on (`biskviit`, `encoding`, `data-uri-to-buffer`, `fetch-blob`, `formdata-polyfill`, `web-streams-polyfill`; `iconv-lite` and `safer-buffer` may stay, Express needs them).
+
+- [ ] **Step 2: Restore the CRLF endings of the lock file**
+
+Run: `perl -pi -e 's/\r?\n/\r\n/' package-lock.json; grep -c $'\r' package-lock.json; wc -l < package-lock.json; git diff --stat package-lock.json package.json`
+Expected: the two counts are equal; the lock file shows removed lines and no added block other than what npm rewrote for the root package; `package.json` shows three removed lines.
+
+- [ ] **Step 3: Drop the imports in index.mjs**
+
+Remove these three lines (and the blank line that follows `dotenv.config();`):
+
+```js
+import fetch from 'node-fetch';
+```
+
+```js
+import dotenv from 'dotenv';
+```
+
+```js
+dotenv.config();
+```
+
+The file starts with `import express from 'express';` followed by `import { diff3Merge } from 'node-diff3';`; the `fetch(url, options)` call in `atlassianFetch` now resolves to the global one. Check the CRLF endings (plan header).
+
+- [ ] **Step 4: Run the tests and list the dependencies**
+
+Run: `npm test && npm ls --depth=0`
+Expected: `ℹ tests 76`, `ℹ fail 0` (the server test starts the server, which proves the imports resolve); `npm ls` lists `express`, `node-cache`, `node-diff3` and nothing else, without `UNMET` or `extraneous`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json index.mjs
+git commit -m "chore: drop node-fetch, dotenv and the unused fetch package (#41)
+
+The server uses the fetch built into Node (20.11 or later); PORT works
+without dotenv and nothing documented a .env file; fetch was never
+imported.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 2: The conflicts endpoint, the dead cache exports, the duplicate auth header
+
+**Files:**
+- Modify: `test/server.test.mjs` (one test)
+- Modify: `index.mjs` (CRLF): the import list at the top, the `fetchJiraSprints` function, the `/api/pull-request-conflicts/:repoName/:spec` route
+- Modify: `cache.mjs` (CRLF): `CACHE_KEYS`, `getCachedSprints`, `clearCache`, `clearAllCache`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/server.test.mjs`:
+
+```js
+test('the per-pull-request conflicts endpoint is gone, the sync statuses endpoint stays', async () => {
+    const conflicts = await fetch(`${baseUrl}/api/pull-request-conflicts/products.secollab/abc..def`);
+    assert.equal(conflicts.status, 404);
+    const statuses = await fetch(`${baseUrl}/api/sync-statuses/OSLC`);
+    assert.equal(statuses.status, 200);
+    assert.equal(typeof (await statuses.json()).statuses, 'object');
+});
+```
+
+- [ ] **Step 2: Run the test to see it fail**
+
+Run: `npm test`
+Expected: the new test fails on the first assertion: the route still exists and answers 500 in fixture mode (its conflict computation cannot reach Atlassian), not 404.
+
+- [ ] **Step 3: Remove the route and the duplicate header in index.mjs**
+
+Delete this whole block:
+
+```js
+app.get('/api/pull-request-conflicts/:repoName/:spec', async (req, res) => {
+    const { repoName, spec } = req.params;
+
+    try {
+        const conflictsData = await getCachedConflicts(repoName, spec, () => {
+            return conflictsLimiter(() => computeConflicts(repoName, spec));
+        });
+
+        res.json(conflictsData);
+    } catch (error) {
+        if (error instanceof RateLimitError) {
+            res.status(503).json({ error: error.message, rateLimitedUntil: new Date(rateLimitedUntil).toISOString() });
+            return;
+        }
+        log(`Error fetching conflicts for commits ${spec}: ${error.message}`, errorLogStream);
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+});
+```
+
+(and the blank line that followed it). In the import list at the top of the file, delete the line `    getCachedSprints,`. In `fetchJiraSprints`, delete its first line:
+
+```js
+    const jiraAuth = Buffer.from(`${config.jira.username}:${config.jira.apiKey}`).toString('base64');
+```
+
+(the module-level `jiraAuth` is identical and stays). Check the CRLF endings.
+
+- [ ] **Step 4: Remove the dead exports in cache.mjs**
+
+Delete the line `    SPRINTS: (projectName) => \`sprints_${projectName}\`,` from `CACHE_KEYS`, and delete these three functions with their JSDoc comments:
+
+```js
+/**
+ * Get sprints data from cache or fetch from source
+ * @param {string} projectName - Project identifier
+ * @param {function} fetchSprints - Function to fetch sprints if cache miss
+ * @returns {Promise<Array>} Sprints data
+ */
+export async function getCachedSprints(projectName, fetchSprints) {
+    return getOrSetCache(CACHE_KEYS.SPRINTS(projectName), fetchSprints, 600); // 10 minutes TTL
+}
+```
+
+```js
+/**
+ * Clear specific cache entry
+ * @param {string} key - Cache key to clear
+ */
+export function clearCache(key) {
+    cache.del(key);
+}
+
+/**
+ * Clear all cache entries
+ */
+export function clearAllCache() {
+    cache.flushAll();
+}
+```
+
+The file keeps `getCachedProjects`, `getCachedProjectData`, `getCachedConflicts`, `getCachedSyncStatuses`, `raiseAllCacheTtls` and `getCacheStats`, each separated by one blank line as before. Check the CRLF endings.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: `ℹ tests 77`, `ℹ fail 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add index.mjs cache.mjs test/server.test.mjs
+git commit -m "chore: remove the per-pull-request conflicts endpoint and the cache exports nothing calls (#41)
+
+The SYNC load has used /api/sync-statuses/:project since 2.1.0. The
+sprints are fetched with the project data: the separate sprint cache
+was never wired, and clearCache/clearAllCache had no caller.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 3: Frontend leftovers, the config template, start.bat
+
+**Files:**
+- Modify: `public/multi-select.js` (CRLF): `toggle`, `getOptions`, `setDisabled`
+- Modify: `public/styles.css` (the `.multi-select.disabled` rule, around line 553)
+- Modify: `public/app-render.js`: `getBranchUrl` (around line 86) and its call (around line 104), `resolvedIssuesAlert` (around lines 206, 221, 227)
+- Modify: `config.js.default`
+- Delete: `start.bat`
+
+- [ ] **Step 1: multi-select.js**
+
+Delete the `getOptions` method:
+
+```js
+    getOptions() {
+        return this.options;
+    }
+
+```
+
+and the `setDisabled` method:
+
+```js
+    setDisabled(disabled) {
+        if (disabled) {
+            this.element.classList.add('disabled');
+            this.close();
+        } else {
+            this.element.classList.remove('disabled');
+        }
+    }
+
+```
+
+Nothing adds the `disabled` class any more, so replace the body of `toggle()`
+
+```js
+    toggle() {
+        if (this.element.classList.contains('disabled')) {
+            return;
+        }
+
+        if (this.element.classList.contains('open')) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+```
+
+with
+
+```js
+    toggle() {
+        if (this.element.classList.contains('open')) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+```
+
+Check the CRLF endings.
+
+- [ ] **Step 2: styles.css**
+
+Delete the rule (and its blank line) that starts with `.multi-select.disabled .multi-select-trigger {` (around line 553); read the rule first to remove exactly that block.
+
+- [ ] **Step 3: app-render.js**
+
+Replace
+
+```js
+// Helper function to get branch URL from Bitbucket
+function getBranchUrl(repoName, branchName, pullRequest) {
+    // Use the repository links from any pull request to get the base URL
+    const baseUrl = pullRequest.source.repository.links.html.href;
+    return `${baseUrl}/branch/${encodeURIComponent(branchName)}`;
+}
+```
+
+with
+
+```js
+// The Bitbucket URL of a branch, from the repository links of one of its pull requests
+function getBranchUrl(branchName, pullRequest) {
+    const baseUrl = pullRequest.source.repository.links.html.href;
+    return `${baseUrl}/branch/${encodeURIComponent(branchName)}`;
+}
+```
+
+and its call
+
+```js
+            const branchUrl = getBranchUrl(rootPullRequests[0].source.repository.name, rootBranch, rootPullRequests[0]);
+```
+
+with
+
+```js
+            const branchUrl = getBranchUrl(rootBranch, rootPullRequests[0]);
+```
+
+In `renderPullRequest`, delete the line `        let resolvedIssuesAlert = '';` (and the blank line before it, so that `sameStatusIcon` is followed directly by `jiraIssuesHtml = ...`), change `        if (sameStatusIcon || noOtherParticipantsAlert || resolvedIssuesAlert) {` to `        if (sameStatusIcon || noOtherParticipantsAlert) {`, and delete the line `                        ${resolvedIssuesAlert}` inside the warnings template.
+
+- [ ] **Step 4: config.js.default and start.bat**
+
+In `config.js.default`, delete the two lines
+
+```js
+        repoName: 'xxx' // for us was products.secollab
+```
+
+```js
+        issuesRegex: /(XXX-\d+)/g // for us was replacing XXX with SECOLLAB
+```
+
+so the `bitbucket` block ends with the `workspace` line and the `jira` block with the `apiKey` line (a trailing comma on those lines is fine). Then `git rm start.bat`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: `ℹ tests 77`, `ℹ fail 0` (the render tests check the branch URL and the warnings by substring).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/multi-select.js public/styles.css public/app-render.js config.js.default start.bat
+git commit -m "chore: remove the multi-select methods, the render leftovers, the config fields and start.bat nothing uses (#41)
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 4: Version 2.6.0 and the documentation
+
+**Files:**
+- Modify: `package.json:3`
+- Modify: `README.md` (Installation, Changelog)
+- Modify: `CLAUDE.md` (version, technology stack, project structure, index.mjs and cache.mjs descriptions, API endpoints)
+- Modify: `PRD.md` (F8.5, 7.2, 7.4, 7.5, 13 risks)
+
+- [ ] **Step 1: package.json**
+
+Set `"version": "2.6.0"` (the `releaseDate` stays `2026-09-10`).
+
+- [ ] **Step 2: README.md**
+
+Replace the Installation bullet
+
+```
+* Open a terminal (we are assuming here you have `nodejs` and `npm` installed)
+```
+
+with
+
+```
+* Open a terminal (Node.js 20.11 or later and `npm` are assumed to be installed; the server uses the `fetch` built into Node)
+```
+
+Insert right after the line `## Changelog:` (before `* Version 2.5.2`):
+
+```
+* Version 2.6.0
+    * Removed what nothing used (#41)
+        * The `/api/pull-request-conflicts/:repoName/:spec` endpoint: the SYNC load has used `/api/sync-statuses/:project` since 2.1.0
+        * The `node-fetch`, `dotenv` and `fetch` dependencies: the server uses the `fetch` built into Node (20.11 or later), `PORT` is read from the environment as before
+        * The sprint cache that was never wired (the sprints are fetched with the project data), the `clearCache` and `clearAllCache` exports, two multi-select methods, the `repoName` and `issuesRegex` fields of `config.js.default`, `start.bat` (`npm start` does the same)
+```
+
+- [ ] **Step 3: CLAUDE.md**
+
+1. `Current version: **2.5.2** (as of 2026-09-10)` becomes `Current version: **2.6.0** (as of 2026-09-10)`.
+2. In "Technology Stack / Backend", replace the four lines
+
+```
+- **Framework**: Express.js (v4.19.2)
+- **HTTP Client**: node-fetch (v3.3.2)
+- **Caching**: node-cache (v5.1.2)
+- **Configuration**: dotenv (v16.4.5)
+```
+
+with
+
+```
+- **Framework**: Express.js (v5.2.1)
+- **HTTP Client**: the `fetch` built into Node.js (20.11 or later)
+- **Caching**: node-cache (v5.1.2)
+- **Three-way merge**: node-diff3 (v3.2.1), for the conflict computation
+```
+
+3. In "Project Structure", delete the line `├── start.bat              # Windows startup script`.
+4. In the `**index.mjs**` bullets, replace `- API endpoint definitions (`/api/projects`, `/api/pull-requests/:project`, `/api/pull-request-conflicts/:repoName/:spec`)` with `- API endpoint definitions (`/api/version`, `/api/projects`, `/api/pull-requests/:project`, `/api/sync-statuses/:project`, `/api/cache/stats`)`.
+5. In the `**cache.mjs**` bullets, delete the line `  - Sprints: 600 seconds (10 minutes)` and add after the TTL list: `- The sprints are fetched with the project data and cached with it (no separate cache)`.
+6. In "API Endpoints", delete the whole `### GET /api/pull-request-conflicts/:repoName/:spec` section (heading, parameters, response, up to the line before `### GET /api/sync-statuses/:project`).
+7. In "Initial Setup", step 7 `Run \`node index.mjs\`` stays; in "Development Workflows" nothing else mentions the removed items.
+
+- [ ] **Step 4: PRD.md**
+
+1. Line `- F8.5: Cache sprint data (10-minute TTL)` becomes `- F8.5: Sprints are fetched and cached with the project data (no separate cache)`.
+2. In "7.2 Technology Stack / Backend", replace
+
+```
+- **Framework:** Express.js v4.19.2
+- **HTTP Client:** node-fetch v3.3.2
+- **Caching:** node-cache v5.1.2
+- **Configuration:** dotenv v16.4.5
+```
+
+with
+
+```
+- **Framework:** Express.js v5.2.1
+- **HTTP Client:** the `fetch` built into Node.js 20.11 or later
+- **Caching:** node-cache v5.1.2
+- **Three-way merge:** node-diff3 v3.2.1 (conflict computation)
+```
+
+3. In "7.4 Caching Strategy", delete the line `- Sprints: 600 seconds`.
+4. In the "7.5 API Endpoints" table, replace the row `| \`/api/pull-request-conflicts/:repo/:spec\` | GET | 300s | Merge conflict detection |` with `| \`/api/sync-statuses/:project\` | GET | 300s | SYNC (conflict) status of every open pull request, loaded on demand |`.
+5. Around line 711, the risk line that reads `Cache sprint data for 10 minutes...` (read it first): reword it to say the sprints are cached with the project data (2 minutes), keeping the rest of the sentence.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: `ℹ tests 77`, `ℹ fail 0` (the server test compares `/api/version` with package.json).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json README.md CLAUDE.md PRD.md
+git commit -m "docs: version 2.6.0, the removals of #41
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 5 (controller): verification and pull request
+
+- [ ] `npm test` ends with `ℹ fail 0` and 77 tests; `npm ls --depth=0` lists three dependencies.
+- [ ] `PORT=3101 node index.mjs --fixtures` in the background: `curl -si localhost:3101/api/pull-request-conflicts/x/a..b | head -1` answers 404, `curl -s localhost:3101/api/sync-statuses/OSLC | head -c 80` answers JSON; the page and a multi-select work in the browser; stop the server.
+- [ ] One real request through the built-in `fetch`: `PORT=3102 node index.mjs` (real `config.js`), `curl -s -m 120 localhost:3102/api/pull-requests/OSLC | head -c 200` answers JSON, `tail -3 error.log` shows no new line; stop the server.
+- [ ] Push the branch and open the pull request with base `claude/serve-readme-route`, `Closes #41`.

--- a/docs/superpowers/plans/2026-09-10-remove-unused.md
+++ b/docs/superpowers/plans/2026-09-10-remove-unused.md
@@ -390,7 +390,7 @@ with
 4. In the `**index.mjs**` bullets, replace `- API endpoint definitions (`/api/projects`, `/api/pull-requests/:project`, `/api/pull-request-conflicts/:repoName/:spec`)` with `- API endpoint definitions (`/api/version`, `/api/projects`, `/api/pull-requests/:project`, `/api/sync-statuses/:project`, `/api/cache/stats`)`.
 5. In the `**cache.mjs**` bullets, delete the line `  - Sprints: 600 seconds (10 minutes)` and add after the TTL list: `- The sprints are fetched with the project data and cached with it (no separate cache)`.
 6. In "API Endpoints", delete the whole `### GET /api/pull-request-conflicts/:repoName/:spec` section (heading, parameters, response, up to the line before `### GET /api/sync-statuses/:project`).
-7. In "Initial Setup", step 7 `Run \`node index.mjs\`` stays; in "Development Workflows" nothing else mentions the removed items.
+7. In "Initial Setup", step 7 `Run \`node index.mjs\`` stays (the review round then changed it to `npm start`); in "Development Workflows" nothing else mentions the removed items.
 
 - [ ] **Step 4: PRD.md**
 

--- a/docs/superpowers/plans/2026-09-10-serve-readme-route.md
+++ b/docs/superpowers/plans/2026-09-10-serve-readme-route.md
@@ -1,0 +1,249 @@
+# Serve README.md Through One Route Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the static middleware mounted on the project directory (which serves `config.js`, the logs and the sources) with one route that sends `README.md`, proven by a test that runs the server.
+
+**Architecture:** `index.mjs` keeps `express.static('public')` and gets `app.get('/README.md', ...)` with `res.sendFile`; the root `express.static(__dirname, ...)` goes. The listen callback logs `server.address().port` so the server can run on `PORT=0`. A new `test/server.test.mjs` spawns `node index.mjs --fixtures` with `PORT=0`, reads the port from stdout and checks what is served.
+
+**Tech Stack:** Node 24 (global `fetch`, `import.meta.dirname`), Express 5, `node:test`. No frontend change.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-serve-readme-route-design.md`
+
+**Branch:** `claude/serve-readme-route`, created from `master` (already checked out). Do not `git add` `config.js`, `config.js.test` or `.claude/`; add files by name. Commit messages end with:
+
+```
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay
+```
+
+**CRLF:** `index.mjs` uses CRLF line endings on every line (800 lines, 800 carriage returns). After editing it, check `grep -c $'\r' index.mjs` equals `wc -l < index.mjs` and that `git diff --stat index.mjs` reports about 15 changed lines; if the whole file shows as changed, restore the endings with `perl -pi -e 's/\r?\n/\r\n/' index.mjs` and check again. New files (the test) use LF like the other tests.
+
+**Running the unit tests:** `npm test`, expected to end with `ℹ fail 0` (73 tests before this plan, 76 after). The server test appends a few lines to `access.log` and `performance.log` in the project directory (the server opens its logs there); this is accepted by the spec.
+
+---
+
+### Task 1: The regression test, then the route
+
+**Files:**
+- Create: `test/server.test.mjs`
+- Modify: `index.mjs:46-53` (static middlewares) and `index.mjs:796-801` (listen)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/server.test.mjs`:
+
+```js
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Runs the server in fixture mode on an ephemeral port and checks what it
+ * serves: the app, the API, README.md for the help modal, and nothing else
+ * from the project directory (config.js holds the credentials).
+ */
+
+const root = path.resolve(import.meta.dirname, '..');
+let server;
+let baseUrl;
+
+before(async () => {
+    server = spawn(process.execPath, ['index.mjs', '--fixtures'], {
+        cwd: root,
+        env: { ...process.env, PORT: '0' },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    baseUrl = await new Promise((resolve, reject) => {
+        let output = '';
+        server.stdout.on('data', chunk => {
+            output += chunk;
+            const match = output.match(/Server is running at (http:\/\/localhost:\d+)/);
+            if (match) resolve(match[1]);
+        });
+        server.stderr.on('data', chunk => { output += chunk; });
+        server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
+        setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
+    });
+});
+
+after(() => {
+    if (server) server.kill();
+});
+
+test('README.md is served for the help modal', async () => {
+    const response = await fetch(`${baseUrl}/README.md`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /^text\/markdown/);
+    assert.equal(await response.text(), readFileSync(path.join(root, 'README.md'), 'utf8'));
+});
+
+test('no other file of the project directory is served', async () => {
+    const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+    for (const file of files) {
+        const response = await fetch(`${baseUrl}/${file}`);
+        assert.equal(response.status, 404, `${file} must not be served`);
+    }
+});
+
+test('the app and the API still answer', async () => {
+    const page = await fetch(`${baseUrl}/`);
+    assert.equal(page.status, 200);
+    assert.match(page.headers.get('content-type'), /^text\/html/);
+    const version = await (await fetch(`${baseUrl}/api/version`)).json();
+    const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+    assert.equal(version.version, packageJson.version);
+});
+```
+
+- [ ] **Step 2: Run the test to see it fail**
+
+Run: `npm test`
+Expected: `test/server.test.mjs` fails. With the current `index.mjs` the startup log prints `http://localhost:0` (the `PORT` string, not the bound port), so the `before` hook resolves a URL on port 0 and every fetch fails with a connection error; that is the failure to expect. (Once Step 3 logs the real port and before the middleware is removed, the failure would be `config.js must not be served`: 200 instead of 404.)
+
+- [ ] **Step 3: Replace the root static middleware with the route, log the bound port**
+
+In `index.mjs`, replace
+
+```js
+// Serve all files in the public folder
+app.use(express.static('public'));
+
+// Serve README.md from the root directory
+app.use(express.static(__dirname, {
+    index: false, // Prevent serving index.html from root
+    extensions: ['md'] // Allow serving .md files without extension
+}));
+```
+
+with
+
+```js
+// Serve all files in the public folder
+app.use(express.static('public'));
+
+// The help modal fetches the README from the root. This route is the only
+// thing served from the project directory: a static middleware mounted on it
+// served config.js (the credentials), the logs and the sources too.
+app.get('/README.md', (req, res) => {
+    res.sendFile(path.join(__dirname, 'README.md'));
+});
+```
+
+and replace the listen block at the end of the file
+
+```js
+app.listen(port, () => {
+    log(`Server is running at http://localhost:${port}`, accessLogStream);
+    if (fixtureSource) {
+        log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
+    }
+});
+```
+
+with
+
+```js
+const server = app.listen(port, () => {
+    // The port actually bound: PORT=0 lets the OS pick one (the server test does that)
+    log(`Server is running at http://localhost:${server.address().port}`, accessLogStream);
+    if (fixtureSource) {
+        log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
+    }
+});
+```
+
+Keep the CRLF endings (see the header of this plan).
+
+- [ ] **Step 4: Run the tests to see them pass**
+
+Run: `npm test`
+Expected: `ℹ tests 76`, `ℹ fail 0`.
+
+- [ ] **Step 5: Check the diff**
+
+Run: `grep -c $'\r' index.mjs; wc -l < index.mjs; git diff --stat`
+Expected: the two counts are equal; `index.mjs` shows about 15 changed lines and no other tracked file changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add index.mjs test/server.test.mjs
+git commit -m "fix: serve README.md through one route, the project directory is no longer served (#40)
+
+The static middleware mounted on the project directory served config.js
+(the Bitbucket and Jira credentials), the logs and the sources to anyone
+who could reach the port. The startup log now shows the port actually
+bound, so the new server test can run on PORT=0.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 2: Version 2.5.2 and the documentation
+
+**Files:**
+- Modify: `package.json:3` (version)
+- Modify: `README.md` (changelog, after the `## Changelog:` line)
+- Modify: `CLAUDE.md` (version line, `index.mjs` description, security considerations, testing approach)
+- Modify: `PRD.md` (6.5 Security)
+
+- [ ] **Step 1: package.json**
+
+Set `"version": "2.5.2"` (the `releaseDate` stays `2026-09-10`).
+
+- [ ] **Step 2: README changelog**
+
+Insert right after the line `## Changelog:` (before `* Version 2.5.1`):
+
+```
+* Version 2.5.2
+    * `README.md` is served by a dedicated route; the static middleware that served it from the project directory also served `config.js` (the Bitbucket and Jira credentials), the logs and the sources to anyone who could reach the port (#40)
+    * The startup log shows the port actually bound, so `PORT=0` reports the port the OS picked
+    * `npm test` starts the server in fixture mode and checks what it serves from the project directory
+```
+
+- [ ] **Step 3: CLAUDE.md**
+
+Four edits:
+
+1. `Current version: **2.5.1** (as of 2026-09-10)` becomes `Current version: **2.5.2** (as of 2026-09-10)`.
+2. In the `**index.mjs**` bullet list of "Key Files Explained", replace `- Static file serving for public directory` with `- Static file serving for the public directory; `README.md` is served through a dedicated route (the help modal fetches it) and nothing else of the project directory is reachable over HTTP`.
+3. In "Security Considerations", add after the `**No input validation**` bullet: `- **Only public/ and README.md are served**: never mount a static middleware on the project directory, it would serve config.js, the logs and the sources (fixed in 2.5.2); `test/server.test.mjs` checks it`.
+4. In "Testing Approach", the `**Unit tests**` bullet ends with `and the fixture generator (volumes, determinism, deep stack, hierarchy); no DOM, no extra dependency`; append `; `test/server.test.mjs` starts the server in fixture mode on an ephemeral port (`PORT=0`) and checks what it serves (the app, the API, `README.md`, nothing else of the project directory)` before the final period of that sentence, i.e. the bullet ends with `no DOM, no extra dependency; `test/server.test.mjs` starts the server ... of the project directory)`.
+
+- [ ] **Step 4: PRD.md**
+
+In `### 6.5 Security`, add after the NFR-SEC4 line:
+
+```
+- **NFR-SEC5**: Only the `public/` directory and `README.md` are served over HTTP; no other file of the project directory (configuration, logs, sources) is reachable
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test`
+Expected: `ℹ tests 76`, `ℹ fail 0` (the server test compares `/api/version` with package.json, so the bump must be consistent).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json README.md CLAUDE.md PRD.md
+git commit -m "docs: version 2.5.2, README.md served through one route (#40)
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay"
+```
+
+---
+
+### Task 3 (controller): verification and pull request
+
+- [ ] `npm test` ends with `ℹ fail 0` and 76 tests.
+- [ ] `PORT=3101 node index.mjs --fixtures` in the background; `curl -sI localhost:3101/config.js` answers `404`, `curl -sI localhost:3101/README.md` answers `200` with `text/markdown`, `curl -sI localhost:3101/access.log` answers `404`; stop the server.
+- [ ] Push the branch and open the pull request to `master` with `Closes #40`.

--- a/docs/superpowers/specs/2026-09-10-remove-unused-design.md
+++ b/docs/superpowers/specs/2026-09-10-remove-unused-design.md
@@ -1,0 +1,101 @@
+# Remove what nothing uses
+
+**Date:** 2026-09-10
+**Issue:** #41
+**Target version:** 2.6.0
+**Status:** Decided in an autonomous session, without a review round (the user asked for the brainstorm to be done alone); every removal below was verified twice by searching the repository (the review of 2026-09-10, then an independent search by a subagent); section 2 lists the decisions to revisit
+
+## 1. Goal
+
+Delete the code, dependencies and files that have no caller and no reader,
+and make the documentation follow. Nothing observable changes for the user of
+the dashboard, except that an endpoint the frontend never called disappears.
+
+## 2. Decisions
+
+1. **Three dependencies go.** `fetch` (1.1.0) is never imported. `node-fetch`
+   is replaced by the `fetch` built into Node: the server only uses
+   `response.ok`, `status`, `statusText`, `json()`, `text()`, `arrayBuffer()`
+   and the request options `method`, `headers` and `signal`
+   (`AbortSignal.timeout`), all identical on the built-in one. `dotenv` only
+   ever loaded a `.env` file that nothing documents, for the single `PORT`
+   variable, which `PORT=3100 node index.mjs` sets without it. The README
+   states the requirement that replaces them: Node.js 20.11 or later (the
+   server test already uses `import.meta.dirname`). No `engines` field: the
+   README sentence is enough for a tool run from a checkout.
+2. **The per-pull-request conflicts endpoint goes.** `GET
+   /api/pull-request-conflicts/:repoName/:spec` has had no caller since the
+   SYNC load moved to `/api/sync-statuses/:project` (2.1.0). The route and its
+   documentation are removed; `getCachedConflicts`, `conflictsLimiter` and
+   `computeConflicts` stay, the sync-statuses endpoint uses them per pull
+   request. The server test checks the route answers 404 and the sync-statuses
+   one still answers.
+3. **The sprint cache is deleted, not wired.** `getCachedSprints` was imported
+   and never called: the sprints have always been fetched with the project
+   data, every build, and they are part of `dataHash`. Wiring a separate
+   10-minute cache would save two or three Jira calls per build and delay a
+   new sprint by up to ten minutes; the calls that matter for the rate limit
+   are the commit counts (two per pull request), so the simpler option wins:
+   the function, its key and the documented TTL go. `clearCache` and
+   `clearAllCache` go with them (no caller).
+4. **Frontend leftovers.** `MultiSelect.getOptions` and `setDisabled` have no
+   caller; with `setDisabled` gone nothing ever adds the `disabled` class, so
+   the guard in `toggle()` and the `.multi-select.disabled` rule in the
+   stylesheet go too. In `app-render.js`, `resolvedIssuesAlert` is always the
+   empty string (removed with its slot in the warnings block) and
+   `getBranchUrl` loses the first parameter it never read.
+5. **Repository files.** `config.js.default` loses `bitbucket.repoName` and
+   `jira.issuesRegex` (unread since the project definitions moved to
+   `projects.js`); `start.bat` (`node index.mjs`) goes, `npm start` does the
+   same on every platform. `fetchJiraSprints` loses the `jiraAuth` it
+   recomputed identically to the module-level one.
+6. **Version 2.6.0:** a public endpoint is removed, so a minor bump rather than
+   a patch; no feature.
+
+## 3. Out of scope
+
+- `getCachedSyncStatuses`, a second copy of `getOrSetCache` for a dynamic
+  TTL: it has a caller, and folding it is a redesign of the cache API.
+- The other small duplications noted by the review (`handleTextFilterInput`
+  next to `handleFilterChange`, the initial `reloadInterval = 100`): they are
+  used code, not unused code; #42 or a later pass.
+- The sprint-issue pagination bug and the per-project `lastResponse`
+  (reported separately, not filed yet).
+
+## 4. Behaviour
+
+- `GET /api/pull-request-conflicts/:repoName/:spec`: 404 (was 200/503/500).
+- `npm ci` installs `express`, `node-cache`, `node-diff3` and their
+  dependencies only.
+- Everything else, including the SYNC load, the multi-selects and the tree,
+  behaves as before.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `package.json`, `package-lock.json` (CRLF) | `fetch`, `node-fetch`, `dotenv` removed (`npm uninstall`), version 2.6.0 |
+| `index.mjs` (CRLF) | the two imports and `dotenv.config()`, the conflicts route, the `getCachedSprints` import, the local `jiraAuth` |
+| `cache.mjs` (CRLF) | `CACHE_KEYS.SPRINTS`, `getCachedSprints`, `clearCache`, `clearAllCache` |
+| `public/multi-select.js` (CRLF) | `getOptions`, `setDisabled`, the `disabled` guard of `toggle` |
+| `public/styles.css` | the `.multi-select.disabled .multi-select-trigger` rule |
+| `public/app-render.js` | `resolvedIssuesAlert`, `getBranchUrl(branchName, pullRequest)` |
+| `config.js.default` | `repoName`, `issuesRegex` |
+| `start.bat` | deleted |
+| `test/server.test.mjs` | the conflicts route answers 404, the sync-statuses route answers |
+| `README.md`, `CLAUDE.md`, `PRD.md` | Node requirement, changelog, stack, endpoints, cache TTLs, project structure, F8.5 |
+
+## 6. Verification
+
+`npm test` (77 tests). `npm ls --depth=0` lists three dependencies. On the
+fixture server (`PORT=3101 node index.mjs --fixtures`): the conflicts route
+answers 404, `/api/sync-statuses/OSLC` answers 200, the page loads and the
+multi-selects open. One real request through the built-in `fetch`: a second
+instance started with the real `config.js` on a spare port answers
+`/api/pull-requests/OSLC` (the smaller project, the same calls the dashboard
+makes at every refresh), then is stopped; `error.log` shows no new line.
+
+## 7. Delivery
+
+Branch `claude/remove-unused` from `claude/serve-readme-route`, pull request
+stacked on #40's, closes #41.

--- a/docs/superpowers/specs/2026-09-10-remove-unused-design.md
+++ b/docs/superpowers/specs/2026-09-10-remove-unused-design.md
@@ -81,7 +81,7 @@ the dashboard, except that an endpoint the frontend never called disappears.
 
 | File | Change |
 |---|---|
-| `package.json`, `package-lock.json` (CRLF) | `fetch`, `node-fetch`, `dotenv` removed (`npm uninstall`), version 2.6.0 |
+| `package.json`, `package-lock.json` (CRLF) | `fetch`, `node-fetch`, `dotenv` removed (`npm uninstall`), version 2.6.0, `engines` |
 | `index.mjs` (CRLF) | the two imports and `dotenv.config()`, the conflicts route, the `getCachedSprints` import, the local `jiraAuth` |
 | `cache.mjs` (CRLF) | `CACHE_KEYS.SPRINTS`, `getCachedSprints`, `clearCache`, `clearAllCache` |
 | `public/multi-select.js` (CRLF) | `getOptions`, `setDisabled`, the `disabled` guard of `toggle` |
@@ -96,7 +96,7 @@ the dashboard, except that an endpoint the frontend never called disappears.
 
 `npm test` (77 tests). `npm ls --depth=0` lists three dependencies. On the
 fixture server (`PORT=3101 node index.mjs --fixtures`): the conflicts route
-answers 404, `/api/sync-statuses/OSLC` answers 200, the page loads and the
+answers 404, the sync-statuses route of the first project answers 200, the page loads and the
 multi-selects open. One real request through the built-in `fetch`: a second
 instance started with the real `config.js` on a spare port answers
 `/api/pull-requests/OSLC` (the smaller project, the same calls the dashboard

--- a/docs/superpowers/specs/2026-09-10-remove-unused-design.md
+++ b/docs/superpowers/specs/2026-09-10-remove-unused-design.md
@@ -21,8 +21,13 @@ the dashboard, except that an endpoint the frontend never called disappears.
    ever loaded a `.env` file that nothing documents, for the single `PORT`
    variable, which `PORT=3100 node index.mjs` sets without it. The README
    states the requirement that replaces them: Node.js 20.11 or later (the
-   server test already uses `import.meta.dirname`). No `engines` field: the
-   README sentence is enough for a tool run from a checkout.
+   server test already uses `import.meta.dirname`). `package.json` declares
+   the requirement in its `engines` field too (added after the code review:
+   without it an older Node fails at the first request with `fetch is not
+   defined`). The built-in `fetch` reports a network failure as "fetch failed"
+   with the reason in `error.cause`; `atlassianFetch` rethrows with the reason
+   and the URL in the message, so `error.log` keeps saying why (found by the
+   code review).
 2. **The per-pull-request conflicts endpoint goes.** `GET
    /api/pull-request-conflicts/:repoName/:spec` has had no caller since the
    SYNC load moved to `/api/sync-statuses/:project` (2.1.0). The route and its
@@ -47,8 +52,10 @@ the dashboard, except that an endpoint the frontend never called disappears.
 5. **Repository files.** `config.js.default` loses `bitbucket.repoName` and
    `jira.issuesRegex` (unread since the project definitions moved to
    `projects.js`); `start.bat` (`node index.mjs`) goes, `npm start` does the
-   same on every platform. `fetchJiraSprints` loses the `jiraAuth` it
-   recomputed identically to the module-level one.
+   same on every platform. Its comments now describe the credentials Atlassian
+   accepts today (account e-mail and scoped API token for Bitbucket, API token
+   for Jira), a finding of the code review. `fetchJiraSprints` loses the
+   `jiraAuth` it recomputed identically to the module-level one.
 6. **Version 2.6.0:** a public endpoint is removed, so a minor bump rather than
    a patch; no feature.
 

--- a/docs/superpowers/specs/2026-09-10-serve-readme-route-design.md
+++ b/docs/superpowers/specs/2026-09-10-serve-readme-route-design.md
@@ -1,0 +1,80 @@
+# Serve README.md through one route
+
+**Date:** 2026-09-10
+**Issue:** #40
+**Target version:** 2.5.2
+**Status:** Decided in an autonomous session, without a review round (the user asked for the brainstorm to be done alone); section 2 lists the decisions to revisit
+
+## 1. Goal
+
+The help modal fetches `README.md` from the server root. `index.mjs` serves it
+through a second `express.static` mounted on the project directory, and that
+middleware serves every non-dotfile of the checkout: `config.js` with the
+Bitbucket and Jira credentials, the three logs, the sources, `CLAUDE.md`
+(checked on a fixture server: HEAD `/config.js` answers 200 with the 798 bytes
+of the file). The server listens on all interfaces, so anyone who can reach the
+port can download the credentials. Replace the middleware with a route that
+sends `README.md` and nothing else, and keep a test that proves it.
+
+## 2. Decisions
+
+1. **One route.** `app.get('/README.md', ...)` answers with
+   `res.sendFile(path.join(__dirname, 'README.md'))`; the middleware
+   `express.static(__dirname, { index: false, extensions: ['md'] })` is
+   removed. Nothing else was fetched from the root: the frontend fetches
+   `README.md` (`fetchAndRenderReadme` in `app-shell.js`) and the `/api/*`
+   routes, and `public/` keeps its own static middleware.
+2. **Regression test.** `test/server.test.mjs` starts the server in fixture
+   mode on an ephemeral port and checks that `/README.md` answers 200 as
+   markdown with the content of the file, that `/config.js`,
+   `/config.js.default`, `/index.mjs`, `/cache.mjs`, `/package.json`,
+   `/access.log`, `/CLAUDE.md` and `/fixtures/generate.mjs` answer 404, and
+   that `/` and `/api/version` still answer. It is the first test that runs
+   the server. The server opens its log streams in the project directory, so a
+   test run appends a few lines to `access.log` and `performance.log` there,
+   as any run of the server does; accepted rather than adding a log-directory
+   option for the sake of a test.
+3. **The actual port in the startup log.** `app.listen` returns the server;
+   the startup line logs `server.address().port`, so `PORT=0` (the OS picks a
+   free port) reports the port actually bound, and the test reads it from
+   stdout. No other change to startup.
+4. **Version 2.5.2:** a fix, no feature, no API change.
+5. **Still bound to all interfaces.** Binding to `127.0.0.1` would be a
+   behaviour change for a dashboard used from another machine on the LAN; it
+   is left as a separate decision, noted in #40.
+
+## 3. Out of scope
+
+- Binding the server to `127.0.0.1`.
+- Making `express.static('public')` independent of the working directory.
+- Any change to the help modal or to the frontend.
+
+## 4. Behaviour
+
+- `GET /README.md`: 200, `Content-Type: text/markdown; charset=utf-8`, the
+  file as on disk.
+- `GET /config.js`, `/index.mjs`, `/package.json`, `/access.log`, `/CLAUDE.md`
+  and any other file of the project directory: 404 (Express default).
+- `GET /` (the app) and `/api/*`: unchanged.
+- Startup log: `Server is running at http://localhost:<port actually bound>`.
+
+## 5. Code structure
+
+| File | Change |
+|---|---|
+| `index.mjs` (CRLF file) | the route replaces the root static middleware; the listen callback logs the actual port |
+| `test/server.test.mjs` | new: starts the fixture server on port 0, checks the routes above |
+| `README.md`, `CLAUDE.md`, `PRD.md`, `package.json` | changelog 2.5.2, what is served from the project directory, NFR-SEC5, version |
+
+## 6. Verification
+
+`npm test`: the new test fails before the fix (`config.js` served with 200)
+and passes after; 76 tests. Manual, on a fixture server (`PORT=3101 node
+index.mjs --fixtures`): `curl -sI localhost:3101/config.js` answers 404,
+`curl -sI localhost:3101/README.md` answers 200 `text/markdown`, the help
+modal of the page still shows the README.
+
+## 7. Delivery
+
+Branch `claude/serve-readme-route` from `master`, pull request to `master`,
+closes #40. First of a stack: the branch of #41 starts from it.

--- a/index.mjs
+++ b/index.mjs
@@ -110,7 +110,16 @@ async function atlassianFetch(url, options) {
         throw new RateLimitError();
     }
 
-    const response = await fetch(url, options);
+    let response;
+    try {
+        response = await fetch(url, options);
+    } catch (error) {
+        // The fetch built into Node reports a network failure as "fetch failed" and
+        // keeps the reason (DNS, TLS, refused connection) in error.cause; the callers
+        // log error.message only, so the reason and the URL go into the message
+        const reason = error.cause ? `: ${error.cause.message}` : '';
+        throw new Error(`${error.message}${reason} (${url})`, { cause: error });
+    }
     if (response.status === 429) {
         await response.arrayBuffer().catch(() => {}); // release the socket
         noteRateLimit(url);
@@ -651,8 +660,8 @@ async function fetchBitbucketJson(url) {
     return response.json();
 }
 
-// Serializes conflict computations: a page load requests conflicts for every PR
-// at once, and each computation makes many Bitbucket calls of its own.
+// Serializes conflict computations: one SYNC load asks for every pull request of
+// a project at once, and each computation makes many Bitbucket calls of its own.
 function createLimiter(maxConcurrent) {
     let active = 0;
     const queue = [];

--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,5 @@
 import express from 'express';
-import fetch from 'node-fetch';
 import { diff3Merge } from 'node-diff3';
-import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
@@ -17,8 +15,6 @@ import {
     raiseAllCacheTtls
 } from './cache.mjs';
 import { parseFixtureOptions, fixtureConfig, createFixtureSource } from './fixtures/index.mjs';
-
-dotenv.config();
 
 // Fixture mode (--fixtures): generated data instead of Atlassian, no config.js needed
 const fixtureOptions = parseFixtureOptions();

--- a/index.mjs
+++ b/index.mjs
@@ -46,11 +46,12 @@ let lastResponse = null;
 // Serve all files in the public folder
 app.use(express.static('public'));
 
-// Serve README.md from the root directory
-app.use(express.static(__dirname, {
-    index: false, // Prevent serving index.html from root
-    extensions: ['md'] // Allow serving .md files without extension
-}));
+// The help modal fetches the README from the root. This route is the only
+// thing served from the project directory: a static middleware mounted on it
+// served config.js (the credentials), the logs and the sources too.
+app.get('/README.md', (req, res) => {
+    res.sendFile(path.join(__dirname, 'README.md'));
+});
 
 // Serve the version details
 app.get('/api/version', (req, res) => {
@@ -793,8 +794,9 @@ async function computeConflicts(repoName, spec) {
     return { conflicts };
 }
 
-app.listen(port, () => {
-    log(`Server is running at http://localhost:${port}`, accessLogStream);
+const server = app.listen(port, () => {
+    // The port actually bound: PORT=0 lets the OS pick one (the server test does that)
+    log(`Server is running at http://localhost:${server.address().port}`, accessLogStream);
     if (fixtureSource) {
         log(`Fixture mode: serving generated data for ${Object.keys(config.projects).join(', ')} (scale ${fixtureSource.scale}, deepest stack ${fixtureSource.chainDepth}), no Atlassian request will be made`, accessLogStream);
     }

--- a/index.mjs
+++ b/index.mjs
@@ -50,7 +50,12 @@ app.use(express.static('public'));
 // thing served from the project directory: a static middleware mounted on it
 // served config.js (the credentials), the logs and the sources too.
 app.get('/README.md', (req, res) => {
-    res.sendFile(path.join(__dirname, 'README.md'));
+    res.sendFile(path.join(__dirname, 'README.md'), error => {
+        if (!error) return;
+        // Without this callback Express would answer with the error and its absolute path
+        log(`Error serving README.md: ${error.message}`, errorLogStream);
+        if (!res.headersSent) res.status(404).send('Not Found');
+    });
 });
 
 // Serve the version details

--- a/index.mjs
+++ b/index.mjs
@@ -117,7 +117,9 @@ async function atlassianFetch(url, options) {
         // The fetch built into Node reports a network failure as "fetch failed" and
         // keeps the reason (DNS, TLS, refused connection) in error.cause; the callers
         // log error.message only, so the reason and the URL go into the message
-        const reason = error.cause ? `: ${error.cause.message}` : '';
+        // A refused or reset connection on a dual-stack host comes as an AggregateError with an empty message
+        const detail = error.cause && (error.cause.message || error.cause.code);
+        const reason = detail ? `: ${detail}` : '';
         throw new Error(`${error.message}${reason} (${url})`, { cause: error });
     }
     if (response.status === 429) {

--- a/index.mjs
+++ b/index.mjs
@@ -10,7 +10,6 @@ import {
     getCachedProjectData,
     getCachedConflicts,
     getCachedSyncStatuses,
-    getCachedSprints,
     getCacheStats,
     raiseAllCacheTtls
 } from './cache.mjs';
@@ -343,7 +342,6 @@ function calculateHash(data) {
 }
 
 async function fetchJiraSprints(jiraProjects) {
-    const jiraAuth = Buffer.from(`${config.jira.username}:${config.jira.apiKey}`).toString('base64');
     const sprints = new Set();
 
     for (const project of jiraProjects) {
@@ -633,25 +631,6 @@ app.get('/api/sync-statuses/:project', async (req, res) => {
             return;
         }
         log(`Error fetching sync statuses for project ${projectName}: ${error.message}`, errorLogStream);
-        res.status(500).json({ error: 'Internal Server Error' });
-    }
-});
-
-app.get('/api/pull-request-conflicts/:repoName/:spec', async (req, res) => {
-    const { repoName, spec } = req.params;
-
-    try {
-        const conflictsData = await getCachedConflicts(repoName, spec, () => {
-            return conflictsLimiter(() => computeConflicts(repoName, spec));
-        });
-
-        res.json(conflictsData);
-    } catch (error) {
-        if (error instanceof RateLimitError) {
-            res.status(503).json({ error: error.message, rateLimitedUntil: new Date(rateLimitedUntil).toISOString() });
-            return;
-        }
-        log(`Error fetching conflicts for commits ${spec}: ${error.message}`, errorLogStream);
         res.status(500).json({ error: 'Internal Server Error' });
     }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
   "name": "version",
-  "version": "2.0.0",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "version",
-      "version": "2.0.0",
+      "version": "2.5.2",
       "license": "Copyright François-Régis Jaunatre",
       "dependencies": {
-        "dotenv": "^17.2.3",
         "express": "^5.2.1",
-        "fetch": "^1.1.0",
         "node-cache": "^5.1.2",
-        "node-diff3": "^3.2.1",
-        "node-fetch": "^3.3.2"
+        "node-diff3": "^3.2.1"
       }
     },
     "node_modules/accepts": {
@@ -28,17 +25,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/biskviit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/biskviit/-/biskviit-1.0.1.tgz",
-      "integrity": "sha512-VGCXdHbdbpEkFgtjkeoBN8vRlbj1ZRX2/mxhE8asCCRalUx2nBzOomLJv8Aw/nRt5+ccDb+tPKidg4XxcfGW4w==",
-      "dependencies": {
-        "psl": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=1.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -166,14 +152,6 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -198,18 +176,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -239,14 +205,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha512-bl1LAgiQc4ZWr++pNYUdRe/alecaHFeHxIJ/pNciqGdKXghaTCOwKkbKp6ye7pKZGu/GcaSXFk8PBVhgs+dJdA==",
-      "dependencies": {
-        "iconv-lite": "~0.4.13"
       }
     },
     "node_modules/es-define-property": {
@@ -337,37 +295,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-5O8TwrGzoNblBG/jtK4NFuZwNCkZX6s5GfRNOaGtm+QGJEuNakSC/i2RW0R93KX6E0jVjNXm6O3CRN4Ql3K+yA==",
-      "dependencies": {
-        "biskviit": "1.0.1",
-        "encoding": "0.1.12"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -387,17 +314,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -519,17 +435,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -640,41 +545,6 @@
         "bun": ">=1.3.10"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -738,11 +608,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/qs": {
       "version": "6.14.1",
@@ -990,14 +855,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "releaseDate": "2026-09-10",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "keywords": [],
   "author": "François-Régis Jaunatre",
   "license": "Copyright François-Régis Jaunatre",
+  "engines": {
+    "node": ">=20.11"
+  },
   "dependencies": {
     "express": "^5.2.1",
     "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "version",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "releaseDate": "2026-09-10",
   "description": "Made with love, and with help from various AI systems (mostly Claude.ai though)",
   "main": "index.mjs",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,8 @@
   "author": "François-Régis Jaunatre",
   "license": "Copyright François-Régis Jaunatre",
   "dependencies": {
-    "node-cache": "^5.1.2",
-    "node-diff3": "^3.2.1",
-    "dotenv": "^17.2.3",
     "express": "^5.2.1",
-    "fetch": "^1.1.0",
-    "node-fetch": "^3.3.2"
+    "node-cache": "^5.1.2",
+    "node-diff3": "^3.2.1"
   }
 }
-

--- a/public/app-render.js
+++ b/public/app-render.js
@@ -99,7 +99,6 @@ function renderPullRequests(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
             rootPullRequests.sort((a, b) => new Date(b.updated_on) - new Date(a.updated_on));
             const totalPullRequestCount = calculateTotalPullRequests(rootPullRequests, pullRequestsByDestination);
 
-            // Get the branch URL using the first pull request's repository information
             const branchUrl = getBranchUrl(rootBranch, rootPullRequests[0]);
 
             html += `

--- a/public/app-render.js
+++ b/public/app-render.js
@@ -82,9 +82,8 @@ export function calculateTotalPullRequests(pullRequests, pullRequestsByDestinati
     return total;
 }
 
-// Helper function to get branch URL from Bitbucket
-function getBranchUrl(repoName, branchName, pullRequest) {
-    // Use the repository links from any pull request to get the base URL
+// The Bitbucket URL of a branch, from the repository links of one of its pull requests
+function getBranchUrl(branchName, pullRequest) {
     const baseUrl = pullRequest.source.repository.links.html.href;
     return `${baseUrl}/branch/${encodeURIComponent(branchName)}`;
 }
@@ -101,7 +100,7 @@ function renderPullRequests(pullRequests, jiraIssuesMap, jiraIssuesDetails, pull
             const totalPullRequestCount = calculateTotalPullRequests(rootPullRequests, pullRequestsByDestination);
 
             // Get the branch URL using the first pull request's repository information
-            const branchUrl = getBranchUrl(rootPullRequests[0].source.repository.name, rootBranch, rootPullRequests[0]);
+            const branchUrl = getBranchUrl(rootBranch, rootPullRequests[0]);
 
             html += `
                 <div class="root-branch">
@@ -203,8 +202,6 @@ function renderPullRequest(pullRequest, jiraIssuesMap, jiraIssuesDetails, pullRe
         let sameStatusIcon = uniqueJiraIssuesStatuses.size > 1 ?
             `<li><i class="fas fa-exclamation-triangle red" title="JIRA issues have different statuses"></i> JIRA issues have different statuses</li>` : '';
 
-        let resolvedIssuesAlert = '';
-
         jiraIssuesHtml = jiraIssuesDetailsForPullRequest.map(issueDetails => {
             const priority = issueDetails.fields.priority;
             const priorityHtml = priority ?
@@ -218,13 +215,12 @@ function renderPullRequest(pullRequest, jiraIssuesMap, jiraIssuesDetails, pullRe
                     </a></li>`;
         }).join('');
 
-        if (sameStatusIcon || noOtherParticipantsAlert || resolvedIssuesAlert) {
+        if (sameStatusIcon || noOtherParticipantsAlert) {
             alertsHtml = `
                 <div class="warnings">
                     <ul>
                         ${sameStatusIcon}
                         ${noOtherParticipantsAlert}
-                        ${resolvedIssuesAlert}
                     </ul>
                 </div>
             `;

--- a/public/multi-select.js
+++ b/public/multi-select.js
@@ -93,10 +93,6 @@ export class MultiSelect {
     }
 
     toggle() {
-        if (this.element.classList.contains('disabled')) {
-            return;
-        }
-
         if (this.element.classList.contains('open')) {
             this.close();
         } else {
@@ -132,10 +128,6 @@ export class MultiSelect {
         this.options = options;
         this.renderOptions();
         this.updateDisplay();
-    }
-
-    getOptions() {
-        return this.options;
     }
 
     setSelectedValues(values) {
@@ -229,15 +221,6 @@ export class MultiSelect {
         this.renderOptions();
         this.updateDisplay();
         this.notifyChange();
-    }
-
-    setDisabled(disabled) {
-        if (disabled) {
-            this.element.classList.add('disabled');
-            this.close();
-        } else {
-            this.element.classList.remove('disabled');
-        }
     }
 
     notifyChange() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -550,12 +550,6 @@ select:disabled {
     box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
-.multi-select.disabled .multi-select-trigger {
-    background-color: var(--surface-muted);
-    opacity: 0.7;
-    cursor: not-allowed;
-}
-
 .multi-select-display {
     flex: 1;
     overflow: hidden;

--- a/start.bat
+++ b/start.bat
@@ -1,1 +1,0 @@
-node index.mjs

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -28,6 +28,7 @@ before(async () => {
             if (match) resolve(match[1]);
         });
         server.stderr.on('data', chunk => { output += chunk; });
+        server.on('error', reject);
         server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
         setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
     });
@@ -45,8 +46,10 @@ test('README.md is served for the help modal', async () => {
 });
 
 test('no other file of the project directory is served', async () => {
+    // A literal `..` is normalised away by fetch itself, so only the encoded forms reach the server
     const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
-        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs',
+        '..%2fconfig.js', 'README.md%2f..%2fconfig.js'];
     for (const file of files) {
         const response = await fetch(`${baseUrl}/${file}`);
         assert.equal(response.status, 404, `${file} must not be served`);

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -70,6 +70,7 @@ test('the per-pull-request conflicts endpoint is gone, the sync statuses endpoin
     assert.equal(conflicts.status, 404);
     // The projects come from projects.js, which users replace with their own
     const [project] = await (await fetch(`${baseUrl}/api/projects`)).json();
+    assert.ok(project, 'no project configured');
     const statuses = await fetch(`${baseUrl}/api/sync-statuses/${encodeURIComponent(project)}`);
     assert.equal(statuses.status, 200);
     assert.equal(typeof (await statuses.json()).statuses, 'object');

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -66,9 +66,11 @@ test('the app and the API still answer', async () => {
 });
 
 test('the per-pull-request conflicts endpoint is gone, the sync statuses endpoint stays', async () => {
-    const conflicts = await fetch(`${baseUrl}/api/pull-request-conflicts/products.secollab/abc..def`);
+    const conflicts = await fetch(`${baseUrl}/api/pull-request-conflicts/some-repository/abc..def`);
     assert.equal(conflicts.status, 404);
-    const statuses = await fetch(`${baseUrl}/api/sync-statuses/OSLC`);
+    // The projects come from projects.js, which users replace with their own
+    const [project] = await (await fetch(`${baseUrl}/api/projects`)).json();
+    const statuses = await fetch(`${baseUrl}/api/sync-statuses/${encodeURIComponent(project)}`);
     assert.equal(statuses.status, 200);
     assert.equal(typeof (await statuses.json()).statuses, 'object');
 });

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -64,3 +64,11 @@ test('the app and the API still answer', async () => {
     const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
     assert.equal(version.version, packageJson.version);
 });
+
+test('the per-pull-request conflicts endpoint is gone, the sync statuses endpoint stays', async () => {
+    const conflicts = await fetch(`${baseUrl}/api/pull-request-conflicts/products.secollab/abc..def`);
+    assert.equal(conflicts.status, 404);
+    const statuses = await fetch(`${baseUrl}/api/sync-statuses/OSLC`);
+    assert.equal(statuses.status, 200);
+    assert.equal(typeof (await statuses.json()).statuses, 'object');
+});

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1,0 +1,63 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Runs the server in fixture mode on an ephemeral port and checks what it
+ * serves: the app, the API, README.md for the help modal, and nothing else
+ * from the project directory (config.js holds the credentials).
+ */
+
+const root = path.resolve(import.meta.dirname, '..');
+let server;
+let baseUrl;
+
+before(async () => {
+    server = spawn(process.execPath, ['index.mjs', '--fixtures'], {
+        cwd: root,
+        env: { ...process.env, PORT: '0' },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    baseUrl = await new Promise((resolve, reject) => {
+        let output = '';
+        server.stdout.on('data', chunk => {
+            output += chunk;
+            const match = output.match(/Server is running at (http:\/\/localhost:\d+)/);
+            if (match) resolve(match[1]);
+        });
+        server.stderr.on('data', chunk => { output += chunk; });
+        server.on('exit', code => reject(new Error(`server exited with code ${code}\n${output}`)));
+        setTimeout(() => reject(new Error(`server did not start\n${output}`)), 10000).unref();
+    });
+});
+
+after(() => {
+    if (server) server.kill();
+});
+
+test('README.md is served for the help modal', async () => {
+    const response = await fetch(`${baseUrl}/README.md`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /^text\/markdown/);
+    assert.equal(await response.text(), readFileSync(path.join(root, 'README.md'), 'utf8'));
+});
+
+test('no other file of the project directory is served', async () => {
+    const files = ['config.js', 'config.js.default', 'index.mjs', 'cache.mjs', 'package.json',
+        'access.log', 'CLAUDE.md', 'fixtures/generate.mjs'];
+    for (const file of files) {
+        const response = await fetch(`${baseUrl}/${file}`);
+        assert.equal(response.status, 404, `${file} must not be served`);
+    }
+});
+
+test('the app and the API still answer', async () => {
+    const page = await fetch(`${baseUrl}/`);
+    assert.equal(page.status, 200);
+    assert.match(page.headers.get('content-type'), /^text\/html/);
+    const version = await (await fetch(`${baseUrl}/api/version`)).json();
+    const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+    assert.equal(version.version, packageJson.version);
+});


### PR DESCRIPTION
## Summary

Everything removed here had no caller or no reader; each removal was verified by two independent searches of the repository (the review of 2026-09-10, then a subagent). Nothing observable changes for the user of the dashboard, except that an endpoint the frontend never called disappears.

- **Three dependencies:** `fetch` (never imported), `node-fetch` (the `fetch` built into Node replaces it: the server only uses `response.ok/status/statusText/json()/text()/arrayBuffer()` and the options `method`, `headers`, `signal`), `dotenv` (only `PORT` is read, nothing documented a `.env` file). The README now states the requirement that replaces them: Node.js 20.11 or later.
- **`GET /api/pull-request-conflicts/:repoName/:spec`:** no caller since the SYNC load moved to `/api/sync-statuses/:project` (2.1.0). `getCachedConflicts`, `conflictsLimiter` and `computeConflicts` stay, the sync-statuses endpoint uses them per pull request. The server test checks the route answers 404 and the sync-statuses one still answers.
- **Dead cache exports:** `getCachedSprints` was imported and never called (the sprints have always been fetched with the project data and are part of `dataHash`; the documented 10-minute sprint cache did not exist), `clearCache`, `clearAllCache`, `CACHE_KEYS.SPRINTS`. Deleted rather than wired: a separate sprint cache would save two or three Jira calls per build and delay a new sprint by up to ten minutes, while the calls that matter for the rate limit are the commit counts.
- **Frontend leftovers:** `MultiSelect.getOptions` and `setDisabled` (with them, the `disabled` class had no writer left, so the guard in `toggle()` and the `.multi-select.disabled` stylesheet rule go too); `resolvedIssuesAlert`, always the empty string, and the unread first parameter of `getBranchUrl` in `app-render.js`.
- **Repository files:** `bitbucket.repoName` and `jira.issuesRegex` in `config.js.default` (unread since the project definitions moved to `projects.js`), `start.bat` (`npm start` does the same), the `jiraAuth` that `fetchJiraSprints` recomputed identically to the module-level one.
- Version 2.6.0 (a public endpoint is removed); README, CLAUDE.md and PRD.md follow (stack, endpoints, cache TTLs, project structure, F8.5).

Spec: `docs/superpowers/specs/2026-09-10-remove-unused-design.md`, plan: `docs/superpowers/plans/2026-09-10-remove-unused.md`. Decided in an autonomous session; the decision to revisit is the sprint cache (deleted, not wired).

Stacked on #44 (`claude/serve-readme-route`). Closes #41.

## Verification

- `npm test`: 77 tests, 0 failures (76 before); `npm ls --depth=0` lists `express`, `node-cache`, `node-diff3` only.
- Fixture server on port 3101: `/api/pull-request-conflicts/...` answers 404, `/api/sync-statuses/OSLC` answers 200 with 24 statuses, `/api/pull-requests/SECOLLAB` answers with 112 pull requests, `/config.js` still 404; in the browser the SECOLLAB tree renders (112 pull requests), the Sprint and Assignee multi-selects open and close (one open at a time), the branch links and the warnings render, the badge shows v2.6.0.
- One real request through the built-in `fetch`: a second instance started with the real `config.js` on port 3102 answered `/api/pull-requests/OSLC` with 200 in 8 s (16 pull requests, all with commit counts, 15 issues, 7 sprints); `error.log` gained no line. The SYNC load was not exercised against Atlassian.
- Every commit had a spec-compliance review and a code-quality review by separate subagents; the last commit applies their findings (the fetch error cause in the logs, `engines`, the limiter comment, a project-agnostic server test, the credential comments of `config.js.default`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKvcYxSmgzzL3huCorE4Ay
